### PR TITLE
Small README update for OCP on AWS + default example to same resource id

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -105,6 +105,18 @@ Below is an example usage of ``nise`` for OCP data::
 
 Generated reports will be generated in monthly .csv files with the file format <Month>-<Year>-<Cluster-ID>.csv.
 
+Below is an example usage of ``nise`` for OCP running on AWS data::
+
+    # First ensure that the resource_id and dates in both AWS and OCP static report files match
+
+    nise --aws --static-report-file aws_static_data.yml
+
+    nise --ocp --ocp-cluster-id my-cluster-id --static-report-file ocp_static_data.yml
+
+Generated AWS reports will be generated in monthly .csv files with the file format <Month>-<Year>-<Report Name>.csv.
+
+Generated OCP reports will be generated in monthly .csv files with the file format <Month>-<Year>-<Cluster-ID>.csv.
+
 Contributing
 =============
 

--- a/example_ocp_static_data.yml
+++ b/example_ocp_static_data.yml
@@ -8,7 +8,7 @@ generators:
           node_name: alpha
           cpu_cores: 2
           memory_gig: 4
-          resource_id: myresourceid
+          resource_id: 55555555
           namespaces:
             namespace_ci:
               pods:


### PR DESCRIPTION
## Summary
A small update to align the OCP and AWS example files to use the same resource_id