### PR TITLE
Date fix 2

### DIFF
--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.0.3"
+__version__ = "2.0.4"
 VERSION = __version__.split(".")

--- a/nise/__main__.py
+++ b/nise/__main__.py
@@ -472,7 +472,7 @@ def _load_static_report_data(options):
 
             attributes["start_date"] = str(generated_start_date)
             if options.get("provider") != "azure":
-                generated_end_date.replace(hour=23, minute=59)
+                generated_end_date = generated_end_date.replace(hour=23, minute=59)
             attributes["end_date"] = str(generated_end_date)
 
         options["start_date"] = min(start_dates)

--- a/nise/__main__.py
+++ b/nise/__main__.py
@@ -459,10 +459,8 @@ def _load_static_report_data(options):
 
             if attributes.get("end_date"):
                 generated_end_date = calculate_end_date(generated_start_date, attributes.get("end_date"))
-                if (
-                    options.get("provider") == "azure"
-                    and generated_end_date.day == 1  # noqa: W503
-                    or generated_end_date == generated_start_date  # noqa: W503
+                if options.get("provider") == "azure" and (
+                    generated_end_date.day == 1 or generated_end_date == generated_start_date
                 ):
                     generated_end_date += datetime.timedelta(hours=24)
             else:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -404,18 +404,6 @@ class CommandLineTestCase(TestCase):
 class MainDateTest(TestCase):
     """Functional data testing class."""
 
-    def test_run_for_azure_dates(self):
-        """That that fix_dates corrects the azure end_date."""
-        start = date.today().replace(day=1)
-        args = ["report", "azure", "-s", str(start)]
-        parsed_args = self.parser.parse_args(args)
-        options = vars(parsed_args)
-        _, provider_type = _validate_provider_inputs(self.parser, options)
-        self.assertEqual(provider_type, "azure")
-        with patch("nise.__main__.azure_create_report"):
-            run(provider_type, options)
-            self.assertEqual(options.get("end_date").date(), start + timedelta(days=1))
-
     @patch("nise.__main__._load_yaml_file")
     def test_aws_dates(self, mock_load):
         """Test that select static-data-file dates return correct dates."""

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -399,3 +399,115 @@ class CommandLineTestCase(TestCase):
         with patch("nise.__main__.azure_create_report"):
             run(provider_type, options)
             self.assertEqual(options.get("end_date").date(), start + timedelta(days=1))
+
+
+class MainDateTest(TestCase):
+    """Functional data testing class."""
+
+    @patch("nise.__main__._load_yaml_file")
+    def test_aws_dates(self, mock_load):
+        """Test that select static-data-file dates return correct dates."""
+        aws_gens = [
+            {"aws_gen_first": {"start_date": datetime(2020, 6, 1).date(), "end_date": datetime(2020, 6, 1).date()}},
+            {"aws_gen_first_start": {"start_date": datetime(2020, 6, 1).date()}},
+            {"aws_gen_last": {"start_date": datetime(2020, 5, 31).date(), "end_date": datetime(2020, 5, 31).date()}},
+            {
+                "aws_gen_last_first": {
+                    "start_date": datetime(2020, 5, 31).date(),
+                    "end_date": datetime(2020, 6, 1).date(),
+                }
+            },
+        ]
+        static_report_data = {"generators": aws_gens}
+        expected = {
+            "aws_gen_first": {"start_date": datetime(2020, 6, 1, 0, 0), "end_date": datetime(2020, 6, 1, 23, 59)},
+            "aws_gen_first_start": {
+                "start_date": datetime(2020, 6, 1, 0, 0),
+                "end_date": datetime(2020, 6, 1, 23, 59),
+            },
+            "aws_gen_last": {"start_date": datetime(2020, 5, 31, 0, 0), "end_date": datetime(2020, 5, 31, 23, 59)},
+            "aws_gen_last_first": {
+                "start_date": datetime(2020, 5, 31, 0, 0),
+                "end_date": datetime(2020, 6, 1, 23, 59),
+            },
+        }
+        options = {"provider": "aws", "static_report_file": "fake-file"}
+        mock_load.return_value = static_report_data
+        _load_static_report_data(options)
+        for generator_dict in options.get("static_report_data").get("generators"):
+            for key, attributes in generator_dict.items():
+                with self.subTest(key=key):
+                    self.assertEqual(attributes.get("start_date"), str(expected.get(key).get("start_date")))
+                    self.assertEqual(attributes.get("end_date"), str(expected.get(key).get("end_date")))
+
+    @patch("nise.__main__._load_yaml_file")
+    def test_ocp_dates(self, mock_load):
+        """Test that select static-data-file dates return correct dates."""
+        ocp_gens = [
+            {"ocp_gen_first": {"start_date": datetime(2020, 6, 1).date(), "end_date": datetime(2020, 6, 1).date()}},
+            {"ocp_gen_first_start": {"start_date": datetime(2020, 6, 1).date()}},
+            {"ocp_gen_last": {"start_date": datetime(2020, 5, 31).date(), "end_date": datetime(2020, 5, 31).date()}},
+            {
+                "ocp_gen_last_first": {
+                    "start_date": datetime(2020, 5, 31).date(),
+                    "end_date": datetime(2020, 6, 1).date(),
+                }
+            },
+        ]
+        static_report_data = {"generators": ocp_gens}
+        expected = {
+            "ocp_gen_first": {"start_date": datetime(2020, 6, 1, 0, 0), "end_date": datetime(2020, 6, 1, 23, 59)},
+            "ocp_gen_first_start": {
+                "start_date": datetime(2020, 6, 1, 0, 0),
+                "end_date": datetime(2020, 6, 1, 23, 59),
+            },
+            "ocp_gen_last": {"start_date": datetime(2020, 5, 31, 0, 0), "end_date": datetime(2020, 5, 31, 23, 59)},
+            "ocp_gen_last_first": {
+                "start_date": datetime(2020, 5, 31, 0, 0),
+                "end_date": datetime(2020, 6, 1, 23, 59),
+            },
+        }
+        options = {"provider": "ocp", "static_report_file": "fake-file"}
+        mock_load.return_value = static_report_data
+        _load_static_report_data(options)
+        for generator_dict in options.get("static_report_data").get("generators"):
+            for key, attributes in generator_dict.items():
+                with self.subTest(key=key):
+                    self.assertEqual(attributes.get("start_date"), str(expected.get(key).get("start_date")))
+                    self.assertEqual(attributes.get("end_date"), str(expected.get(key).get("end_date")))
+
+    @patch("nise.__main__._load_yaml_file")
+    def test_azure_dates(self, mock_load):
+        """Test that select static-data-file dates return correct dates."""
+        azure_gens = [
+            {"azure_gen_first": {"start_date": datetime(2020, 6, 1).date(), "end_date": datetime(2020, 6, 1).date()}},
+            {"azure_gen_first_start": {"start_date": datetime(2020, 6, 1).date()}},
+            {"azure_gen_last": {"start_date": datetime(2020, 5, 31).date(), "end_date": datetime(2020, 5, 31).date()}},
+            {
+                "azure_gen_last_first": {
+                    "start_date": datetime(2020, 5, 31).date(),
+                    "end_date": datetime(2020, 6, 1).date(),
+                }
+            },
+        ]
+        static_report_data = {"generators": azure_gens}
+        expected = {
+            "azure_gen_first": {"start_date": datetime(2020, 6, 1, 0, 0), "end_date": datetime(2020, 6, 2, 0, 0)},
+            "azure_gen_first_start": {
+                "start_date": datetime(2020, 6, 1, 0, 0),
+                "end_date": datetime.now().replace(microsecond=0, second=0, minute=0) + timedelta(hours=24),
+            },
+            "azure_gen_last": {"start_date": datetime(2020, 5, 31, 0, 0), "end_date": datetime(2020, 6, 1, 0, 0)},
+            "azure_gen_last_first": {
+                "start_date": datetime(2020, 5, 31, 0, 0),
+                "end_date": datetime(2020, 6, 2, 0, 0),
+            },
+        }
+        options = {"provider": "azure", "static_report_file": "fake-file"}
+        mock_load.return_value = static_report_data
+        _load_static_report_data(options)
+        for generator_dict in options.get("static_report_data").get("generators"):
+            for key, attributes in generator_dict.items():
+                with self.subTest(key=key):
+                    self.assertEqual(attributes.get("start_date"), str(expected.get(key).get("start_date")))
+                    self.assertEqual(attributes.get("end_date"), str(expected.get(key).get("end_date")))

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -423,7 +423,7 @@ class MainDateTest(TestCase):
             "aws_gen_first": {"start_date": datetime(2020, 6, 1, 0, 0), "end_date": datetime(2020, 6, 1, 23, 59)},
             "aws_gen_first_start": {
                 "start_date": datetime(2020, 6, 1, 0, 0),
-                "end_date": datetime(2020, 6, 1, 23, 59),
+                "end_date": datetime.now().replace(hour=23, minute=59, second=0, microsecond=0),
             },
             "aws_gen_last": {"start_date": datetime(2020, 5, 31, 0, 0), "end_date": datetime(2020, 5, 31, 23, 59)},
             "aws_gen_last_first": {
@@ -459,7 +459,7 @@ class MainDateTest(TestCase):
             "ocp_gen_first": {"start_date": datetime(2020, 6, 1, 0, 0), "end_date": datetime(2020, 6, 1, 23, 59)},
             "ocp_gen_first_start": {
                 "start_date": datetime(2020, 6, 1, 0, 0),
-                "end_date": datetime(2020, 6, 1, 23, 59),
+                "end_date": datetime.now().replace(hour=23, minute=59, second=0, microsecond=0),
             },
             "ocp_gen_last": {"start_date": datetime(2020, 5, 31, 0, 0), "end_date": datetime(2020, 5, 31, 23, 59)},
             "ocp_gen_last_first": {

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -404,6 +404,18 @@ class CommandLineTestCase(TestCase):
 class MainDateTest(TestCase):
     """Functional data testing class."""
 
+    def test_run_for_azure_dates(self):
+        """That that fix_dates corrects the azure end_date."""
+        start = date.today().replace(day=1)
+        args = ["report", "azure", "-s", str(start)]
+        parsed_args = self.parser.parse_args(args)
+        options = vars(parsed_args)
+        _, provider_type = _validate_provider_inputs(self.parser, options)
+        self.assertEqual(provider_type, "azure")
+        with patch("nise.__main__.azure_create_report"):
+            run(provider_type, options)
+            self.assertEqual(options.get("end_date").date(), start + timedelta(days=1))
+
     @patch("nise.__main__._load_yaml_file")
     def test_aws_dates(self, mock_load):
         """Test that select static-data-file dates return correct dates."""


### PR DESCRIPTION
Add some critical parenthesis. Add some test cases so that we can understand what static yaml date combination will produce which result.

Testing

use this yaml (save as aws1.yml):
```yaml
---
  generators:
    - EC2Generator:
        start_date: 2020-06-01
        end_date: 2020-06-01
        tags:
          resourceTags/user:environment: dev
          resourceTags/user:version: alpha


  accounts:
    payer: 9999999999999
    user:
      - 9999999999999
```
this command:
`nise report aws -w --static-report-file aws1.yml`

Check the generated file. Make sure the `identity/TimeInterval` column does not have a date range similar to `2020-06-02T22:00:00Z/2020-06-02T23:00:00Z` (note June 2nd in there).
The generated dates should only be in the June 1st range.