### PR TITLE
fixing last day of month bug

### DIFF
--- a/nise/manifest.py
+++ b/nise/manifest.py
@@ -63,9 +63,9 @@ def aws_generate_manifest(fake, template_data):
         (String): S3 storage path
         (String): Rendered template data
     """
-    end = template_data.get('end_date')
+    start = template_data.get('start_date')
     report_name = template_data.get('aws_report_name')
-    bp_start = end.replace(microsecond=0, second=0, minute=0,
+    bp_start = start.replace(microsecond=0, second=0, minute=0,
                            hour=0, day=1)
     bp_end = bp_start + relativedelta(months=+1)
 

--- a/nise/manifest.py
+++ b/nise/manifest.py
@@ -66,7 +66,7 @@ def aws_generate_manifest(fake, template_data):
     start = template_data.get('start_date')
     report_name = template_data.get('aws_report_name')
     bp_start = start.replace(microsecond=0, second=0, minute=0,
-                           hour=0, day=1)
+                             hour=0, day=1)
     bp_end = bp_start + relativedelta(months=+1)
 
     range_str = _manifest_datetime_range(bp_start, bp_end)

--- a/nise/report.py
+++ b/nise/report.py
@@ -223,28 +223,28 @@ def _create_generator_dates_from_yaml(attributes, month):
     """Calculate generator start and end dates based on yaml and current month."""
     gen_start_date = None
     gen_end_date = None
-
+    
     # Generator range is larger then current month on both start and end
-    if attributes.get('start_date') <= month.get('start') and \
-            attributes.get('end_date') >= month.get('end'):
+    if attributes.get('start_date') < month.get('start') and \
+            attributes.get('end_date') > month.get('end').replace(hour=23, minute=59, second=59):
         gen_start_date = month.get('start')
         gen_end_date = month.get('end') + relativedelta(days=1)
 
     # Generator starts before month start and ends within month
     if attributes.get('start_date') <= month.get('start') and \
-            attributes.get('end_date') <= month.get('end'):
+            attributes.get('end_date') <= month.get('end').replace(hour=23, minute=59, second=59):
         gen_start_date = month.get('start')
         gen_end_date = attributes.get('end_date')
 
     # Generator is within month
     if attributes.get('start_date') >= month.get('start') and \
-            attributes.get('end_date') <= month.get('end'):
+            attributes.get('end_date') <= month.get('end').replace(hour=23, minute=59, second=59):
         gen_start_date = attributes.get('start_date')
         gen_end_date = attributes.get('end_date')
 
     # Generator starts within month and ends in next month
     if attributes.get('start_date') >= month.get('start') and \
-            attributes.get('end_date') >= month.get('end'):
+            attributes.get('end_date') > month.get('end').replace(hour=23, minute=59, second=59):
         gen_start_date = attributes.get('start_date')
         gen_end_date = month.get('end') + relativedelta(days=1)
 

--- a/nise/report.py
+++ b/nise/report.py
@@ -223,7 +223,7 @@ def _create_generator_dates_from_yaml(attributes, month):
     """Calculate generator start and end dates based on yaml and current month."""
     gen_start_date = None
     gen_end_date = None
-    
+
     # Generator range is larger then current month on both start and end
     if attributes.get('start_date') < month.get('start') and \
             attributes.get('end_date') > month.get('end').replace(hour=23, minute=59, second=59):


### PR DESCRIPTION
Re-running yaml from issue.  `interval_end` is now ends at current time

```
(nise_fork) ➜  nise_fork git:(today_fix) ✗ nise --ocp --insights-upload ~/insights_local --ocp-cluster-id my-ocp-cluster-1 --static-report-file example_ocp_static_data.yml
Successfully extracted OCP for my-ocp-cluster-1/20190401-20190501
(nise_fork) ➜  nise_fork git:(today_fix) ✗

(nise_fork) ➜  nise_fork git:(today_fix) ✗ tail April-2019-my-ocp-cluster-1-ocp_pod_usage.csv
2019-04-01 00:00:00 +0000 UTC,2019-05-01 00:00:00 +0000 UTC,tiers,ocp_tiers,ocp-tiers,i-11995555,2019-04-30 05:00:00 +0000 UTC,2019-04-30 06:00:00 +0000 UTC,10800,7200,14400,7730941132800,11596411699200,15461882265600,5,18000,5368709120,19327352832000,label_app:teirs
2019-04-01 00:00:00 +0000 UTC,2019-05-01 00:00:00 +0000 UTC,tiers,ocp_tiers,ocp-tiers,i-11995555,2019-04-30 06:00:00 +0000 UTC,2019-04-30 07:00:00 +0000 UTC,10800,7200,14400,7730941132800,11596411699200,15461882265600,5,18000,5368709120,19327352832000,label_app:teirs
2019-04-01 00:00:00 +0000 UTC,2019-05-01 00:00:00 +0000 UTC,tiers,ocp_tiers,ocp-tiers,i-11995555,2019-04-30 07:00:00 +0000 UTC,2019-04-30 08:00:00 +0000 UTC,10800,7200,14400,7730941132800,11596411699200,15461882265600,5,18000,5368709120,19327352832000,label_app:teirs
2019-04-01 00:00:00 +0000 UTC,2019-05-01 00:00:00 +0000 UTC,tiers,ocp_tiers,ocp-tiers,i-11995555,2019-04-30 08:00:00 +0000 UTC,2019-04-30 09:00:00 +0000 UTC,10800,7200,14400,7730941132800,11596411699200,15461882265600,5,18000,5368709120,19327352832000,label_app:teirs
2019-04-01 00:00:00 +0000 UTC,2019-05-01 00:00:00 +0000 UTC,tiers,ocp_tiers,ocp-tiers,i-11995555,2019-04-30 09:00:00 +0000 UTC,2019-04-30 10:00:00 +0000 UTC,10800,7200,14400,7730941132800,11596411699200,15461882265600,5,18000,5368709120,19327352832000,label_app:teirs
2019-04-01 00:00:00 +0000 UTC,2019-05-01 00:00:00 +0000 UTC,tiers,ocp_tiers,ocp-tiers,i-11995555,2019-04-30 10:00:00 +0000 UTC,2019-04-30 11:00:00 +0000 UTC,10800,7200,14400,7730941132800,11596411699200,15461882265600,5,18000,5368709120,19327352832000,label_app:teirs
2019-04-01 00:00:00 +0000 UTC,2019-05-01 00:00:00 +0000 UTC,tiers,ocp_tiers,ocp-tiers,i-11995555,2019-04-30 11:00:00 +0000 UTC,2019-04-30 12:00:00 +0000 UTC,10800,7200,14400,7730941132800,11596411699200,15461882265600,5,18000,5368709120,19327352832000,label_app:teirs
2019-04-01 00:00:00 +0000 UTC,2019-05-01 00:00:00 +0000 UTC,tiers,ocp_tiers,ocp-tiers,i-11995555,2019-04-30 12:00:00 +0000 UTC,2019-04-30 13:00:00 +0000 UTC,10800,7200,14400,7730941132800,11596411699200,15461882265600,5,18000,5368709120,19327352832000,label_app:teirs
2019-04-01 00:00:00 +0000 UTC,2019-05-01 00:00:00 +0000 UTC,tiers,ocp_tiers,ocp-tiers,i-11995555,2019-04-30 13:00:00 +0000 UTC,2019-04-30 14:00:00 +0000 UTC,10800,7200,14400,7730941132800,11596411699200,15461882265600,5,18000,5368709120,19327352832000,label_app:teirs
2019-04-01 00:00:00 +0000 UTC,2019-05-01 00:00:00 +0000 UTC,tiers,ocp_tiers,ocp-tiers,i-11995555,2019-04-30 14:00:00 +0000 UTC,2019-04-30 15:00:00 +0000 UTC,10800,7200,14400,7730941132800,11596411699200,15461882265600,5,18000,5368709120,19327352832000,label_app:teirs
(nise_fork) ➜  nise_fork git:(today_fix) ✗
```
Addresses #104 