### PR TITLE
Generate multi-month reports with correct S3 layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ venv.bak/
 
 .vscode
 .sw*
+
+# Generated csv files
+*.csv

--- a/README.rst
+++ b/README.rst
@@ -61,17 +61,18 @@ nise is a command line tool. Currently only accepting a limited number of argume
 
 - *--start-date MM-dd-YYYY*
 - *--end-date MM-dd-YYYY* (optional, defaults to today and current hour)
-- *--output-file file*
 - *--s3-bucket-name bucket_name*  (optional, must include --s3-report-name) Note: Use local directory path to populate a "local S3 bucket".
 - *--s3-report-name report_name*  (optional, must include --s3-bucket-name)
 
 Below is an example usage of ``nise``::
 
-    nise --start-date 06-03-2018 --output-file test.csv
+    nise --start-date 06-03-2018
 
-    nise --start-date 06-20-2018 --output-file test.csv --s3-bucket-name testbucket --s3-report-name cur
+    nise --start-date 06-20-2018 --s3-bucket-name testbucket --s3-report-name cur
 
-    nise --start-date 06-20-2018 --output-file test.csv --s3-bucket-name /local/path/testbucket --s3-report-name cur
+    nise --start-date 06-20-2018 --s3-bucket-name /local/path/testbucket --s3-report-name cur
+
+Generated reports will be generated in monthly .csv files with the file format <Month>-<Year>-<Report Name>.csv.
 
 Contributing
 =============

--- a/nise/__main__.py
+++ b/nise/__main__.py
@@ -102,7 +102,7 @@ def main():
     args = parser.parse_args()
     options = vars(args)
     _check_s3_arguments(parser, options)
-    create_report(args.output_file, options)
+    create_report(options)
 
 
 if __name__ == '__main__':

--- a/nise/__main__.py
+++ b/nise/__main__.py
@@ -53,12 +53,6 @@ def create_parser():
                         type=valid_date,
                         default=today(),
                         help='Date to end generating data (MM-DD-YYYY). Default is today.')
-    parser.add_argument('--output-file',
-                        metavar='FILE',
-                        dest='output_file',
-                        required=True,
-                        type=argparse.FileType('w'),
-                        help='Generated output file')
     parser.add_argument('--s3-bucket-name',
                         metavar='BUCKET_NAME',
                         dest='bucket_name',

--- a/nise/report.py
+++ b/nise/report.py
@@ -94,19 +94,16 @@ def _create_month_list(start_date, end_date):
         while current <= end_date:
             month = {}
             month['name'] = calendar.month_name[current.month]
+            month['end'] = datetime(year=current.year,
+                                    month=current.month,
+                                    day=calendar.monthrange(year=current.year,
+                                                            month=current.month)[1])
             if current.month == start_date.month:
-                # First month
+                # First month start with start_date
                 month['start'] = start_date
-                month['end'] = datetime(year=current.year,
-                                        month=current.month,
-                                        day=calendar.monthrange(year=current.year,
-                                                                month=current.month)[1])
             else:
+                # Every other month begin on the first of the month
                 month['start'] = datetime(year=current.year, month=current.month, day=1)
-                month['end'] = datetime(year=current.year,
-                                        month=current.month,
-                                        day=calendar.monthrange(year=current.year,
-                                                                month=current.month)[1])
             months.append(month)
             current += relativedelta(months=+1)
 

--- a/nise/report.py
+++ b/nise/report.py
@@ -83,31 +83,23 @@ def _create_month_list(start_date, end_date):
     months = []
     current = start_date
 
-    if start_date.month == end_date.month:
-        # No month range
+    while current.month <= end_date.month:
         month = {}
-        month['name'] = calendar.month_name[start_date.month]
-        month['start'] = start_date
-        month['end'] = end_date
-        months.append(month)
-    else:
-        while current.month <= end_date.month:
-            month = {}
-            month['name'] = calendar.month_name[current.month]
-            month['start'] = datetime(year=current.year, month=current.month, day=1)
-            month['end'] = datetime(year=current.year,
-                                    month=current.month,
-                                    day=calendar.monthrange(year=current.year,
-                                                            month=current.month)[1])
-            if current.month == start_date.month:
-                # First month start with start_date
-                month['start'] = start_date
-            elif current.month == end_date.month:
-                # Last month ends with end_date
-                month['end'] = end_date
+        month['name'] = calendar.month_name[current.month]
+        month['start'] = datetime(year=current.year, month=current.month, day=1)
+        month['end'] = datetime(year=current.year,
+                                month=current.month,
+                                day=calendar.monthrange(year=current.year,
+                                                        month=current.month)[1])
+        if current.month == start_date.month:
+            # First month start with start_date
+            month['start'] = start_date
+        if current.month == end_date.month:
+            # Last month ends with end_date
+            month['end'] = end_date
 
-            months.append(month)
-            current += relativedelta(months=+1)
+        months.append(month)
+        current += relativedelta(months=+1)
 
     return months
 

--- a/nise/report.py
+++ b/nise/report.py
@@ -126,6 +126,7 @@ def create_report(options):
                       fake.ean(length=13),  # pylint: disable=no-member
                       fake.ean(length=13))  # pylint: disable=no-member
     for month in months:
+        data = []
         for generator in generators:
             gen = generator(month.get('start'), month.get('end'), payer_account, usage_accounts)
             data += gen.generate_data()

--- a/nise/report.py
+++ b/nise/report.py
@@ -114,7 +114,7 @@ def _create_month_list(start_date, end_date):
 
 
 # pylint: disable=too-many-locals
-def create_report(output_file, options):
+def create_report(options):
     """Create a cost usage report file."""
     generators = [DataTransferGenerator, EBSGenerator, EC2Generator, S3Generator]
     data = []
@@ -133,14 +133,10 @@ def create_report(output_file, options):
             gen = generator(month.get('start'), month.get('end'), payer_account, usage_accounts)
             data += gen.generate_data()
 
-        file_path = os.path.dirname(output_file.name)
-        if not file_path:
-            file_path = os.getcwd()
-        file_name = os.path.basename(output_file.name)
         month_output_file_name = '{}-{}-{}'.format(month.get('name'),
                                                    month.get('start').year,
-                                                   file_name)
-        month_output_file = '{}/{}'.format(file_path, month_output_file_name)
+                                                   options.get('report_name'))
+        month_output_file = '{}/{}.csv'.format(os.getcwd(), month_output_file_name)
         _write_csv(month_output_file, data)
 
         bucket_name = options.get('bucket_name')

--- a/nise/report.py
+++ b/nise/report.py
@@ -15,11 +15,14 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 """Module responsible for generating the cost and usage report."""
+import calendar
 import csv
 import gzip
 import os
+from datetime import datetime
 from tempfile import NamedTemporaryFile
 
+from dateutil.relativedelta import relativedelta
 from faker import Faker
 
 from nise.copy import copy_to_local_dir
@@ -34,7 +37,7 @@ from nise.upload import upload_to_s3
 
 def _write_csv(output_file, data, header=COLUMNS):
     """Output csv file data."""
-    with output_file as file:
+    with open(output_file, 'w') as file:
         writer = csv.DictWriter(file, fieldnames=header)
         writer.writeheader()
         for row in data:
@@ -75,6 +78,41 @@ def route_file(bucket_name, bucket_file_path, local_path):
                      local_path)
 
 
+def _create_month_list(start_date, end_date):
+    """Create a list of months given the date range args."""
+    months = []
+    current = start_date
+
+    if start_date.month == end_date.month:
+        # No month range
+        month = {}
+        month['name'] = calendar.month_name[start_date.month]
+        month['start'] = start_date
+        month['end'] = end_date
+        months.append(month)
+    else:
+        while current <= end_date:
+            month = {}
+            month['name'] = calendar.month_name[current.month]
+            if current.month == start_date.month:
+                # First month
+                month['start'] = start_date
+                month['end'] = datetime(year=current.year,
+                                        month=current.month,
+                                        day=calendar.monthrange(year=current.year,
+                                                                month=current.month)[1])
+            else:
+                month['start'] = datetime(year=current.year, month=current.month, day=1)
+                month['end'] = datetime(year=current.year,
+                                        month=current.month,
+                                        day=calendar.monthrange(year=current.year,
+                                                                month=current.month)[1])
+            months.append(month)
+            current += relativedelta(months=+1)
+
+    return months
+
+
 # pylint: disable=too-many-locals
 def create_report(output_file, options):
     """Create a cost usage report file."""
@@ -82,6 +120,7 @@ def create_report(output_file, options):
     data = []
     start_date = options.get('start_date')
     end_date = options.get('end_date')
+    months = _create_month_list(start_date, end_date)
     fake = Faker()
     payer_account = fake.ean(length=13)  # pylint: disable=no-member
     usage_accounts = (payer_account,
@@ -89,32 +128,43 @@ def create_report(output_file, options):
                       fake.ean(length=13),  # pylint: disable=no-member
                       fake.ean(length=13),  # pylint: disable=no-member
                       fake.ean(length=13))  # pylint: disable=no-member
-    for generator in generators:
-        gen = generator(start_date, end_date, payer_account, usage_accounts)
-        data += gen.generate_data()
+    for month in months:
+        for generator in generators:
+            gen = generator(month.get('start'), month.get('end'), payer_account, usage_accounts)
+            data += gen.generate_data()
 
-    _write_csv(output_file, data)
+        file_path = os.path.dirname(output_file.name)
+        if not file_path:
+            file_path = os.getcwd()
+        file_name = os.path.basename(output_file.name)
+        month_output_file_name = '{}-{}-{}'.format(month.get('name'),
+                                                   month.get('start').year,
+                                                   file_name)
+        month_output_file = '{}/{}'.format(file_path, month_output_file_name)
+        _write_csv(month_output_file, data)
 
-    bucket_name = options.get('bucket_name')
-    if bucket_name:
-        report_name = options.get('report_name')
-        manifest_values = {'account': payer_account}
-        manifest_values.update(options)
-        s3_cur_path, manifest_data = generate_manifest(fake, manifest_values)
-        s3_assembly_path = os.path.dirname(s3_cur_path)
-        s3_month_path = os.path.dirname(s3_assembly_path)
-        s3_month_manifest_path = s3_month_path + '/' + report_name + '-Manifest.json'
-        s3_assembly_manifest_path = s3_assembly_path + '/' + report_name + '-Manifest.json'
-        temp_manifest = _write_manifest(manifest_data)
-        temp_cur_zip = _gzip_report(output_file.name)
-        route_file(bucket_name,
-                   s3_month_manifest_path,
-                   temp_manifest)
-        route_file(bucket_name,
-                   s3_assembly_manifest_path,
-                   temp_manifest)
-        route_file(bucket_name,
-                   s3_cur_path,
-                   temp_cur_zip)
-        os.remove(temp_manifest)
-        os.remove(temp_cur_zip)
+        bucket_name = options.get('bucket_name')
+        if bucket_name:
+            report_name = options.get('report_name')
+            manifest_values = {'account': payer_account}
+            manifest_values.update(options)
+            manifest_values['start_date'] = month.get('start')
+            manifest_values['end_date'] = month.get('end')
+            s3_cur_path, manifest_data = generate_manifest(fake, manifest_values)
+            s3_assembly_path = os.path.dirname(s3_cur_path)
+            s3_month_path = os.path.dirname(s3_assembly_path)
+            s3_month_manifest_path = s3_month_path + '/' + report_name + '-Manifest.json'
+            s3_assembly_manifest_path = s3_assembly_path + '/' + report_name + '-Manifest.json'
+            temp_manifest = _write_manifest(manifest_data)
+            temp_cur_zip = _gzip_report(month_output_file)
+            route_file(bucket_name,
+                       s3_month_manifest_path,
+                       temp_manifest)
+            route_file(bucket_name,
+                       s3_assembly_manifest_path,
+                       temp_manifest)
+            route_file(bucket_name,
+                       s3_cur_path,
+                       temp_cur_zip)
+            os.remove(temp_manifest)
+            os.remove(temp_cur_zip)

--- a/nise/report.py
+++ b/nise/report.py
@@ -91,9 +91,10 @@ def _create_month_list(start_date, end_date):
         month['end'] = end_date
         months.append(month)
     else:
-        while current <= end_date:
+        while current.month <= end_date.month:
             month = {}
             month['name'] = calendar.month_name[current.month]
+            month['start'] = datetime(year=current.year, month=current.month, day=1)
             month['end'] = datetime(year=current.year,
                                     month=current.month,
                                     day=calendar.monthrange(year=current.year,
@@ -101,9 +102,10 @@ def _create_month_list(start_date, end_date):
             if current.month == start_date.month:
                 # First month start with start_date
                 month['start'] = start_date
-            else:
-                # Every other month begin on the first of the month
-                month['start'] = datetime(year=current.year, month=current.month, day=1)
+            elif current.month == end_date.month:
+                # Last month ends with end_date
+                month['end'] = end_date
+
             months.append(month)
             current += relativedelta(months=+1)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -51,8 +51,7 @@ class CommandLineTestCase(TestCase):
         Test where user passes an invalid date format.
         """
         with self.assertRaises(SystemExit):
-            self.parser.parse_args(['--start-date', 'foo',
-                                    '--output-file', 'out.csv'])
+            self.parser.parse_args(['--start-date', 'foo'])
 
     def test_valid_s3_no_input(self):
         """

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -25,7 +25,7 @@ from unittest.mock import ANY, patch
 
 from moto import mock_s3
 
-from nise.report import create_report, _write_csv, _write_manifest
+from nise.report import create_report, _create_month_list, _write_csv, _write_manifest
 
 
 class ReportTestCase(TestCase):
@@ -39,7 +39,7 @@ class ReportTestCase(TestCase):
         headers = ['col1', 'col2']
         data = [{'col1': 'r1c1', 'col2': 'r1c2'},
                 {'col1': 'r2c1', 'col2': 'r2c2'}]
-        _write_csv(temp_file, data, headers)
+        _write_csv(temp_file.name, data, headers)
         self.assertTrue(os.path.exists(temp_file.name))
         os.remove(temp_file.name)
 
@@ -54,7 +54,7 @@ class ReportTestCase(TestCase):
     @patch('nise.report._write_csv')
     def test_create_report_no_s3(self, write_csv):
         """Test the report creation method no s3."""
-        temp_file = NamedTemporaryFile()
+        temp_file = NamedTemporaryFile(mode='w')
         now = datetime.datetime.now().replace(microsecond=0, second=0, minute=0)
         one_day = datetime.timedelta(days=1)
         yesterday = now - one_day
@@ -65,7 +65,7 @@ class ReportTestCase(TestCase):
     @patch('nise.report._write_csv')
     def test_create_report_with_s3(self, write_csv):
         """Test the report creation method with s3."""
-        temp_file = NamedTemporaryFile()
+        temp_file = NamedTemporaryFile(mode='w')
         now = datetime.datetime.now().replace(microsecond=0, second=0, minute=0)
         one_day = datetime.timedelta(days=1)
         yesterday = now - one_day
@@ -73,13 +73,29 @@ class ReportTestCase(TestCase):
                    'end_date': now,
                    'bucket_name': 'my_bucket',
                    'report_name': 'cur_report'}
-        create_report(temp_file, options)
+        create_report(temp_file.name, options)
         write_csv.assert_called_once_with(ANY, ANY)
 
     @patch('nise.report._write_csv')
     def test_create_report_with_local_dir(self, write_csv):
         """Test the report creation method with local directory."""
-        temp_file = NamedTemporaryFile()
+        temp_file = NamedTemporaryFile(mode='w')
+        now = datetime.datetime.now().replace(microsecond=0, second=0, minute=0)
+        one_day = datetime.timedelta(days=1)
+        yesterday = now - one_day
+        local_bucket_path = mkdtemp()
+        options = {'start_date': yesterday,
+                   'end_date': now,
+                   'bucket_name': local_bucket_path,
+                   'report_name': 'cur_report'}
+        create_report(temp_file.name, options)
+        write_csv.assert_called_once_with(ANY, ANY)
+        shutil.rmtree(local_bucket_path)
+
+    @patch('nise.report._write_csv')
+    def test_create_report_no_path(self, write_csv):
+        """Test the report creation method with no file path specified."""
+        temp_file = open('test.csv', 'w+')
         now = datetime.datetime.now().replace(microsecond=0, second=0, minute=0)
         one_day = datetime.timedelta(days=1)
         yesterday = now - one_day
@@ -91,3 +107,29 @@ class ReportTestCase(TestCase):
         create_report(temp_file, options)
         write_csv.assert_called_once_with(ANY, ANY)
         shutil.rmtree(local_bucket_path)
+
+    def test_create_month_list(self):
+        """Test to create month lists."""
+        test_matrix = [{
+                        'start_date': datetime.datetime(year=2018, month=1, day=15),
+                        'end_date': datetime.datetime(year=2018, month=1, day=30),
+                        'expected_list': [{'name': 'January',
+                                           'start': datetime.datetime(year=2018, month=1, day=15),
+                                           'end': datetime.datetime(year=2018, month=1, day=30)}]},
+                        {
+                        'start_date': datetime.datetime(year=2018, month=1, day=15),
+                        'end_date': datetime.datetime(year=2018, month=3, day=30),
+                        'expected_list': [{'name': 'January',
+                                           'start': datetime.datetime(year=2018, month=1, day=15),
+                                           'end': datetime.datetime(year=2018, month=1, day=31)},
+                                           {'name': 'February',
+                                           'start': datetime.datetime(year=2018, month=2, day=1),
+                                           'end': datetime.datetime(year=2018, month=2, day=28)},
+                                           {'name': 'March',
+                                           'start': datetime.datetime(year=2018, month=3, day=1),
+                                           'end': datetime.datetime(year=2018, month=3, day=31)}]},                    
+                      ]
+        
+        for test_case in test_matrix:
+            output = _create_month_list(test_case['start_date'], test_case['end_date'])
+            self.assertCountEqual(output, test_case['expected_list'])

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -113,7 +113,7 @@ class ReportTestCase(TestCase):
                                            'end': datetime.datetime(year=2018, month=1, day=30)}]},
                         {
                         'start_date': datetime.datetime(year=2018, month=1, day=15),
-                        'end_date': datetime.datetime(year=2018, month=3, day=30),
+                        'end_date': datetime.datetime(year=2018, month=3, day=5),
                         'expected_list': [{'name': 'January',
                                            'start': datetime.datetime(year=2018, month=1, day=15),
                                            'end': datetime.datetime(year=2018, month=1, day=31)},
@@ -122,7 +122,7 @@ class ReportTestCase(TestCase):
                                            'end': datetime.datetime(year=2018, month=2, day=28)},
                                            {'name': 'March',
                                            'start': datetime.datetime(year=2018, month=3, day=1),
-                                           'end': datetime.datetime(year=2018, month=3, day=31)}]},                    
+                                           'end': datetime.datetime(year=2018, month=3, day=5)}]},                    
                       ]
         
         for test_case in test_matrix:


### PR DESCRIPTION
**Overview**
Now nise will generate multi-month reports and split the generated data into the appropriate monthly bills to conform with AWS S3 report structure.

The `--output-file` parameter was removed and instead a file name is automatically generated for each month of data.

**Testing**
1. Clear contents of an s3 bucket.  Generate a few months of data and send contents to the bucket.  Verify in AWS console
2. Create a local bucket.  Generate a few months of data and send contents to the folder.  Verify the folder contents.
3. Add the S3 and local provider to koku
4. Download/Process data in masu.  Verify successful
5. Verify that generating a report with no report-name (i.e. no S3 upload) works

Test Results:
[nise_issue_18_ut.txt](https://github.com/project-koku/nise/files/2271374/nise_issue_18_ut.txt)

Closes #18