### PR TITLE
Changed nise default for saving the monthly files.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,6 +86,7 @@ nise is a command line tool. Currently only accepting a limited number of argume
 - *--static-report-file file_name* (optional) Note: Static report generation based on specified yaml file.  See example_aws[ocp]_static_data.yml for examples.
 - *--gcp-report-prefix prefix_name*  (optional)
 - *--gcp-bucket-name bucket_name*  (optional, see example usage below)
+- *--write-monthly* (optional, writes monthly files)
 
 Note: If `--aws-s3-report-name` or `--aws-s3-report-prefix` are specified they should match what is configured in the AWS cost usage report settings.
 
@@ -126,7 +127,7 @@ Below is an example usage of ``nise`` for OCP data::
 
     nise --start-date 2018-06-03 --ocp --ocp-cluster-id test-001 --insights-upload  https://cloud.redhat.com/api/ingress/v1/upload
 
-    nise --start-date 2018-06-03 --ocp --ocp-cluster-id test-001 --insights-upload  /local/path/upload_dir
+    nise --start-date 2018-06-03 --ocp --write-monthly --ocp-cluster-id test-001 --insights-upload  /local/path/upload_dir
 
     nise --ocp --ocp-cluster-id my-cluster-id --static-report-file ocp_static_data.yml
 

--- a/nise/__main__.py
+++ b/nise/__main__.py
@@ -147,7 +147,11 @@ def create_parser():
                         required=False,
                         default=os.getenv('AZURE_STORAGE_ACCOUNT'),
                         help='Azure container to place the data.')
-
+    parser.add_argument('--write-monthly',
+                        dest='write_monthly',
+                        action='store_true',
+                        required=False,
+                        help='Writes the monthly files.')
     return parser
 
 
@@ -179,13 +183,14 @@ def _get_azure_options(options):
         azure_container_name (string): Azure storage account name
         azure_report_name (string): Azure report name
         azure_prefix_name (string): Azure report prefix
-        azure_finalize_report (string): Azure finalize choice
+        azure_account_name (string): Azure account name
 
     """
     azure_container_name = options.get('azure_container_name')
     azure_report_name = options.get('azure_report_name')
     azure_prefix_name = options.get('azure_prefix_name')
-    return (azure_container_name, azure_report_name, azure_prefix_name)
+    azure_account_name = options.get('azure_account_name')
+    return (azure_container_name, azure_report_name, azure_prefix_name, azure_account_name)
 
 
 def _get_ocp_options(options):
@@ -284,7 +289,7 @@ def _validate_azure_arguments(parser, options):
             msg = 'GCP arguments cannot be supplied when generating AWS data.'
             parser.error(msg)
 
-    azure_container_name, azure_report_name, _ = _get_azure_options(options)
+    azure_container_name, azure_report_name, _, _ = _get_azure_options(options)
     if azure_container_name and azure_report_name:
         azure_valid = True
     elif not azure_container_name and not azure_report_name:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -93,7 +93,8 @@ class CommandLineTestCase(TestCase):
         options = {'azure': True,
                    'azure_container_name': 'storage',
                    'azure_report_name': 'report',
-                   'azure_prefix_name': 'value'}
+                   'azure_prefix_name': 'value',
+                   'azure_account_name': 'account'}
         valid = _validate_provider_inputs(self.parser, options)
         self.assertTrue(valid)
 
@@ -116,7 +117,7 @@ class CommandLineTestCase(TestCase):
             options = {'aws': True, 'azure_container_name': '123'}
             _validate_provider_inputs(self.parser, options)
         with self.assertRaises(SystemExit):
-            options = {'azure': True, 'gcp_report_prefix': 'gcp-report'}
+            options = {'aws': True, 'gcp_report_prefix': 'gcp-report'}
             _validate_provider_inputs(self.parser, options)
 
     def test_invalid_azure_inputs(self):
@@ -147,7 +148,7 @@ class CommandLineTestCase(TestCase):
             options = {'ocp': True, 'azure_container_name': '123'}
             _validate_provider_inputs(self.parser, options)
         with self.assertRaises(SystemExit):
-            options = {'azure': True, 'gcp_report_prefix': 'gcp-report'}
+            options = {'ocp': True, 'gcp_report_prefix': 'gcp-report'}
             _validate_provider_inputs(self.parser, options)
 
     @patch.dict(os.environ, {'INSIGHTS_ACCOUNT_ID': '12345', 'INSIGHTS_ORG_ID': '54321'})
@@ -185,6 +186,14 @@ class CommandLineTestCase(TestCase):
         with self.assertRaises(SystemExit):
             options = {'ocp': True}
             _validate_provider_inputs(self.parser, options)
+
+    def test_ocp_no_insights_upload(self):
+        """
+        Test where user passes ocp without insights upload.
+        """
+        options = {'ocp': True, 'ocp_cluster_id':'132'}
+        is_valid, _ = _validate_provider_inputs(self.parser, options)
+        self.assertTrue(is_valid)
 
     def test_main_no_inputs(self):
         """
@@ -237,18 +246,13 @@ class CommandLineTestCase(TestCase):
             options = {'gcp': True, 'azure_report_name': 'report'}
             _validate_provider_inputs(self.parser, options)
         with self.assertRaises(SystemExit):
+            options = {'gcp': True, 'azure_account_name': 'report'}
+            _validate_provider_inputs(self.parser, options)
+        with self.assertRaises(SystemExit):
             options = {'gcp': True, 'aws_bucket_name': 'mybucket'}
             _validate_provider_inputs(self.parser, options)
         with self.assertRaises(SystemExit):
             options = {'gcp': True, 'ocp_cluster_id': '123'}
-            _validate_provider_inputs(self.parser, options)
-
-    def test_invalid_gcp_inputs_aws_args(self):
-        """
-        Test where user aws arg when creating gcp data.
-        """
-        with self.assertRaises(SystemExit):
-            options = {'gcp': True, 'aws_bucket_name': 'my-bucket'}
             _validate_provider_inputs(self.parser, options)
 
     def test_no_provider_type_fail(self):


### PR DESCRIPTION
Notice that the monthly files are not created.
```
nise --aws --static-report-file example_aws_static_data.yml
nise --ocp --ocp-cluster-id my-cluster-id --static-report-file example_ocp_static_data.yml
nise --azure --static-report-file example_azure_static_data.yml
nise --gcp --static-report-file example_gcp_static_data.yml
```
Notice that the monthly files are created.
```
nise --aws --write-monthly --static-report-file example_aws_static_data.yml
nise --ocp --write-monthly --ocp-cluster-id my-cluster-id --static-report-file example_ocp_static_data.yml
nise --azure --write-monthly --static-report-file example_azure_static_data.yml
nise --gcp --write-monthly --static-report-file example_gcp_static_data.yml
```