### PR TITLE
better integrate azure storage api update

### DIFF
--- a/nise/__main__.py
+++ b/nise/__main__.py
@@ -141,14 +141,12 @@ def create_parser():
                         dest='gcp_bucket_name',
                         required=False,
                         help='GCP storage account to place the data.')
-    parser.add_argument(
-        "--azure-account-name",
-        metavar="AZURE_ACCOUNT_NAME",
-        dest="azure_account_name",
-        required=False,
-        default=os.getenv("AZURE_STORAGE_ACCOUNT"),
-        help="Azure container to place the data.",
-    )
+    parser.add_argument('--azure-account-name',
+                        metavar='AZURE_ACCOUNT_NAME',
+                        dest='azure_account_name',
+                        required=False,
+                        default=os.getenv('AZURE_STORAGE_ACCOUNT'),
+                        help='Azure container to place the data.')
 
     return parser
 

--- a/nise/__main__.py
+++ b/nise/__main__.py
@@ -141,6 +141,14 @@ def create_parser():
                         dest='gcp_bucket_name',
                         required=False,
                         help='GCP storage account to place the data.')
+    parser.add_argument(
+        "--azure-account-name",
+        metavar="AZURE_ACCOUNT_NAME",
+        dest="azure_account_name",
+        required=False,
+        default=os.getenv("AZURE_STORAGE_ACCOUNT"),
+        help="Azure container to place the data.",
+    )
 
     return parser
 

--- a/nise/report.py
+++ b/nise/report.py
@@ -148,7 +148,7 @@ def aws_route_file(bucket_name, bucket_file_path, local_path):
 
 def azure_route_file(storage_account_name, storage_file_name, local_path, storage_file_path=None):
     """Route file to either storage account or local filesystem."""
-    connect_str = os.getenv("AZURE_STORAGE_CONNECTION_STRING")
+    connect_str = os.getenv('AZURE_STORAGE_CONNECTION_STRING')
     if storage_file_path is None and connect_str is None:
         copy_to_local_dir(storage_account_name, local_path, storage_file_name)
     else:

--- a/nise/report.py
+++ b/nise/report.py
@@ -148,14 +148,11 @@ def aws_route_file(bucket_name, bucket_file_path, local_path):
 
 def azure_route_file(storage_account_name, storage_file_name, local_path, storage_file_path=None):
     """Route file to either storage account or local filesystem."""
-    if storage_file_path is None:
-        copy_to_local_dir(storage_account_name,
-                          local_path,
-                          storage_file_name)
+    connect_str = os.getenv("AZURE_STORAGE_CONNECTION_STRING")
+    if storage_file_path is None and connect_str is None:
+        copy_to_local_dir(storage_account_name, local_path, storage_file_name)
     else:
-        upload_to_azure_container(storage_file_name,
-                                  local_path,
-                                  storage_file_path)
+        upload_to_azure_container(storage_file_name, local_path, storage_file_path)
 
 
 def ocp_route_file(insights_upload, local_path):

--- a/nise/upload.py
+++ b/nise/upload.py
@@ -65,13 +65,14 @@ def upload_to_azure_container(storage_file_name, local_path, storage_file_path):
     """
     try:
         # Retrieve the connection string for use with the application.
-        connect_str = os.getenv('AZURE_STORAGE_CONNECTION_STRING')
+        connect_str = os.getenv("AZURE_STORAGE_CONNECTION_STRING")
         blob_service_client = BlobServiceClient.from_connection_string(connect_str)
-        blob_client = blob_service_client.get_blob_client(container=storage_file_name,
-                                                          blob=storage_file_path)
-        with open(local_path, 'rb') as data:
+        blob_client = blob_service_client.get_blob_client(
+            container=storage_file_name, blob=storage_file_path
+        )
+        with open(local_path, "rb") as data:
             blob_client.upload_blob(data=data)
-        print(f'uploaded {storage_file_name} to {storage_file_path}')
+        print(f"uploaded {storage_file_name} to {storage_file_path}")
     # pylint: disable=broad-except
     except Exception as error:
         print(error)

--- a/nise/upload.py
+++ b/nise/upload.py
@@ -65,14 +65,14 @@ def upload_to_azure_container(storage_file_name, local_path, storage_file_path):
     """
     try:
         # Retrieve the connection string for use with the application.
-        connect_str = os.getenv("AZURE_STORAGE_CONNECTION_STRING")
+        connect_str = os.getenv('AZURE_STORAGE_CONNECTION_STRING')
         blob_service_client = BlobServiceClient.from_connection_string(connect_str)
         blob_client = blob_service_client.get_blob_client(
             container=storage_file_name, blob=storage_file_path
         )
-        with open(local_path, "rb") as data:
+        with open(local_path, 'rb') as data:
             blob_client.upload_blob(data=data)
-        print(f"uploaded {storage_file_name} to {storage_file_path}")
+        print(f'uploaded {storage_file_name} to {storage_file_path}')
     # pylint: disable=broad-except
     except Exception as error:
         print(error)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="koku-nise",
-    version="1.0.2",
+    version="1.0.3",
     author="Project Koku",
     author_email="cost_mgmt@redhat.com",
     description="A tool for generating sample cost and usage data for testing purposes.",


### PR DESCRIPTION
This PR fleshes out the plumbing for the current Azure storage API a bit better.

I've added a new CLI arg `--azure-account-name` that also reads the `AZURE_STORAGE_ACCOUNT` environment variable for its default. This enables both the older workflow and the new flow using the `AZURE_STORAGE_CONNECTION_STRING` variable.

I'll continue improving the UX in a future PR. This change is intended to be a minimum-functional solution.

Azure upload:
```
nise --azure --azure-container-name=output --azure-report-name=blentz-test --start-date=2020-01-01 --azure-account-name=mysa1
uploaded output to blentz-test/20200101-20200131/costreport_7d2c1d86-8e7e-44db-9780-c6d7414d9010.csv
```