### PR TITLE
Local report generation was incorrectly creating directories

### DIFF
--- a/nise/copy.py
+++ b/nise/copy.py
@@ -35,7 +35,7 @@ def copy_to_local_dir(bucket_name, bucket_file_path, local_path):
         return False
 
     full_bucket_path = '{}{}'.format(bucket_name, bucket_file_path)
-    os.makedirs(full_bucket_path, exist_ok=True)
+    os.makedirs(os.path.dirname(full_bucket_path), exist_ok=True)
     shutil.copy2(local_path, full_bucket_path)
     msg = 'Copied {} to s3 bucket {}.'.format(bucket_file_path, bucket_name)
     print(msg)

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -33,19 +33,15 @@ class CopyTestCase(TestCase):
         source_file.seek(0)
         source_file.write(b'cur report')
         source_file.flush()
-
+        source_file_name = os.path.split(source_file.name)[1]
         bucket_name = mkdtemp()
-        bucket_file_path = '/bucket_location'
+        bucket_file_path = '/{}/{}'.format('report_name', source_file_name)
 
         success = copy_to_local_dir(bucket_name, bucket_file_path, source_file.name)
         self.assertTrue(success)
 
-        expected_full_bucket_path = '{}{}'.format(bucket_name, bucket_file_path)
-        self.assertTrue(os.path.isdir(expected_full_bucket_path))
-
-        expected_file_location = '{}/{}'.format(expected_full_bucket_path,
-                                                os.path.basename(source_file.name))
-        self.assertTrue(os.path.isfile(expected_file_location))
+        expected_full_file_path = '{}{}'.format(bucket_name, bucket_file_path)
+        self.assertTrue(os.path.isfile(expected_full_file_path))        
 
         shutil.rmtree(bucket_name)
         os.remove(source_file.name)


### PR DESCRIPTION
Fix for a bug where file names were being created as directories

Test results:
```
$ nise --start-date 06-20-2018 --output-file test.csv --s3-bucket-name /var/tmp/local_s3_bucket --s3-report-name koku-local
Copied /koku-local/20180701-20180801/koku-local-Manifest.json to s3 bucket /var/tmp/local_s3_bucket.
Copied /koku-local/20180701-20180801/ca0ef420-2463-45f0-aee7-581016a1cc7f/koku-local-Manifest.json to s3 bucket /var/tmp/local_s3_bucket.
Copied /koku-local/20180701-20180801/ca0ef420-2463-45f0-aee7-581016a1cc7f/koku-local-1.csv.gz to s3 bucket /var/tmp/local_s3_bucket.
$ 
$ ls -tla /var/tmp/local_s3_bucket/koku-local/20180701-20180801/
total 16
drwxr-xr-x  4 curtisd  wheel   128 Jul 24 10:18 ca0ef420-2463-45f0-aee7-581016a1cc7f
drwxr-xr-x  4 curtisd  wheel   128 Jul 24 10:18 .
drwxr-xr-x  3 curtisd  wheel    96 Jul 24 10:18 ..
-rw-------  1 curtisd  wheel  4820 Jul 24 10:18 koku-local-Manifest.json
$ 
koku-local-Manifest.json is now a file
```