### PR TITLE
Add s3 report prefix as an option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,9 +63,9 @@ nise is a command line tool. Currently only accepting a limited number of argume
 - *--end-date MM-dd-YYYY* (optional, defaults to today and current hour)
 - *--s3-bucket-name bucket_name*  (optional, must include --s3-report-name) Note: Use local directory path to populate a "local S3 bucket".
 - *--s3-report-name report_name*  (optional, must include --s3-bucket-name)
-- *--s3-prefix-name prefix_name*  (optional)
+- *--s3-report-prefix prefix_name*  (optional)
 
-Note: If `--s3-report-name` or `--s3-prefix-name` are specified they should match what is configured in the AWS cost usage report settings.
+Note: If `--s3-report-name` or `--s3-report-prefix` are specified they should match what is configured in the AWS cost usage report settings.
 
 Below is an example usage of ``nise``::
 
@@ -75,7 +75,7 @@ Below is an example usage of ``nise``::
 
     nise --start-date 06-20-2018 --s3-bucket-name /local/path/testbucket --s3-report-name cur
 
-    nise --start-date 06-20-2018 --s3-bucket-name /local/path/testbucket --s3-report-name cur --s3-prefix-name my-prefix
+    nise --start-date 06-20-2018 --s3-bucket-name /local/path/testbucket --s3-report-name cur --s3-report-prefix my-prefix
 
 Generated reports will be generated in monthly .csv files with the file format <Month>-<Year>-<Report Name>.csv.
 

--- a/README.rst
+++ b/README.rst
@@ -63,6 +63,9 @@ nise is a command line tool. Currently only accepting a limited number of argume
 - *--end-date MM-dd-YYYY* (optional, defaults to today and current hour)
 - *--s3-bucket-name bucket_name*  (optional, must include --s3-report-name) Note: Use local directory path to populate a "local S3 bucket".
 - *--s3-report-name report_name*  (optional, must include --s3-bucket-name)
+- *--s3-prefix-name prefix_name*  (optional)
+
+Note: If `--s3-report-name` or `--s3-prefix-name` are specified they should match what is configured in the AWS cost usage report settings.
 
 Below is an example usage of ``nise``::
 
@@ -71,6 +74,8 @@ Below is an example usage of ``nise``::
     nise --start-date 06-20-2018 --s3-bucket-name testbucket --s3-report-name cur
 
     nise --start-date 06-20-2018 --s3-bucket-name /local/path/testbucket --s3-report-name cur
+
+    nise --start-date 06-20-2018 --s3-bucket-name /local/path/testbucket --s3-report-name cur --s3-prefix-name my-prefix
 
 Generated reports will be generated in monthly .csv files with the file format <Month>-<Year>-<Report Name>.csv.
 

--- a/nise/__main__.py
+++ b/nise/__main__.py
@@ -63,6 +63,12 @@ def create_parser():
                         dest='report_name',
                         required=False,
                         help='Directory path to store data in the S3 bucket.')
+    parser.add_argument('--s3-prefix-name',
+                        metavar='PREFIX_NAME',
+                        dest='prefix_name',
+                        required=False,
+                        help='Directory path to store data in the S3 bucket.')
+
     return parser
 
 

--- a/nise/__main__.py
+++ b/nise/__main__.py
@@ -63,7 +63,7 @@ def create_parser():
                         dest='report_name',
                         required=False,
                         help='Directory path to store data in the S3 bucket.')
-    parser.add_argument('--s3-prefix-name',
+    parser.add_argument('--s3-report-prefix',
                         metavar='PREFIX_NAME',
                         dest='prefix_name',
                         required=False,

--- a/nise/copy.py
+++ b/nise/copy.py
@@ -34,7 +34,7 @@ def copy_to_local_dir(bucket_name, bucket_file_path, local_path):
         print('Path does not exist for the bucket: {}'.format(bucket_name))
         return False
 
-    full_bucket_path = '{}{}'.format(bucket_name, bucket_file_path)
+    full_bucket_path = '{}/{}'.format(bucket_name, bucket_file_path)
     os.makedirs(os.path.dirname(full_bucket_path), exist_ok=True)
     shutil.copy2(local_path, full_bucket_path)
     msg = 'Copied {} to s3 bucket {}.'.format(bucket_file_path, bucket_name)

--- a/nise/manifest.py
+++ b/nise/manifest.py
@@ -69,10 +69,18 @@ def generate_manifest(fake, template_data):
     range_str = _manifest_datetime_range(bp_start, bp_end)
     assembly_id = uuid4()
     report_id = fake.sha256(raw_output=False)
-    report_key = '/{report_name}/{range_str}/{assembly_id}/{report_name}-1.csv.gz'
-    report_key = report_key.format(report_name=report_name,
-                                   range_str=range_str,
-                                   assembly_id=assembly_id)
+    prefix_name = template_data.get('prefix_name')
+    if prefix_name:
+        report_key = '{prefix_name}/{report_name}/{range_str}/{assembly_id}/{report_name}-1.csv.gz'
+        report_key = report_key.format(prefix_name=prefix_name,
+                                       report_name=report_name,
+                                       range_str=range_str,
+                                       assembly_id=assembly_id)
+    else:
+        report_key = '/{report_name}/{range_str}/{assembly_id}/{report_name}-1.csv.gz'
+        report_key = report_key.format(report_name=report_name,
+                                       range_str=range_str,
+                                       assembly_id=assembly_id)
     render_data = {'assembly_id': assembly_id,
                    'report_id': report_id,
                    'billing_period_start': _manifest_datetime_str(bp_start),

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -128,3 +128,23 @@ class ReportTestCase(TestCase):
         for test_case in test_matrix:
             output = _create_month_list(test_case['start_date'], test_case['end_date'])
             self.assertCountEqual(output, test_case['expected_list'])
+
+    def test_create_report_with_local_dir_report_prefix(self):
+        """Test the report creation method with local directory and a report prefix."""
+        now = datetime.datetime.now().replace(microsecond=0, second=0, minute=0)
+        one_day = datetime.timedelta(days=1)
+        yesterday = now - one_day
+        local_bucket_path = mkdtemp()
+        options = {'start_date': yesterday,
+                   'end_date': now,
+                   'bucket_name': local_bucket_path,
+                   'report_name': 'cur_report',
+                   'prefix_name': 'my_prefix'}
+        create_report(options)
+        month_output_file_name = '{}-{}-{}'.format(calendar.month_name[now.month],
+                                                   now.year,
+                                                   'cur_report')
+        expected_month_output_file = '{}/{}.csv'.format(os.getcwd(), month_output_file_name)
+        self.assertTrue(os.path.isfile(expected_month_output_file))
+        os.remove(expected_month_output_file)
+        shutil.rmtree(local_bucket_path)


### PR DESCRIPTION
**Overview**
Adding `--s3-report-prefix` as an optional parameter.  When this is used it should match what is configured in AWS for the cost usage report in order for masu to successfully download it.

**Testing**
1. Generate a report and push to S3 with prefix name.  Verify S3 contents:
2. Generate a report and push to S3 without a prefix name. . Verify S3 contents:
3. Generate a report and push to a local directory with a prefix.  Verify folder contents
4. Generate a report and push to a local directory without a prefix. Verify folder contents
5. Verify that masu can download from a bucket with a CUR report prefix configured:

Results:
[nise_prefix_ut.txt](https://github.com/project-koku/nise/files/2275760/nise_prefix_ut.txt)
