### PR TITLE
adding resourceTags to aws ec2 generator

### DIFF
--- a/nise/generators/aws/aws_generator.py
+++ b/nise/generators/aws/aws_generator.py
@@ -90,8 +90,10 @@ RESERVE_COLS = ('reservation/AvailabilityZone',
                 'reservation/TotalReservedNormalizedUnits',
                 'reservation/TotalReservedUnits',
                 'reservation/UnitsPerReservation')
+RESOURCE_TAG_COLS = ('resourceTags/user:environment',
+                     'resourceTags/user:version')
 AWS_COLUMNS = (IDENTITY_COLS + BILL_COLS + LINE_ITEM_COLS +  # noqa: W504
-               PRODUCT_COLS + PRICING_COLS + RESERVE_COLS)
+               PRODUCT_COLS + PRICING_COLS + RESERVE_COLS + RESOURCE_TAG_COLS)
 
 
 # pylint: disable=too-few-public-methods

--- a/nise/generators/aws/ec2_generator.py
+++ b/nise/generators/aws/ec2_generator.py
@@ -96,6 +96,8 @@ class EC2Generator(AWSGenerator):
         row['pricing/publicOnDemandRate'] = rate
         row['pricing/term'] = 'OnDemand'
         row['pricing/unit'] = 'Hrs'
+        row['resourceTags/user:environment'] = choice(('dev', 'ci', 'qa', 'stage', 'prod'))
+        row['resourceTags/user:version'] = choice(('alpha', 'beta'))
         return row
 
     def generate_data(self):


### PR DESCRIPTION
Adding two resrouceTags to ECT generator.

**Testing**
Add local provider:
```
POST /api/v1/providers/
HTTP 201 Created
Allow: GET, POST, HEAD, OPTIONS
Content-Type: application/json
Vary: Accept

{
    "uuid": "571a8db1-2e75-49c7-aa94-8ca30b6b0481",
    "name": "AWSLocalProvider",
    "type": "AWS-local",
    "authentication": {
        "uuid": "b6a89323-d152-4fc9-bf97-a10b6e261036",
        "provider_resource_name": "arn:aws:iam::589173575009:role/LocalOne"
    },
    "billing_source": {
        "uuid": "0506e9de-94ac-4be4-8f11-83b2d0f0b1c0",
        "bucket": "/tmp/local_bucket"
    },
    "customer": {
        "uuid": "cf5aec9c-0b15-4211-890d-ceae0dc303e9",
        "account_id": "10001",
        "date_created": "2019-01-09T17:01:02.981073Z"
    },
    "created_by": {
        "uuid": "a71066fe-3fdd-4d0d-b896-e2f1f928c9db",
        "username": "user_dev",
        "email": "user_dev@foo.com"
    }
}
```

Generate Data:
```
(nise_fork-lW4EhP1Y) ➜  nise_fork git:(aws_tags) nise --aws --start-date 1-1-2019 --aws-s3-bucket-name ~/aws_local --aws-s3-report-name local-report
Copied /local-report/20190101-20190201/local-report-Manifest.json to local directory /Users/curtisd/aws_local.
Copied /local-report/20190101-20190201/70e32769-d981-49a1-837f-17717c7be471/local-report-Manifest.json to local directory /Users/curtisd/aws_local.
Copied /local-report/20190101-20190201/70e32769-d981-49a1-837f-17717c7be471/local-report-1.csv.gz to local directory /Users/curtisd/aws_local.
(nise_fork-lW4EhP1Y) ➜  nise_fork git:(aws_tags)
```

Ingest in Masu and verify db line items has tags
```
postgres=# select tags from reporting_awscostentrylineitem;
...
{"resourceTags/user:version": "alpha", "resourceTags/user:environment": "dev"}
 {"resourceTags/user:version": "beta", "resourceTags/user:environment": "dev"}
 {"resourceTags/user:version": "beta", "resourceTags/user:environment": "ci"}
 {"resourceTags/user:version": "alpha", "resourceTags/user:environment": "qa"}
 {"resourceTags/user:version": "alpha", "resourceTags/user:environment": "prod"}
```
