### PR TITLE
Bug fix for volume claim labels. Closes #79.

### DIFF
--- a/example_ocp_static_data.yml
+++ b/example_ocp_static_data.yml
@@ -51,7 +51,7 @@ generators:
                   - volume_claim:
                     volume_claim_name: pod_name1_data
                     pod_name: pod_name1
-                    labels: label_key2:label_value2
+                    labels: vc_label_key2:label_value2
                     capacity_gig: 5
                     volume_claim_usage_gig:
                       2-1-2019: 1
@@ -63,7 +63,7 @@ generators:
                   - volume_claim:
                     volume_claim_name: pod_name2_data
                     pod_name: pod_name2
-                    labels: label_key3:label_value3
+                    labels: vc_label_key3:label_value3
                     capacity_gig: 10
                     volume_claim_usage_gig:
                       2-1-2019: 3

--- a/nise/generators/ocp/ocp_generator.py
+++ b/nise/generators/ocp/ocp_generator.py
@@ -248,7 +248,7 @@ class OCPGenerator(AbstractGenerator):
                         volume_claims[vol_claim] = {
                             'namespace': namespace,
                             'volume': volume,
-                            'labels': specified_volume.get('labels', None),
+                            'labels': specified_vc.get('labels', None),
                             'capacity': claim_capacity,
                             'pod': pod,
                             'volume_claim_usage_gig': usage_gig,


### PR DESCRIPTION
Result of bug fix with updated example yaml:
```
nise --ocp --ocp-cluster-id my-cluster-id --static-report-file example_ocp_static_data.yml  --insights-upload ~/Desktop/
Successfully extracted OCP for my-cluster-id/20190201-20190301
```
[6e0c009e-c61a-4062-9638-2f90e25ed1e5_openshift_usage_report.1.txt](https://github.com/project-koku/nise/files/2880284/6e0c009e-c61a-4062-9638-2f90e25ed1e5_openshift_usage_report.1.txt)
