### PR TITLE
Automate a way to see if local nise changes break iqe-tests.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+KOKU_PATH=/path/to/koku

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-DATE		= $(shell date)
-PYTHON		= $(shell which python)
+DATE    = $(shell date)
+PYTHON  = $(shell which python)
 
 TOPDIR = $(shell pwd)
 IQE_CMD = 'iqe tests plugin --debug hccm -k test_api -m hccm_smoke'
@@ -11,6 +11,7 @@ help:
 	@echo "  clean               to remove client egg"
 	@echo "  test                to run unit tests"
 	@echo "  run-iqe             ro runs iqe tests with local changes. (Defaults to smoke tests.)"
+	@echo "                          @param IQE_CMD - The iqe command you want to run defaults to: ($(IQE_CMD))"
 
 install: clean
 	$(PYTHON) setup.py build -f

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ PYTHON  = $(shell which python)
 TOPDIR = $(shell pwd)
 IQE_CMD = 'iqe tests plugin --debug hccm -k test_api -m hccm_smoke'
 
+DOCKER := $(shell command -v docker 2> /dev/null)
+PODMAN := $(shell command -v podman 2> /dev/null)
+
 help:
 	@echo "Please use \`make <target>' where <target> is one of:"
 	@echo "  help                to show this message"
@@ -19,8 +22,15 @@ install: clean
 
 clean:
 	-rm -rf dist/ build/ koku_nise.egg-info/
-	docker stop iqe-nise | true
-	docker rm iqe-nise | true
+ifdef DOCKER
+	docker stop iqe-nise 2> /dev/null | true
+	docker rm iqe-nise 2> /dev/null | true
+endif
+ifdef PODMAN
+	podman stop 2> /dev/null | true
+	podman rm iqe-nise 2> /dev/null | true
+endif
+
 
 test:
 	tox -e py36

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+DATE		= $(shell date)
+PYTHON		= $(shell which python)
+
+TOPDIR = $(shell pwd)
+IQE_CMD = 'iqe tests plugin --debug hccm -k test_api -m hccm_smoke'
+
+help:
+	@echo "Please use \`make <target>' where <target> is one of:"
+	@echo "  help                to show this message"
+	@echo "  install             to install the client egg"
+	@echo "  clean               to remove client egg"
+	@echo "  test                to run unit tests"
+	@echo "  run-iqe             ro runs iqe tests with local changes. (Defaults to smoke tests.)"
+
+install: clean
+	$(PYTHON) setup.py build -f
+	$(PYTHON) setup.py install -f
+
+clean:
+	-rm -rf dist/ build/ koku_nise.egg-info/
+	docker stop iqe-nise | true
+	docker rm iqe-nise | true
+
+test:
+	tox -e py36
+
+lint:
+	tox -e lint
+
+run-iqe:
+	cd scripts; ./iqe_container.sh $(IQE_CMD)

--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,18 @@ To lint the code base ::
 
     tox -e lint
 
+Nise and IQE Tests
+------------------
+
+The iqe tests use nise to generate mock data; therefore, we need to ensure that our nise changes do not break the iqe tests. To do this you will need to copy the `.env.example` to a `.env` file.
+After the `.env` file is configured you will then need to run ::
+
+    make run-iqe
+
+The `make run-iqe` command by default will run the smoke tests. However, if you want to run a specific iqe test command you can pass it in through the `IQE_CMD` parameter ::
+
+    make run-iqe IQE_CMD='iqe tests plugin hccm -k test_api_aws_provider_create_foo_resource_name'
+
 
 Publishing
 ----------

--- a/scripts/entrypoint_append.sh
+++ b/scripts/entrypoint_append.sh
@@ -1,0 +1,4 @@
+pip uninstall -y koku-nise
+cd /var/nise;
+python3 setup.py build -f
+python3 setup.py install -f

--- a/scripts/iqe_container.sh
+++ b/scripts/iqe_container.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+COMMAND=$@
+export KOKU_PATH="${KOKU_PATH}"
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+NISE_PATH="$(dirname $(pwd))"
+IMAGE="docker-registry.upshift.redhat.com/insights-qe/iqe-tests"
+
+FLAGS=
+HOST=$(uname)
+if [ $HOST == 'Linux' ]; then
+    FLAGS=':Z'
+fi
+
+main() {
+    if command -v docker > /dev/null 2>&1; then
+        CONTAINER_RUNTIME=docker
+    elif command -v podman > /dev/null 2>&1; then
+        CONTAINER_RUNTIME=podman
+    else
+        echo "Please install podman or docker first"
+        exit 1
+    fi
+
+    $CONTAINER_RUNTIME pull $IMAGE
+
+    $CONTAINER_RUNTIME run -it \
+                           --rm \
+                           --network="host" \
+                           --name "iqe-nise" \
+                           -e "IQE_TESTS_LOCAL_CONF_PATH=/iqe_conf" \
+                           -e "ENV_FOR_DYNACONF=local" \
+                           -v $KOKU_PATH/testing/conf:/iqe_conf${FLAGS} \
+                           -v $KOKU_PATH/local_providers/aws_local:/tmp/local_bucket${FLAGS} \
+                           -v $KOKU_PATH/local_providers/aws_local_0:/tmp/local_bucket_0${FLAGS} \
+                           -v $KOKU_PATH/local_providers/aws_local_1:/tmp/local_bucket_1${FLAGS} \
+                           -v $KOKU_PATH/local_providers/aws_local_2:/tmp/local_bucket_2${FLAGS} \
+                           -v $KOKU_PATH/local_providers/aws_local_3:/tmp/local_bucket_3${FLAGS} \
+                           -v $KOKU_PATH/local_providers/aws_local_4:/tmp/local_bucket_4${FLAGS} \
+                           -v $KOKU_PATH/local_providers/aws_local_5:/tmp/local_bucket_5${FLAGS} \
+                           -v $KOKU_PATH/local_providers/azure_local:/tmp/local_container${FLAGS} \
+                           -v $KOKU_PATH/pvc_dir/insights_local:/var/tmp/masu/insights_local${FLAGS} \
+                           -v $NISE_PATH:/var/nise/${FLAGS} \
+                           $IMAGE \
+                           bash -c "cd /var/nise/scripts/; ./entrypoint_append.sh; cd -; $COMMAND" \
+
+}
+
+main


### PR DESCRIPTION
~On hold due to new changes pushed to the insights-tests dockerfile that breaks the current `docker-registry.upshift.redhat.com/insights-qe/iqe-tests` image.~

Psav fixed the issue with the image and we are good to go. 👍 