### PR TITLE
Updating to handle OCP multiple report files.

### DIFF
--- a/example_ocp_static_data.yml
+++ b/example_ocp_static_data.yml
@@ -1,8 +1,8 @@
 ---
 generators:
   - OCPGenerator:
-      start_date: 1-21-2019
-      end_date: 1-23-2019
+      start_date: 2-1-2019
+      end_date: 2-6-2019
       nodes:
         - node:
           node_name: alpha

--- a/nise/ocp-template-manifest.json
+++ b/nise/ocp-template-manifest.json
@@ -1,5 +1,5 @@
 {
-    "file": "{{ ocp_assembly_id }}_openshift_usage_report.csv",
+    "files": ["{{ ocp_assembly_id }}_openshift_usage_report.csv"],
     "date": "{{ report_datetime }}",
     "uuid": "{{ ocp_assembly_id }}",
     "cluster_id": "{{ ocp_cluster_id }}"


### PR DESCRIPTION
Related to https://github.com/project-koku/masu/pull/359

OCP manifest changed to support multiple files to prepare us for OCP storage report processing.

@lcouzens without this test automation will fail.


```
➜  ocp git:(ocp_storage_processor) ✗ cat ~/insights_local/my-ocp-cluster-2/20190201-20190301/manifest.json
{
    "files": ["4280c1d6-942b-46d5-9ebb-0e9a09332fe1_openshift_usage_report.csv"],
    "date": "2019-02-01 00:00:00",
    "uuid": "4280c1d6-942b-46d5-9ebb-0e9a09332fe1",
    "cluster_id": "my-ocp-cluster-2"
}%
```

Testing: Successfully generated and ingested with `--insights-upload ~/insights_local` parameter