### PR TITLE
fix file copying. ignore file metadata when copying files.

### DIFF
--- a/nise/copy.py
+++ b/nise/copy.py
@@ -40,7 +40,7 @@ def copy_to_local_dir(local_dir_home, local_path, local_file_path=None):
         full_bucket_path = '{}/{}'.format(local_dir_home, local_file_path)
         outpath = local_file_path
     os.makedirs(os.path.dirname(full_bucket_path), exist_ok=True)
-    shutil.copy2(local_path, full_bucket_path)
+    shutil.copyfile(local_path, full_bucket_path)
     msg = 'Copied {} to local directory {}.'.format(outpath, local_dir_home)
     print(msg)
     return True

--- a/nise/upload.py
+++ b/nise/upload.py
@@ -67,10 +67,8 @@ def upload_to_azure_container(storage_file_name, local_path, storage_file_path):
         # Retrieve the connection string for use with the application.
         connect_str = os.getenv('AZURE_STORAGE_CONNECTION_STRING')
         blob_service_client = BlobServiceClient.from_connection_string(connect_str)
-        print('XXX1: %s' % blob_service_client)
         blob_client = blob_service_client.get_blob_client(container=storage_file_name,
                                                           blob=storage_file_path)
-        print('XXX2: %s' % blob_client)
         with open(local_path, 'rb') as data:
             blob_client.upload_blob(data=data)
         print(f'uploaded {storage_file_name} to {storage_file_path}')

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="koku-nise",
-    version="1.0.1",
+    version="1.0.2",
     author="Project Koku",
     author_email="cost_mgmt@redhat.com",
     description="A tool for generating sample cost and usage data for testing purposes.",


### PR DESCRIPTION
This fixes a bug seen on Linux systems when using Nise. The problem is in attempting to copy the file metadata, including xattrs. On Linux when SELinux is enforcing, we can't guarantee that we'll have sufficient permissions to set xattrs in the destination directory.

In most cases, we don't need to copy the metadata. Inheriting the destination directory's permissions is the correct behavior in most cases. So, this PR changes from using `shutils.copy2` to using `shutils.copyfile` so that nise is only copying the file contents without preserving the file metadata.

Before the fix:
```
nise --aws --aws-s3-bucket-name /tmp/local_bucket --aws-s3-report-name blentz --static-report-file ./example_aws_data.yml 
Traceback (most recent call last):
  File "/iqe_venv/bin/nise", line 8, in <module>
    sys.exit(main())
  File "/iqe_venv/lib64/python3.6/site-packages/nise/__main__.py", line 507, in main
    aws_create_report(options)
  File "/iqe_venv/lib64/python3.6/site-packages/nise/report.py", line 413, in aws_create_report
    temp_manifest)
  File "/iqe_venv/lib64/python3.6/site-packages/nise/report.py", line 142, in aws_route_file
    bucket_file_path,)
  File "/iqe_venv/lib64/python3.6/site-packages/nise/copy.py", line 43, in copy_to_local_dir
    shutil.copy2(local_path, full_bucket_path)
  File "/usr/lib64/python3.6/shutil.py", line 264, in copy2
    copystat(src, dst, follow_symlinks=follow_symlinks)
  File "/usr/lib64/python3.6/shutil.py", line 229, in copystat
    _copyxattr(src, dst, follow_symlinks=follow)
  File "/usr/lib64/python3.6/shutil.py", line 165, in _copyxattr
    os.setxattr(dst, name, value, follow_symlinks=follow_symlinks)
PermissionError: [Errno 13] Permission denied: '/tmp/local_bucket//blentz/20190801-20190901/blentz-Manifest.json'
```
After the fix:
```
nise --aws --aws-s3-bucket-name /tmp/local_bucket --aws-s3-report-name blentz --static-report-file ./example_aws_data.yml 
Copied /blentz/20190801-20190901/blentz-Manifest.json to local directory /tmp/local_bucket.
Copied /blentz/20190801-20190901/cd55000a-7707-4c2d-a5fe-57a3b7a035bc/blentz-Manifest.json to local directory /tmp/local_bucket.
Copied /blentz/20190801-20190901/cd55000a-7707-4c2d-a5fe-57a3b7a035bc/blentz-1.csv.gz to local directory /tmp/local_bucket.
Copied /blentz/20190901-20191001/blentz-Manifest.json to local directory /tmp/local_bucket.
Copied /blentz/20190901-20191001/9215441c-f007-4333-ab93-4b1ca51e676d/blentz-Manifest.json to local directory /tmp/local_bucket.
Copied /blentz/20190901-20191001/9215441c-f007-4333-ab93-4b1ca51e676d/blentz-1.csv.gz to local directory /tmp/local_bucket.
Copied /blentz/20191001-20191101/blentz-Manifest.json to local directory /tmp/local_bucket.
Copied /blentz/20191001-20191101/4e2679d4-7342-4d06-838d-53f6733f8066/blentz-Manifest.json to local directory /tmp/local_bucket.
Copied /blentz/20191001-20191101/4e2679d4-7342-4d06-838d-53f6733f8066/blentz-1.csv.gz to local directory /tmp/local_bucket.
Copied /blentz/20191101-20191201/blentz-Manifest.json to local directory /tmp/local_bucket.
Copied /blentz/20191101-20191201/ada0c4d5-2ec0-4455-8bae-f7ab616aa574/blentz-Manifest.json to local directory /tmp/local_bucket.
Copied /blentz/20191101-20191201/ada0c4d5-2ec0-4455-8bae-f7ab616aa574/blentz-1.csv.gz to local directory /tmp/local_bucket.
Copied /blentz/20191201-20200101/blentz-Manifest.json to local directory /tmp/local_bucket.
Copied /blentz/20191201-20200101/66f6abbe-6542-4438-8bbf-bf046649458b/blentz-Manifest.json to local directory /tmp/local_bucket.
Copied /blentz/20191201-20200101/66f6abbe-6542-4438-8bbf-bf046649458b/blentz-1.csv.gz to local directory /tmp/local_bucket.
Copied /blentz/20200101-20200201/blentz-Manifest.json to local directory /tmp/local_bucket.
Copied /blentz/20200101-20200201/74f2082a-37a6-4bfc-8177-bbe8add2a467/blentz-Manifest.json to local directory /tmp/local_bucket.
Copied /blentz/20200101-20200201/74f2082a-37a6-4bfc-8177-bbe8add2a467/blentz-1.csv.gz to local directory /tmp/local_bucket.

```