### PR TITLE
Date fixes

### DIFF
--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.0.2"
+__version__ = "2.0.3"
 VERSION = __version__.split(".")

--- a/nise/__main__.py
+++ b/nise/__main__.py
@@ -55,10 +55,6 @@ def today():
     return datetime.datetime.now().replace(microsecond=0, second=0, minute=0)
 
 
-def last_day_of_month(date):
-    return calendar.monthrange(date.year, date.month)[1]
-
-
 def add_aws_parser_args(parser):
     """Add AWS sub-parser args."""
     parser.add_argument(

--- a/nise/__main__.py
+++ b/nise/__main__.py
@@ -459,6 +459,12 @@ def _load_static_report_data(options):
 
             if attributes.get("end_date"):
                 generated_end_date = calculate_end_date(generated_start_date, attributes.get("end_date"))
+                if (
+                    options.get("provider") == "azure"
+                    and generated_end_date.day == 1  # noqa: W503
+                    or generated_end_date == generated_start_date  # noqa: W503
+                ):
+                    generated_end_date += datetime.timedelta(hours=24)
             else:
                 if options.get("provider") == "azure":
                     generated_end_date = today() + datetime.timedelta(hours=24)
@@ -467,8 +473,8 @@ def _load_static_report_data(options):
             end_dates.append(generated_end_date)
 
             attributes["start_date"] = str(generated_start_date)
-            if generated_end_date == generated_start_date:
-                generated_end_date += relativedelta(hours=23, minutes=59)
+            if options.get("provider") != "azure":
+                generated_end_date.replace(hour=23, minute=59)
             attributes["end_date"] = str(generated_end_date)
 
         options["start_date"] = min(start_dates)

--- a/nise/__main__.py
+++ b/nise/__main__.py
@@ -471,6 +471,8 @@ def _load_static_report_data(options):
             end_dates.append(generated_end_date)
 
             attributes["start_date"] = str(generated_start_date)
+            if generated_end_date == generated_start_date:
+                generated_end_date += relativedelta(hours=23, minutes=59)
             attributes["end_date"] = str(generated_end_date)
 
         options["start_date"] = min(start_dates)
@@ -518,15 +520,8 @@ def calculate_end_date(start_date, end_date):
 
 
 def fix_dates(options, provider_type):
-    if options.get("start_date"):
-        options["start_date"] = calculate_start_date(options.get("start_date"))
-    if options.get("end_date"):
-        options["end_date"] = calculate_end_date(options.get("start_date"), options.get("end_date"))
-    if provider_type == "azure":
-        # if options.get("start_date").day == last_day_of_month(options.get("start_date")):
-        #     options["start_date"] -= relativedelta(days=1)
-        if options.get("end_date").day == 1:
-            options["end_date"] += relativedelta(days=1)
+    if provider_type == "azure" and options.get("end_date").day == 1:
+        options["end_date"] += relativedelta(days=1)
 
 
 def run(provider_type, options):

--- a/nise/report.py
+++ b/nise/report.py
@@ -339,14 +339,14 @@ def _create_generator_dates_from_yaml(attributes, month):
         hour=23, minute=59, second=59
     ):
         gen_start_date = month.get("start")
-        gen_end_date = attributes.get("end_date")
+        gen_end_date = attributes.get("end_date").replace(hour=23, minute=59)
 
     # Generator is within month
     if attributes.get("start_date") >= month.get("start") and attributes.get("end_date") <= month.get("end").replace(
         hour=23, minute=59, second=59
     ):
         gen_start_date = attributes.get("start_date")
-        gen_end_date = attributes.get("end_date")
+        gen_end_date = attributes.get("end_date").replace(hour=23, minute=59)
 
     # Generator starts within month and ends in next month
     if attributes.get("start_date") >= month.get("start") and attributes.get("end_date") > month.get("end").replace(

--- a/nise/report.py
+++ b/nise/report.py
@@ -428,8 +428,7 @@ def aws_create_report(options):  # noqa: C901
                 if attributes.get("start_date") > month.get("end"):
                     continue
 
-                gen_start_date, gen_end_date = _create_generator_dates_from_yaml(attributes, month)
-
+            gen_start_date, gen_end_date = _create_generator_dates_from_yaml(attributes, month)
             gen = generator_cls(gen_start_date, gen_end_date, payer_account, usage_accounts, attributes)
             num_instances = 1 if attributes else randint(2, 60)
             for _ in range(num_instances):
@@ -539,6 +538,8 @@ def azure_create_report(options):  # noqa: C901
                     continue
                 if attributes.get("start_date") > month.get("end"):
                     continue
+            else:
+                attributes = {"end_date": end_date, "start_date": start_date}
 
                 gen_start_date, gen_end_date = _create_generator_dates_from_yaml(attributes, month)
 

--- a/nise/report.py
+++ b/nise/report.py
@@ -255,6 +255,8 @@ def _create_month_list(start_date, end_date):
                 year=current.year,
                 month=current.month,
                 day=calendar.monthrange(year=current.year, month=current.month)[1],
+                hour=23,
+                minute=59,
             ),
         }
         if current.month == start_date.month:
@@ -428,7 +430,8 @@ def aws_create_report(options):  # noqa: C901
                 if attributes.get("start_date") > month.get("end"):
                     continue
 
-            gen_start_date, gen_end_date = _create_generator_dates_from_yaml(attributes, month)
+                gen_start_date, gen_end_date = _create_generator_dates_from_yaml(attributes, month)
+
             gen = generator_cls(gen_start_date, gen_end_date, payer_account, usage_accounts, attributes)
             num_instances = 1 if attributes else randint(2, 60)
             for _ in range(num_instances):
@@ -541,7 +544,7 @@ def azure_create_report(options):  # noqa: C901
             else:
                 attributes = {"end_date": end_date, "start_date": start_date}
 
-                gen_start_date, gen_end_date = _create_generator_dates_from_yaml(attributes, month)
+            gen_start_date, gen_end_date = _create_generator_dates_from_yaml(attributes, month)
 
             attributes["meter_cache"] = meter_cache
             gen = generator_cls(gen_start_date, gen_end_date, payer_account, usage_accounts, attributes)

--- a/nise/report.py
+++ b/nise/report.py
@@ -264,7 +264,7 @@ def _create_month_list(start_date, end_date):
             month["start"] = start_date
         if current.month == end_date.month:
             # Last month ends with end_date
-            month["end"] = end_date
+            month["end"] = end_date.replace(hour=23, minute=59)
 
         months.append(month)
         current += relativedelta(months=+1)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -28,6 +28,7 @@ from nise.__main__ import _load_yaml_file
 from nise.__main__ import _validate_provider_inputs
 from nise.__main__ import create_parser
 from nise.__main__ import main
+from nise.__main__ import run
 from nise.__main__ import valid_date
 
 
@@ -386,3 +387,14 @@ class CommandLineTestCase(TestCase):
                     mock_args.return_value = parsed_args
                     mock_options.return_value = options
                     self.assertIsNone(main())
+
+    def test_run_for_azure_dates(self):
+        """That that fix_dates corrects the azure end_date."""
+        args = ["report", "azure", "-s", str(date.today().replace(day=1))]
+        parsed_args = self.parser.parse_args(args)
+        options = vars(parsed_args)
+        _, provider_type = _validate_provider_inputs(self.parser, options)
+        self.assertEqual(provider_type, "azure")
+        with patch("nise.__main__.azure_create_report"):
+            run(provider_type, options)
+            self.assertEqual(options.get("end_date").date(), date.today().replace(day=1) + timedelta(days=1))

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -390,11 +390,12 @@ class CommandLineTestCase(TestCase):
 
     def test_run_for_azure_dates(self):
         """That that fix_dates corrects the azure end_date."""
-        args = ["report", "azure", "-s", str(date.today().replace(day=1))]
+        start = date.today().replace(day=1)
+        args = ["report", "azure", "-s", str(start)]
         parsed_args = self.parser.parse_args(args)
         options = vars(parsed_args)
         _, provider_type = _validate_provider_inputs(self.parser, options)
         self.assertEqual(provider_type, "azure")
         with patch("nise.__main__.azure_create_report"):
             run(provider_type, options)
-            self.assertEqual(options.get("end_date").date(), date.today().replace(day=1) + timedelta(days=1))
+            self.assertEqual(options.get("end_date").date(), start + timedelta(days=1))

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -50,20 +50,6 @@ from nise.report import post_payload_to_ingest_service
 fake = faker.Faker()
 
 
-class ReportTestCase(TestCase):
-    def setUp(self):
-        self.expected_month_output_file = None
-
-    def tearDown(self):
-        if self.expected_month_output_file:
-            # cleanup any leftover files
-            regex = re.compile(self.month_output_file_name)
-            for _, _, files in os.walk("."):
-                for fname in files:
-                    if regex.match(fname):
-                        os.remove(fname)
-
-
 class MiscReportTestCase(TestCase):
     """
     TestCase class for report functions
@@ -212,7 +198,7 @@ class MiscReportTestCase(TestCase):
         self.assertNotIn("headers", mock_post.call_args[1])
 
 
-class AWSReportTestCase(ReportTestCase):
+class AWSReportTestCase(TestCase):
     """
     TestCase class for AWS report functions.
     """
@@ -552,7 +538,7 @@ class AWSReportTestCase(ReportTestCase):
         shutil.rmtree(local_bucket_path)
 
 
-class OCPReportTestCase(ReportTestCase):
+class OCPReportTestCase(TestCase):
     """
     TestCase class for OCP report functions.
     """
@@ -884,7 +870,7 @@ class OCPReportTestCase(ReportTestCase):
         shutil.rmtree(local_insights_upload)
 
 
-class AzureReportTestCase(ReportTestCase):
+class AzureReportTestCase(TestCase):
     """
     TestCase class for Azure report functions.
     """
@@ -1028,7 +1014,7 @@ class AzureReportTestCase(ReportTestCase):
         self.assertFalse(os.path.isfile(local_path))
 
 
-class GCPReportTestCase(ReportTestCase):
+class GCPReportTestCase(TestCase):
     """
     Tests for GCP report generation.
     """

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -543,6 +543,12 @@ class AWSReportTestCase(ReportTestCase):
         self.assertTrue(os.path.isfile(expected_month_output_file_1))
         self.assertTrue(os.path.isfile(expected_month_output_file_2))
 
+        # cleanup any leftover files
+        regex = re.compile(self.month_output_file_name)
+        for _, _, files in os.walk("."):
+            for fname in files:
+                if regex.match(fname):
+                    os.remove(fname)
         shutil.rmtree(local_bucket_path)
 
 
@@ -867,6 +873,13 @@ class OCPReportTestCase(ReportTestCase):
 
                 self.assertTrue(os.path.isfile(expected_month_output_file_1))
                 self.assertTrue(os.path.isfile(expected_month_output_file_2))
+
+                # cleanup any leftover files
+                regex = re.compile(self.month_output_file_name)
+                for _, _, files in os.walk("."):
+                    for fname in files:
+                        if regex.match(fname):
+                            os.remove(fname)
 
         shutil.rmtree(local_insights_upload)
 

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -522,15 +522,15 @@ class AWSReportTestCase(TestCase):
             "write_monthly": True,
         }
         aws_create_report(options)
-        self.month_output_file_name = "{}-{}-{}".format(calendar.month_name[now.month], now.year, "cur_report")
-        expected_month_output_file_1 = "{}/{}-1.csv".format(os.getcwd(), self.month_output_file_name)
-        expected_month_output_file_2 = "{}/{}-2.csv".format(os.getcwd(), self.month_output_file_name)
+        month_output_file_name = "{}-{}-{}".format(calendar.month_name[now.month], now.year, "cur_report")
+        expected_month_output_file_1 = "{}/{}-1.csv".format(os.getcwd(), month_output_file_name)
+        expected_month_output_file_2 = "{}/{}-2.csv".format(os.getcwd(), month_output_file_name)
 
         self.assertTrue(os.path.isfile(expected_month_output_file_1))
         self.assertTrue(os.path.isfile(expected_month_output_file_2))
 
         # cleanup any leftover files
-        regex = re.compile(self.month_output_file_name)
+        regex = re.compile(month_output_file_name)
         for _, _, files in os.walk("."):
             for fname in files:
                 if regex.match(fname):
@@ -845,11 +845,11 @@ class OCPReportTestCase(TestCase):
 
         for report_type in OCP_REPORT_TYPE_TO_COLS.keys():
             with self.subTest(report=report_type):
-                self.month_output_file_name = "{}-{}-{}-{}".format(
+                month_output_file_name = "{}-{}-{}-{}".format(
                     calendar.month_name[now.month], now.year, cluster_id, report_type
                 )
-                month_output_file_pt_1 = f"{self.month_output_file_name}-1"
-                month_output_file_pt_2 = f"{self.month_output_file_name}-2"
+                month_output_file_pt_1 = f"{month_output_file_name}-1"
+                month_output_file_pt_2 = f"{month_output_file_name}-2"
 
                 expected_month_output_file_1 = "{}/{}.csv".format(os.getcwd(), month_output_file_pt_1)
                 expected_month_output_file_2 = "{}/{}.csv".format(os.getcwd(), month_output_file_pt_2)
@@ -861,7 +861,7 @@ class OCPReportTestCase(TestCase):
                 self.assertTrue(os.path.isfile(expected_month_output_file_2))
 
                 # cleanup any leftover files
-                regex = re.compile(self.month_output_file_name)
+                regex = re.compile(month_output_file_name)
                 for _, _, files in os.walk("."):
                     for fname in files:
                         if regex.match(fname):


### PR DESCRIPTION
The gist: this PR replaces end_date time with 23 hours and 59 minutes.

Testing:
Ensure that each file produced with these commands contains data.
```
nise report aws -w -s 2020-06-01
nise report aws -w -s 2020-06-01 -e 2020-06-01
nise report aws -w -s 2020-05-31 -e 2020-06-01
nise report aws -w -s 2020-05-31
nise report azure -w -s 2020-06-01
nise report azure -w -s 2020-06-01 -e 2020-06-01
nise report azure -w -s 2020-05-31 -e 2020-06-01
nise report azure -w -s 2020-05-31
nise report ocp --ocp-cluster-id id -w -s 2020-06-01
nise report ocp --ocp-cluster-id id -w -s 2020-06-01 -e 2020-06-01
nise report ocp --ocp-cluster-id id -w -s 2020-05-31 -e 2020-06-01
nise report ocp --ocp-cluster-id id -w -s 2020-05-31
```


Using the same date ranges as above, set the dates in the example yaml files. Use one generator in each yaml.
```
nise report aws -w --static-report-file example_aws_static_data.yml
nise report azure -w --static-report-file example_azure_static_data.yml
nise report ocp -w --ocp-cluster-id cluster-id --static-report-file example_ocp_static_data.yml
```
Ensure all of these produce files containing data.