### PR TITLE
date fix 3

### DIFF
--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.0.5"
+__version__ = "2.0.6"
 VERSION = __version__.split(".")

--- a/nise/__main__.py
+++ b/nise/__main__.py
@@ -517,7 +517,9 @@ def calculate_end_date(start_date, end_date):
 
 
 def fix_dates(options, provider_type):
-    if provider_type == "azure" and options.get("end_date").day == 1:
+    """Correct any unique dates."""
+    # Azure end_date is always the following day
+    if provider_type == "azure":
         options["end_date"] += relativedelta(days=1)
 
 

--- a/nise/__main__.py
+++ b/nise/__main__.py
@@ -461,15 +461,10 @@ def _load_static_report_data(options):
 
             if attributes.get("end_date"):
                 generated_end_date = calculate_end_date(generated_start_date, attributes.get("end_date"))
-                if options.get("provider") == "azure" and (
-                    generated_end_date.day == 1 or generated_end_date == generated_start_date
-                ):
-                    generated_end_date += datetime.timedelta(hours=24)
             else:
-                if options.get("provider") == "azure":
-                    generated_end_date = today() + datetime.timedelta(hours=24)
-                else:
-                    generated_end_date = today()
+                generated_end_date = today()
+            if options.get("provider") == "azure":
+                generated_end_date += datetime.timedelta(hours=24)
             end_dates.append(generated_end_date)
 
             attributes["start_date"] = str(generated_start_date)

--- a/nise/__main__.py
+++ b/nise/__main__.py
@@ -465,11 +465,11 @@ def _load_static_report_data(options):
                 generated_end_date = today()
             if options.get("provider") == "azure":
                 generated_end_date += datetime.timedelta(hours=24)
+            else:
+                generated_end_date = generated_end_date.replace(hour=23, minute=59)
             end_dates.append(generated_end_date)
 
             attributes["start_date"] = str(generated_start_date)
-            if options.get("provider") != "azure":
-                generated_end_date = generated_end_date.replace(hour=23, minute=59)
             attributes["end_date"] = str(generated_end_date)
 
         options["start_date"] = min(start_dates)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -388,10 +388,23 @@ class CommandLineTestCase(TestCase):
                     mock_options.return_value = options
                     self.assertIsNone(main())
 
-    def test_run_for_azure_dates(self):
+    def test_run_for_azure_startdates(self):
         """That that fix_dates corrects the azure end_date."""
         start = date.today().replace(day=1)
         args = ["report", "azure", "-s", str(start)]
+        parsed_args = self.parser.parse_args(args)
+        options = vars(parsed_args)
+        _, provider_type = _validate_provider_inputs(self.parser, options)
+        self.assertEqual(provider_type, "azure")
+        with patch("nise.__main__.azure_create_report"):
+            run(provider_type, options)
+            self.assertEqual(options.get("end_date").date(), start + timedelta(days=1))
+
+    def test_run_for_azure_enddates(self):
+        """That that fix_dates corrects the azure end_date."""
+        start = date.today().replace(day=1)
+        end = date.today().replace(day=1)
+        args = ["report", "azure", "-s", str(start), "-e", str(end)]
         parsed_args = self.parser.parse_args(args)
         options = vars(parsed_args)
         _, provider_type = _validate_provider_inputs(self.parser, options)
@@ -409,6 +422,12 @@ class MainDateTest(TestCase):
         """Test that select static-data-file dates return correct dates."""
         aws_gens = [
             {"aws_gen_first": {"start_date": datetime(2020, 6, 1).date(), "end_date": datetime(2020, 6, 1).date()}},
+            {
+                "aws_gen_first_second": {
+                    "start_date": datetime(2020, 6, 1).date(),
+                    "end_date": datetime(2020, 6, 2).date(),
+                }
+            },
             {"aws_gen_first_start": {"start_date": datetime(2020, 6, 1).date()}},
             {"aws_gen_last": {"start_date": datetime(2020, 5, 31).date(), "end_date": datetime(2020, 5, 31).date()}},
             {
@@ -421,6 +440,10 @@ class MainDateTest(TestCase):
         static_report_data = {"generators": aws_gens}
         expected = {
             "aws_gen_first": {"start_date": datetime(2020, 6, 1, 0, 0), "end_date": datetime(2020, 6, 1, 23, 59)},
+            "aws_gen_first_second": {
+                "start_date": datetime(2020, 6, 1, 0, 0),
+                "end_date": datetime(2020, 6, 2, 23, 59),
+            },
             "aws_gen_first_start": {
                 "start_date": datetime(2020, 6, 1, 0, 0),
                 "end_date": datetime.now().replace(hour=23, minute=59, second=0, microsecond=0),
@@ -445,6 +468,12 @@ class MainDateTest(TestCase):
         """Test that select static-data-file dates return correct dates."""
         ocp_gens = [
             {"ocp_gen_first": {"start_date": datetime(2020, 6, 1).date(), "end_date": datetime(2020, 6, 1).date()}},
+            {
+                "ocp_gen_first_second": {
+                    "start_date": datetime(2020, 6, 1).date(),
+                    "end_date": datetime(2020, 6, 2).date(),
+                }
+            },
             {"ocp_gen_first_start": {"start_date": datetime(2020, 6, 1).date()}},
             {"ocp_gen_last": {"start_date": datetime(2020, 5, 31).date(), "end_date": datetime(2020, 5, 31).date()}},
             {
@@ -457,6 +486,10 @@ class MainDateTest(TestCase):
         static_report_data = {"generators": ocp_gens}
         expected = {
             "ocp_gen_first": {"start_date": datetime(2020, 6, 1, 0, 0), "end_date": datetime(2020, 6, 1, 23, 59)},
+            "ocp_gen_first_second": {
+                "start_date": datetime(2020, 6, 1, 0, 0),
+                "end_date": datetime(2020, 6, 2, 23, 59),
+            },
             "ocp_gen_first_start": {
                 "start_date": datetime(2020, 6, 1, 0, 0),
                 "end_date": datetime.now().replace(hour=23, minute=59, second=0, microsecond=0),
@@ -481,6 +514,12 @@ class MainDateTest(TestCase):
         """Test that select static-data-file dates return correct dates."""
         azure_gens = [
             {"azure_gen_first": {"start_date": datetime(2020, 6, 1).date(), "end_date": datetime(2020, 6, 1).date()}},
+            {
+                "azure_gen_first_second": {
+                    "start_date": datetime(2020, 6, 1).date(),
+                    "end_date": datetime(2020, 6, 2).date(),
+                }
+            },
             {"azure_gen_first_start": {"start_date": datetime(2020, 6, 1).date()}},
             {"azure_gen_last": {"start_date": datetime(2020, 5, 31).date(), "end_date": datetime(2020, 5, 31).date()}},
             {
@@ -493,6 +532,10 @@ class MainDateTest(TestCase):
         static_report_data = {"generators": azure_gens}
         expected = {
             "azure_gen_first": {"start_date": datetime(2020, 6, 1, 0, 0), "end_date": datetime(2020, 6, 2, 0, 0)},
+            "azure_gen_first_second": {
+                "start_date": datetime(2020, 6, 1, 0, 0),
+                "end_date": datetime(2020, 6, 3, 0, 0),
+            },
             "azure_gen_first_start": {
                 "start_date": datetime(2020, 6, 1, 0, 0),
                 "end_date": datetime.now().replace(microsecond=0, second=0, minute=0) + timedelta(hours=24),

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -398,7 +398,7 @@ class CommandLineTestCase(TestCase):
         self.assertEqual(provider_type, "azure")
         with patch("nise.__main__.azure_create_report"):
             run(provider_type, options)
-            self.assertEqual(options.get("end_date").date(), start + timedelta(days=1))
+            self.assertEqual(options.get("end_date").date(), date.today() + timedelta(days=1))
 
     def test_run_for_azure_enddates(self):
         """That that fix_dates corrects the azure end_date."""
@@ -411,7 +411,7 @@ class CommandLineTestCase(TestCase):
         self.assertEqual(provider_type, "azure")
         with patch("nise.__main__.azure_create_report"):
             run(provider_type, options)
-            self.assertEqual(options.get("end_date").date(), start + timedelta(days=1))
+            self.assertEqual(options.get("end_date").date(), end + timedelta(days=1))
 
 
 class MainDateTest(TestCase):


### PR DESCRIPTION
Testing:
Date combos (start/end):
1. 2020-05-31 / 2020-05-31
2. 2020-05-31 / 2020-06-01
3. 2020-05-31 / 2020-06-02
4. 2020-06-01 / 2020-06-01
5. 2020-06-01 / 2020-06-02

Try a simple yml for each provider with all of those date combos. Expected results:

AWS/OCP - for May results, should not see June dates anywhere. End date times are 23:59. Should not see any June dates in the May files. Should not see any end dates on the following day (e.g. should not see 06-02 if the yaml specifies end_date: 06-01).
Azure - for May results, should see end date of June 1. Combo 1 above will generate a file for June, but it will be empty. All the others, the end date should be on the following day as specified in the yaml (e.g. should see 06-02 if end_date: 06-01).