### PR TITLE
Add option to use identity header for ingest

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -18,18 +18,18 @@
     "default": {
         "boto3": {
             "hashes": [
-                "sha256:9b14e28f89e6e6e7fda505ffd3d681e2edceb48c72acdef15b8d79c574285d37",
-                "sha256:9b4ef9b1ce046b482785102f9e20ad9268259a2ba1abc106a1535716a4cfa2b6"
+                "sha256:3701eb13dbee1de3ecc6ed3c725929993933aa2ffdbb6fe8a4985d5c94d6a67a",
+                "sha256:d32a19f1e373cfe7f1fbd22137489f69e08e61a904a09bd7235fbadcfc647789"
             ],
             "index": "pypi",
-            "version": "==1.9.201"
+            "version": "==1.9.216"
         },
         "botocore": {
             "hashes": [
-                "sha256:91d1deb7d09a27122820a3a99d22f45dbadc039c1d5cf6270eb245b95071e7ba",
-                "sha256:e4678f5072bd8a429ea27243004964986db5dfda911084d47a9f18de5c8d75d7"
+                "sha256:63ca29cf8a47b190886923c789a3f2b2a7e1665b5f6e22a97fed057af2e5f1af",
+                "sha256:bebb869754459035fe45eac1f8a93a97dd8698522bc7f7ebde791e32311b035a"
             ],
-            "version": "==1.12.201"
+            "version": "==1.12.216"
         },
         "certifi": {
             "hashes": [
@@ -47,19 +47,19 @@
         },
         "docutils": {
             "hashes": [
-                "sha256:02aec4bd92ab067f6ff27a38a38a41173bf01bed8f89157768c1573f53e474a6",
-                "sha256:51e64ef2ebfb29cae1faa133b3710143496eca21c530f3f71424d77687764274",
-                "sha256:7a4bd47eaf6596e1295ecb11361139febe29b084a87bf005bf899f9a42edc3c6"
+                "sha256:6c4f696463b79f1fb8ba0c594b63840ebd41f059e92b31957c46b74a4599b6d0",
+                "sha256:9e4d7ecfc600058e07ba661411a2b7de2fd0fafa17d1a7f7361cd47b1175c827",
+                "sha256:a2aeea129088da402665e92e0b25b04b073c04b2dce4ab65caaa38b7ce2e1a99"
             ],
-            "version": "==0.14"
+            "version": "==0.15.2"
         },
         "faker": {
             "hashes": [
-                "sha256:96ad7902706f2409a2d0c3de5132f69b413555a419bacec99d3f16e657895b47",
-                "sha256:b3bb64aff9571510de6812df45122b633dbc6227e870edae3ed9430f94698521"
+                "sha256:1d3f700e8dfcefd6e657118d71405d53e86974448aba78884f119bbd84c0cddf",
+                "sha256:d5366e120191c5610fceeebfe1c298dc46da0277096f639c6dd7e2eaee0fa547"
             ],
             "index": "pypi",
-            "version": "==2.0.0"
+            "version": "==2.0.1"
         },
         "idna": {
             "hashes": [
@@ -238,26 +238,26 @@
         },
         "lazy-object-proxy": {
             "hashes": [
-                "sha256:159a745e61422217881c4de71f9eafd9d703b93af95618635849fe469a283661",
-                "sha256:23f63c0821cc96a23332e45dfaa83266feff8adc72b9bcaef86c202af765244f",
-                "sha256:3b11be575475db2e8a6e11215f5aa95b9ec14de658628776e10d96fa0b4dac13",
-                "sha256:3f447aff8bc61ca8b42b73304f6a44fa0d915487de144652816f950a3f1ab821",
-                "sha256:4ba73f6089cd9b9478bc0a4fa807b47dbdb8fad1d8f31a0f0a5dbf26a4527a71",
-                "sha256:4f53eadd9932055eac465bd3ca1bd610e4d7141e1278012bd1f28646aebc1d0e",
-                "sha256:64483bd7154580158ea90de5b8e5e6fc29a16a9b4db24f10193f0c1ae3f9d1ea",
-                "sha256:6f72d42b0d04bfee2397aa1862262654b56922c20a9bb66bb76b6f0e5e4f9229",
-                "sha256:7c7f1ec07b227bdc561299fa2328e85000f90179a2f44ea30579d38e037cb3d4",
-                "sha256:7c8b1ba1e15c10b13cad4171cfa77f5bb5ec2580abc5a353907780805ebe158e",
-                "sha256:8559b94b823f85342e10d3d9ca4ba5478168e1ac5658a8a2f18c991ba9c52c20",
-                "sha256:a262c7dfb046f00e12a2bdd1bafaed2408114a89ac414b0af8755c696eb3fc16",
-                "sha256:acce4e3267610c4fdb6632b3886fe3f2f7dd641158a843cf6b6a68e4ce81477b",
-                "sha256:be089bb6b83fac7f29d357b2dc4cf2b8eb8d98fe9d9ff89f9ea6012970a853c7",
-                "sha256:bfab710d859c779f273cc48fb86af38d6e9210f38287df0069a63e40b45a2f5c",
-                "sha256:c10d29019927301d524a22ced72706380de7cfc50f767217485a912b4c8bd82a",
-                "sha256:dd6e2b598849b3d7aee2295ac765a578879830fb8966f70be8cd472e6069932e",
-                "sha256:e408f1eacc0a68fed0c08da45f31d0ebb38079f043328dce69ff133b95c29dc1"
+                "sha256:02b260c8deb80db09325b99edf62ae344ce9bc64d68b7a634410b8e9a568edbf",
+                "sha256:18f9c401083a4ba6e162355873f906315332ea7035803d0fd8166051e3d402e3",
+                "sha256:1f2c6209a8917c525c1e2b55a716135ca4658a3042b5122d4e3413a4030c26ce",
+                "sha256:2f06d97f0ca0f414f6b707c974aaf8829c2292c1c497642f63824119d770226f",
+                "sha256:616c94f8176808f4018b39f9638080ed86f96b55370b5a9463b2ee5c926f6c5f",
+                "sha256:63b91e30ef47ef68a30f0c3c278fbfe9822319c15f34b7538a829515b84ca2a0",
+                "sha256:77b454f03860b844f758c5d5c6e5f18d27de899a3db367f4af06bec2e6013a8e",
+                "sha256:83fe27ba321e4cfac466178606147d3c0aa18e8087507caec78ed5a966a64905",
+                "sha256:84742532d39f72df959d237912344d8a1764c2d03fe58beba96a87bfa11a76d8",
+                "sha256:874ebf3caaf55a020aeb08acead813baf5a305927a71ce88c9377970fe7ad3c2",
+                "sha256:9f5caf2c7436d44f3cec97c2fa7791f8a675170badbfa86e1992ca1b84c37009",
+                "sha256:a0c8758d01fcdfe7ae8e4b4017b13552efa7f1197dd7358dc9da0576f9d0328a",
+                "sha256:a4def978d9d28cda2d960c279318d46b327632686d82b4917516c36d4c274512",
+                "sha256:ad4f4be843dace866af5fc142509e9b9817ca0c59342fdb176ab6ad552c927f5",
+                "sha256:ae33dd198f772f714420c5ab698ff05ff900150486c648d29951e9c70694338e",
+                "sha256:b4a2b782b8a8c5522ad35c93e04d60e2ba7f7dcb9271ec8e8c3e08239be6c7b4",
+                "sha256:c462eb33f6abca3b34cdedbe84d761f31a60b814e173b98ede3c81bb48967c4f",
+                "sha256:fd135b8d35dfdcdb984828c84d695937e58cc5f49e1c854eb311c4d6aa03f4f1"
             ],
-            "version": "==1.4.1"
+            "version": "==1.4.2"
         },
         "mccabe": {
             "hashes": [
@@ -265,6 +265,13 @@
                 "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
             ],
             "version": "==0.6.1"
+        },
+        "more-itertools": {
+            "hashes": [
+                "sha256:409cd48d4db7052af495b09dec721011634af3753ae1ef92d2b32f73a745f832",
+                "sha256:92b8c4b06dac4f0611c0729b2f2ede52b2e1bac1ab48f089c7ddc12e26bb60c4"
+            ],
+            "version": "==7.2.0"
         },
         "packaging": {
             "hashes": [
@@ -366,10 +373,10 @@
         },
         "virtualenv": {
             "hashes": [
-                "sha256:6cb2e4c18d22dbbe283d0a0c31bb7d90771a606b2cb3415323eea008eaee6a9d",
-                "sha256:909fe0d3f7c9151b2df0a2cb53e55bdb7b0d61469353ff7a49fd47b0f0ab9285"
+                "sha256:94a6898293d07f84a98add34c4df900f8ec64a570292279f6d91c781d37fd305",
+                "sha256:f6fc312c031f2d2344f885de114f1cb029dfcffd26aa6e57d2ee2296935c4e7d"
             ],
-            "version": "==16.7.2"
+            "version": "==16.7.4"
         },
         "wrapt": {
             "hashes": [
@@ -379,10 +386,10 @@
         },
         "zipp": {
             "hashes": [
-                "sha256:4970c3758f4e89a7857a973b1e2a5d75bcdc47794442f2e2dd4fe8e0466e809a",
-                "sha256:8a5712cfd3bb4248015eb3b0b3c54a5f6ee3f2425963ef2a0125b8bc40aafaec"
+                "sha256:3718b1cbcd963c7d4c5511a8240812904164b7f381b647143a89d3b98f9bcd8e",
+                "sha256:f06903e9f1f43b12d371004b4ac7b06ab39a44adc747266928ae6debfa7b3335"
             ],
-            "version": "==0.5.2"
+            "version": "==0.6.0"
         }
     }
 }

--- a/nise/__main__.py
+++ b/nise/__main__.py
@@ -207,6 +207,8 @@ def _validate_ocp_arguments(parser, options):
                 'defined when {} {} is supplied.'
             msg = msg.format('--insights-upload', insights_upload)
             parser.error(msg)
+        # Either set of acceptable credentials are acceptable
+        ocp_valid = True
     else:
         ocp_valid = True
     return ocp_valid

--- a/nise/__main__.py
+++ b/nise/__main__.py
@@ -198,9 +198,13 @@ def _validate_ocp_arguments(parser, options):
     elif insights_upload is not None and not os.path.isdir(insights_upload):
         insights_user = os.environ.get('INSIGHTS_USER')
         insights_password = os.environ.get('INSIGHTS_PASSWORD')
-        if insights_user is None or insights_password is None:
-            msg = 'The environment must have INSIGHTS_USER and ' \
-                'INSIGHTS_PASSWORD defined when {} {} is supplied.'
+        insights_account_id = os.environ.get('INSIGHTS_ACCOUNT_ID')
+        insights_org_id = os.environ.get('INSIGHTS_ORG_ID')
+        if (insights_account_id is None or insights_org_id is None) and \
+                (insights_user is None or insights_password is None):
+            msg = 'The environment must have \nINSIGHTS_USER and ' \
+                'INSIGHTS_PASSWORD or\nINSIGHTS_ACCOUNT_ID and INSIGHTS_ORG_ID' \
+                'defined when {} {} is supplied.'
             msg = msg.format('--insights-upload', insights_upload)
             parser.error(msg)
     else:

--- a/nise/report.py
+++ b/nise/report.py
@@ -15,11 +15,13 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 """Module responsible for generating the cost and usage report."""
+import base64
 import calendar
 import copy
 import csv
 import gzip
 import importlib
+import json
 import os
 import random
 import shutil
@@ -126,22 +128,51 @@ def ocp_route_file(insights_upload, local_path):
         extract_payload(insights_upload,
                         local_path)
     else:
-        with open(local_path, 'rb') as upload_file:
-            insights_user = os.environ.get('INSIGHTS_USER')
-            insights_password = os.environ.get('INSIGHTS_PASSWORD')
-            response = requests.post(insights_upload,
-                                     data={},
-                                     files={'file': ('payload.tar.gz',
-                                                     upload_file,
-                                                     'application/vnd.redhat.hccm.tar+tgz')},
-                                     auth=(insights_user, insights_password),
-                                     verify=False)
-            if response.status_code == 202:
-                print('File uploaded successfully.')
-                print(response.text)
-            else:
-                print('{} File upload failed.'.format(response.status_code))
-                print(response.text)
+        response = post_payload_to_ingest_service(insights_upload, local_path)
+        if response.status_code == 202:
+            print('File uploaded successfully.')
+            print(response.text)
+        else:
+            print('{} File upload failed.'.format(response.status_code))
+            print(response.text)
+
+
+def post_payload_to_ingest_service(insights_upload, local_path):
+    """POST the payload to Insights via header or basic auth."""
+    insights_account_id = os.environ.get('INSIGHTS_ACCOUNT_ID')
+    insights_org_id = os.environ.get('INSIGHTS_ORG_ID')
+    insights_user = os.environ.get('INSIGHTS_USER')
+    insights_password = os.environ.get('INSIGHTS_PASSWORD')
+    with open(local_path, 'rb') as upload_file:
+        if insights_account_id and insights_org_id:
+            header = {
+                'identity': {
+                    'account_number': insights_account_id,
+                    'internal': {'org_id': insights_org_id}
+                }
+
+            }
+            headers = {
+                'x-rh-identity': base64.b64encode(json.dumps(header).encode('UTF-8'))
+            }
+            return requests.post(
+                insights_upload,
+                data={},
+                files={
+                    'file': ('payload.tar.gz',
+                             upload_file,
+                             'application/vnd.redhat.hccm.tar+tgz')
+                },
+                headers=headers
+            )
+
+        return requests.post(insights_upload,
+                             data={},
+                             files={'file': ('payload.tar.gz',
+                                             upload_file,
+                                             'application/vnd.redhat.hccm.tar+tgz')},
+                             auth=(insights_user, insights_password),
+                             verify=False)
 
 
 def _create_month_list(start_date, end_date):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -14,8 +14,10 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
+import os
 from datetime import datetime, date
 from unittest import TestCase
+from unittest.mock import patch
 
 from nise.__main__ import (create_parser,
                            main,
@@ -88,6 +90,35 @@ class CommandLineTestCase(TestCase):
         with self.assertRaises(SystemExit):
             options = {'ocp': True, 'aws_bucket_name': 'mybucket', 'ocp_cluster_id': '123'}
             _validate_provider_inputs(self.parser, options)
+
+    @patch.dict(os.environ, {'INSIGHTS_ACCOUNT_ID': '12345', 'INSIGHTS_ORG_ID': '54321'})
+    def test_ocp_inputs_insights_upload_account_org_ids(self):
+        """
+        Test where user passes an invalid ocp argument combination.
+        """
+
+        options = {'ocp': True, 'insights_upload': 'true', 'ocp_cluster_id': '123'}
+        is_valid, _ = _validate_provider_inputs(self.parser, options)
+        self.assertTrue(is_valid)
+
+    @patch.dict(os.environ, {'INSIGHTS_USER': '12345', 'INSIGHTS_PASSWORD': '54321'})
+    def test_ocp_inputs_insights_upload_user_pass(self):
+        """
+        Test where user passes an invalid ocp argument combination.
+        """
+
+        options = {'ocp': True, 'insights_upload': 'true', 'ocp_cluster_id': '123'}
+        is_valid, _ = _validate_provider_inputs(self.parser, options)
+        self.assertTrue(is_valid)
+
+    def test_ocp_inputs_insights_upload_no_envs(self):
+        """
+        Test where user passes an invalid ocp argument combination.
+        """
+        with self.assertRaises(SystemExit):
+            options = {'ocp': True, 'insights_upload': 'true', 'ocp_cluster_id': '123'}
+            _validate_provider_inputs(self.parser, options)
+
 
     def test_ocp_no_cluster_id(self):
         """


### PR DESCRIPTION
## Summary
If the `INSIGHTS_ACCOUNT_ID` and `INSIGHTS_ORG_ID` environment variables are set, they will override the auth for the Insights ingest service and instead create an identity header for the POST.