### PR TITLE
updating s3 generator service name

### DIFF
--- a/nise/generators/aws/s3_generator.py
+++ b/nise/generators/aws/s3_generator.py
@@ -37,13 +37,13 @@ class S3Generator(AWSGenerator):
         rate = round(uniform(0.02, 0.06), 3)
         amount = uniform(0.2, 6000.99)
         cost = amount * rate
-        location, aws_region, avail_zone, storage_region = self._get_location()
+        location, aws_region, avail_zone, _ = self._get_location()
         description = '${} per GB-Month of snapshot data stored - {}'.format(rate, location)
         amazon_resource_name = self._get_arn(avail_zone)
 
-        row['lineItem/ProductCode'] = 'AmazonEC2'
-        row['lineItem/UsageType'] = '{}:SnapshotUsage'.format(storage_region)
-        row['lineItem/Operation'] = 'CreateSnapshot'
+        row['lineItem/ProductCode'] = 'AmazonS3'
+        row['lineItem/UsageType'] = 'Requests-Tier2'
+        row['lineItem/Operation'] = 'GetObject'
         row['lineItem/ResourceId'] = amazon_resource_name
         row['lineItem/UsageAmount'] = str(amount)
         row['lineItem/CurrencyCode'] = 'USD'
@@ -52,15 +52,15 @@ class S3Generator(AWSGenerator):
         row['lineItem/BlendedRate'] = str(rate)
         row['lineItem/BlendedCost'] = str(cost)
         row['lineItem/LineItemDescription'] = description
-        row['product/ProductName'] = 'Amazon Elastic Compute Cloud'
+        row['product/ProductName'] = 'Amazon Simple Storage Service'
         row['product/location'] = location
         row['product/locationType'] = 'AWS Region'
         row['product/productFamily'] = 'Storage Snapshot'
         row['product/region'] = aws_region
-        row['product/servicecode'] = 'AmazonEC2'
+        row['product/servicecode'] = 'AmazonS3'
         row['product/sku'] = self.fake.pystr(min_chars=12, max_chars=12).upper()  # pylint: disable=no-member
         row['product/storageMedia'] = 'Amazon S3'
-        row['product/usagetype'] = '{}:SnapshotUsage'.format(storage_region)
+        row['product/usagetype'] = 'Requests-Tier2'
         row['pricing/publicOnDemandCost'] = str(cost)
         row['pricing/publicOnDemandRate'] = str(rate)
         row['pricing/term'] = 'OnDemand'


### PR DESCRIPTION
*Test Results*
S3 now shows up in services group_by
```
GET /api/v1/reports/costs/aws/?filter[time_scope_units]=month&filter[time_scope_value]=-1&group_by[service]=*
HTTP 200 OK
Allow: GET, OPTIONS
Content-Type: application/json
Vary: Accept

{
    "group_by": {
        "service": [
            "*"
        ]
    },
    "filter": {
        "time_scope_value": "-1",
        "time_scope_units": "month"
    },
    "data": [
        {
            "date": "2018-12",
            "services": [
                {
                    "service": "AmazonS3",
                    "values": [
                        {
                            "date": "2018-12",
                            "units": "USD",
                            "service": "AmazonS3",
                            "total": 6415.095424336
                        }
                    ]
                },
                {
                    "service": "AmazonEC2",
                    "values": [
                        {
                            "date": "2018-12",
                            "units": "USD",
                            "service": "AmazonEC2",
                            "total": 1119.814135966
                        }
                    ]
                }
            ]
        }
    ],
    "total": {
        "value": 7534.909560302,
        "cost": 7534.909560302,
        "units": "USD"
    }
}
```

Closes #50.  @lcouzens said having at least 2 services is good enough to do basic group_by and filtering tests.  This could close the issue for now.