### PR TITLE
Publish workflow sync

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install dependencies
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install setuptools wheel twine
+          python3 -m pip install pipenv-setup setuptools wheel twine
       - name: Build and publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -31,6 +31,8 @@ jobs:
           VERSION=$(python setup.py --version)
           if [ ! -z $(git tag -l "${VERSION}") ]; then
             echo "Tag already exists, doing nothing";
+          elif [ -z "$(pipenv-setup check)" ]; then
+            echo "setup.py out of sync with Pipfile"
           else
             echo "Creating tag ${VERSION}";
             git config --local user.email "cost-mgmt@redhat.com"

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="koku-nise",
-    version="1.0.15",
+    version="1.0.16",
     author="Project Koku",
     author_email="cost_mgmt@redhat.com",
     description="A tool for generating sample cost and usage data for testing purposes.",

--- a/tests/test_yaml_file_generator.py
+++ b/tests/test_yaml_file_generator.py
@@ -140,7 +140,7 @@ class YamlGeneratorTestCase(TestCase):
         label_str = self.yg.generate_labels(2)
         labels = label_str.split("|")
         self.assertEqual(len(labels), 2)
-        labels = [len(l.split(":")) == 2 for l in labels]
+        labels = [len(label.split(":")) == 2 for label in labels]
         self.assertTrue(all(labels))
 
     def test_build_data(self):


### PR DESCRIPTION
While updating the `README` in a separate PR, I noticed our publishing workflow is missing the Pipfile/setup.py sync check. This PR adds that check.

testing the bash `if` statement:
I used this snippet for testing:
```bash
if [ ! -z $(git tag -l "${VERSION}") ]; then       
  echo "Tag already exists, doing nothing";
elif [ -z "$(pipenv-setup check)" ]; then
  echo "setup.py out of sync with Pipfile"
else
  echo "Creating tag ${VERSION}";
fi
```
This snippet should show `Creating tag` when the `Pipfile` and `setup.py` are in sync, and `setup.py out of sync with Pipfile` when they are out of sync.

1. Run snippet without changes to the Pipfile. See `Creating tag` printed.
2. add a package to the Pipfile: `pipenv install tiny`
3. Run the snippet again, see `setup.py out of sync with Pipfile` printed.
4. Remove tiny: `pipenv uninstall tiny` and add it to dev: `pipenv install tiny --dev`.
5. Rerun the snippet. See `Creating tag` printed (because dev packages do not go in `setup.py` file).