### PR TITLE
Fix validation of start_date

### DIFF
--- a/nise/__main__.py
+++ b/nise/__main__.py
@@ -30,6 +30,10 @@ from nise.report import (aws_create_report,
                          ocp_create_report)
 
 
+class NiseError(Exception):
+    pass
+
+
 def valid_date(date_string):
     """Create date from date string."""
     try:
@@ -508,6 +512,9 @@ def calculate_end_date(start_date, end_date):
 def run(provider_type, options):
     """Run nise."""
     _load_static_report_data(options)
+    if not options.get('start_date'):
+        raise NiseError("'start_date' is required in static files.")
+
 
     if provider_type == 'aws':
         aws_create_report(options)
@@ -526,7 +533,7 @@ def main():
     options = vars(args)
     _, provider_type = _validate_provider_inputs(parser, options)
 
-    if not options.get('start_date'):
+    if not (options.get('start_date') or options.get('static_report_file')):
         parser.error('the following arguments are required: --start-date')
 
     run(provider_type, options)

--- a/nise/__main__.py
+++ b/nise/__main__.py
@@ -31,6 +31,7 @@ from nise.report import (aws_create_report,
 
 
 class NiseError(Exception):
+    """A Nise Exception class."""
     pass
 
 
@@ -514,7 +515,6 @@ def run(provider_type, options):
     _load_static_report_data(options)
     if not options.get('start_date'):
         raise NiseError("'start_date' is required in static files.")
-
 
     if provider_type == 'aws':
         aws_create_report(options)

--- a/nise/__main__.py
+++ b/nise/__main__.py
@@ -32,7 +32,6 @@ from nise.report import (aws_create_report,
 
 class NiseError(Exception):
     """A Nise Exception class."""
-    pass
 
 
 def valid_date(date_string):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="koku-nise",
-    version="1.0.9",
+    version="1.0.10",
     author="Project Koku",
     author_email="cost_mgmt@redhat.com",
     description="A tool for generating sample cost and usage data for testing purposes.",


### PR DESCRIPTION
## Summary
start_date gets inserted to options when parsing a static file, but the static file parsing is now done in `run()` after parser validation. 