### PR TITLE
Fix node names in example YAMLs

### DIFF
--- a/examples/ocp_on_aws/ocp_static_data.yml
+++ b/examples/ocp_on_aws/ocp_static_data.yml
@@ -5,7 +5,7 @@ generators:
       end_date: 2019-07-31
       nodes:
         - node:
-          node_name: compute_1
+          node_name: aws_compute1
           cpu_cores: 2
           memory_gig: 8
           resource_id: 55555555
@@ -55,7 +55,7 @@ generators:
                     labels: label_environment:dev|label_app:catalog|label_version:prod|label_storageclass:delta
                     capacity_gig: 20
         - node:
-          node_name: compute_2
+          node_name: aws_compute2
           cpu_cores: 2
           memory_gig: 8
           resource_id: 55555556
@@ -83,7 +83,7 @@ generators:
                     labels: label_environment:qe|label_app:cost|label_version:beta|label_storageclass:epsilon
                     capacity_gig: 20
         - node:
-          node_name: compute_3
+          node_name: aws_compute3
           cpu_cores: 2
           memory_gig: 8
           resource_id: 55555557
@@ -111,7 +111,7 @@ generators:
                     labels: label_environment:prod|label_app:analytics|label_version:gamma|label_storageclass:charlie
                     capacity_gig: 20
         - node:
-          node_name: master
+          node_name: aws_master
           cpu_cores: 2
           memory_gig: 8
           resource_id: 55555558

--- a/examples/ocp_on_azure/azure_static_data.yml
+++ b/examples/ocp_on_azure/azure_static_data.yml
@@ -6,7 +6,7 @@ generators:
       service_name: Virtual Machines
       meter_id: 55555555-4444-3333-2222-111111111128
       resource_location: "US East"
-      instance_id: '/subscriptions/99999999-9999-9999-9999-999999999999/resourceGroups/koku-99hqd-rg/providers/Microsoft.Compute/virtualMachines/compute_1'
+      instance_id: '/subscriptions/99999999-9999-9999-9999-999999999999/resourceGroups/koku-99hqd-rg/providers/Microsoft.Compute/virtualMachines/azure_compute1'
       tags:
         version: Mars
   - VMGenerator:
@@ -15,7 +15,7 @@ generators:
       service_name: Virtual Machines
       meter_id: 55555555-4444-3333-2222-111111111127
       resource_location: "US East"
-      instance_id: '/subscriptions/99999999-9999-9999-9999-999999999999/resourceGroups/koku-99hqd-rg/providers/Microsoft.Compute/virtualMachines/compute_2'
+      instance_id: '/subscriptions/99999999-9999-9999-9999-999999999999/resourceGroups/koku-99hqd-rg/providers/Microsoft.Compute/virtualMachines/azure_compute2'
       tags:
         environment: Jupiter
         version: MilkyWay
@@ -25,7 +25,7 @@ generators:
       service_name: Virtual Machines
       meter_id: 55555555-4444-3333-2222-111111111126
       resource_location: "US East"
-      instance_id: '/subscriptions/99999999-9999-9999-9999-999999999999/resourceGroups/koku-99hqd-rg/providers/Microsoft.Compute/virtualMachines/compute_3'
+      instance_id: '/subscriptions/99999999-9999-9999-9999-999999999999/resourceGroups/koku-99hqd-rg/providers/Microsoft.Compute/virtualMachines/azure_compute3'
       tags:
         environment: Jupiter
         version: Andromeda
@@ -35,7 +35,7 @@ generators:
       service_name: Virtual Machines
       meter_id: 55555555-4444-3333-2222-111111111125
       resource_location: "US East"
-      instance_id: '/subscriptions/99999999-9999-9999-9999-999999999999/resourceGroups/koku-99hqd-rg/providers/Microsoft.Compute/virtualMachines/master'
+      instance_id: '/subscriptions/99999999-9999-9999-9999-999999999999/resourceGroups/koku-99hqd-rg/providers/Microsoft.Compute/virtualMachines/azure_master'
       tags:
         version: Sombrero
   - StorageGenerator:

--- a/examples/ocp_on_azure/ocp_static_data.yml
+++ b/examples/ocp_on_azure/ocp_static_data.yml
@@ -5,7 +5,7 @@ generators:
       end_date: 2019-11-30
       nodes:
         - node:
-          node_name: compute_1
+          node_name: azure_compute1
           cpu_cores: 2
           memory_gig: 8
           resource_id: 99999995
@@ -55,7 +55,7 @@ generators:
                     labels: label_environment:Jupiter|label_app:mobile|label_version:Mars|label_storageclass:Loki
                     capacity_gig: 20
         - node:
-          node_name: compute_2
+          node_name: azure_compute2
           cpu_cores: 2
           memory_gig: 8
           resource_id: 99999996
@@ -83,7 +83,7 @@ generators:
                     labels: label_environment:qe|label_app:banking|label_version:MilkyWay|label_storageclass:Odin
                     capacity_gig: 20
         - node:
-          node_name: compute_3
+          node_name: azure_compute3
           cpu_cores: 2
           memory_gig: 8
           resource_id: 99999997
@@ -111,7 +111,7 @@ generators:
                     labels: label_environment:Mars|label_app:weather|label_version:Andromeda|label_storageclass:Thor
                     capacity_gig: 20
         - node:
-          node_name: master
+          node_name: azure_master
           cpu_cores: 2
           memory_gig: 8
           resource_id: 99999998

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="koku-nise",
-    version="1.0.11",
+    version="1.0.12",
     author="Project Koku",
     author_email="cost_mgmt@redhat.com",
     description="A tool for generating sample cost and usage data for testing purposes.",


### PR DESCRIPTION
## Summary
No node name collisions between OCP on AWs and OCP on Azure.