### PR TITLE
enable custom aws tags in static yamls

### DIFF
--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.0.6"
+__version__ = "2.0.7"
 VERSION = __version__.split(".")

--- a/nise/__main__.py
+++ b/nise/__main__.py
@@ -446,6 +446,7 @@ def _load_yaml_file(filename):
 
 
 def get_aws_tags(options):
+    """Parse all tag keys from AWS generators."""
     tags = set()
     for generator_dict in options.get("static_report_data").get("generators"):
         for _, attributes in generator_dict.items():

--- a/nise/__main__.py
+++ b/nise/__main__.py
@@ -445,6 +445,14 @@ def _load_yaml_file(filename):
     return yamlfile
 
 
+def get_aws_tags(options):
+    tags = set()
+    for generator_dict in options.get("static_report_data").get("generators"):
+        for _, attributes in generator_dict.items():
+            tags.update(attributes.get("tags", {}).keys())
+    options["aws_tags"] = tags
+
+
 def _load_static_report_data(options):
     """Validate/load and set start_date if static file is provided."""
     if not options.get("static_report_file"):
@@ -472,11 +480,14 @@ def _load_static_report_data(options):
             attributes["start_date"] = str(generated_start_date)
             attributes["end_date"] = str(generated_end_date)
 
-        options["start_date"] = min(start_dates)
-        latest_date = max(end_dates)
-        last_day_of_month = calendar.monthrange(year=latest_date.year, month=latest_date.month)[1]
-        options["end_date"] = latest_date.replace(day=last_day_of_month, hour=0, minute=0)
-        options["static_report_data"] = static_report_data
+    options["start_date"] = min(start_dates)
+    latest_date = max(end_dates)
+    last_day_of_month = calendar.monthrange(year=latest_date.year, month=latest_date.month)[1]
+    options["end_date"] = latest_date.replace(day=last_day_of_month, hour=0, minute=0)
+    options["static_report_data"] = static_report_data
+    if options.get("provider") == "aws":
+        get_aws_tags(options)
+
     return True
 
 

--- a/nise/generators/aws/__init__.py
+++ b/nise/generators/aws/__init__.py
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 """Module for aws data generators."""
-from nise.generators.aws.aws_generator import AWS_COLUMNS  # noqa: F401
 from nise.generators.aws.aws_generator import AWSGenerator  # noqa: F401
 from nise.generators.aws.data_transfer_generator import DataTransferGenerator  # noqa: F401
 from nise.generators.aws.ebs_generator import EBSGenerator  # noqa: F401

--- a/nise/generators/aws/data_transfer_generator.py
+++ b/nise/generators/aws/data_transfer_generator.py
@@ -29,9 +29,9 @@ class DataTransferGenerator(AWSGenerator):
         ("{}-{}-AWS-Out-Bytes", "PublicIP-Out", "InterRegion Outbound"),
     )
 
-    def __init__(self, start_date, end_date, payer_account, usage_accounts, attributes=None):
+    def __init__(self, start_date, end_date, payer_account, usage_accounts, attributes=None, tag_cols=None):
         """Initialize the data transfer generator."""
-        super().__init__(start_date, end_date, payer_account, usage_accounts, attributes)
+        super().__init__(start_date, end_date, payer_account, usage_accounts, attributes, tag_cols)
         self._amount = None
         self._rate = None
         self._product_sku = None

--- a/nise/generators/aws/ebs_generator.py
+++ b/nise/generators/aws/ebs_generator.py
@@ -29,9 +29,9 @@ class EBSGenerator(AWSGenerator):
         ("3000 for volumes <= 1 TiB", "10000", "160 MB/sec", "16 TiB", "SSD-backed", "General Purpose"),
     )
 
-    def __init__(self, start_date, end_date, payer_account, usage_accounts, attributes=None):
+    def __init__(self, start_date, end_date, payer_account, usage_accounts, attributes=None, tag_cols=None):
         """Initialize the EBS generator."""
-        super().__init__(start_date, end_date, payer_account, usage_accounts, attributes)
+        super().__init__(start_date, end_date, payer_account, usage_accounts, attributes, tag_cols)
         self._resource_id = "vol-{}".format(self.fake.ean8())
         self._amount = uniform(0.2, 300.99)
         self._rate = round(uniform(0.02, 0.16), 3)

--- a/nise/generators/aws/ec2_generator.py
+++ b/nise/generators/aws/ec2_generator.py
@@ -68,9 +68,9 @@ class EC2Generator(AWSGenerator):
 
     ARCHS = ("32-bit", "64-bit")
 
-    def __init__(self, start_date, end_date, payer_account, usage_accounts, attributes=None):
+    def __init__(self, start_date, end_date, payer_account, usage_accounts, attributes=None, tag_cols=None):
         """Initialize the EC2 generator."""
-        super().__init__(start_date, end_date, payer_account, usage_accounts, attributes)
+        super().__init__(start_date, end_date, payer_account, usage_accounts, attributes, tag_cols)
         self._processor_arch = choice(self.ARCHS)
         self._resource_id = "i-{}".format(self.fake.ean8())
         self._product_sku = self.fake.pystr(min_chars=12, max_chars=12).upper()

--- a/nise/generators/aws/rds_generator.py
+++ b/nise/generators/aws/rds_generator.py
@@ -68,9 +68,9 @@ class RDSGenerator(AWSGenerator):
 
     ARCHS = ("32-bit", "64-bit")
 
-    def __init__(self, start_date, end_date, payer_account, usage_accounts, attributes=None):
+    def __init__(self, start_date, end_date, payer_account, usage_accounts, attributes=None, tag_cols=None):
         """Initialize the RDS generator."""
-        super().__init__(start_date, end_date, payer_account, usage_accounts, attributes)
+        super().__init__(start_date, end_date, payer_account, usage_accounts, attributes, tag_cols)
         self._processor_arch = choice(self.ARCHS)
         self._product_sku = self.fake.pystr(min_chars=12, max_chars=12).upper()
         self._instance_type = choice(self.INSTANCE_TYPES)

--- a/nise/generators/aws/route53_generatory.py
+++ b/nise/generators/aws/route53_generatory.py
@@ -29,9 +29,9 @@ ROUTE_53_PRODUCTS = list(ROUTE_53_PRODUCTS_DICT.values())
 class Route53Generator(AWSGenerator):
     """Generator for Route53 data."""
 
-    def __init__(self, start_date, end_date, payer_account, usage_accounts, attributes=None):
+    def __init__(self, start_date, end_date, payer_account, usage_accounts, attributes=None, tag_cols=None):
         """Initialize the Route53 generator."""
-        super().__init__(start_date, end_date, payer_account, usage_accounts, attributes)
+        super().__init__(start_date, end_date, payer_account, usage_accounts, attributes, tag_cols)
         self._product_sku = self.fake.pystr(min_chars=12, max_chars=12).upper()
         self._product_family = None
         self._resource_id = self.fake.ean8()

--- a/nise/generators/aws/s3_generator.py
+++ b/nise/generators/aws/s3_generator.py
@@ -23,9 +23,9 @@ from nise.generators.aws.aws_generator import AWSGenerator
 class S3Generator(AWSGenerator):
     """Generator for S3 data."""
 
-    def __init__(self, start_date, end_date, payer_account, usage_accounts, attributes=None):
+    def __init__(self, start_date, end_date, payer_account, usage_accounts, attributes=None, tag_cols=None):
         """Initialize the S3 generator."""
-        super().__init__(start_date, end_date, payer_account, usage_accounts, attributes)
+        super().__init__(start_date, end_date, payer_account, usage_accounts, attributes, tag_cols)
         self._amount = uniform(0.2, 6000.99)
         self._rate = round(uniform(0.02, 0.06), 3)
         self._product_sku = self.fake.pystr(min_chars=12, max_chars=12).upper()

--- a/nise/generators/aws/vpc_generator.py
+++ b/nise/generators/aws/vpc_generator.py
@@ -21,9 +21,9 @@ from nise.generators.aws.aws_generator import AWSGenerator
 class VPCGenerator(AWSGenerator):
     """Generator for VPC data."""
 
-    def __init__(self, start_date, end_date, payer_account, usage_accounts, attributes=None):
+    def __init__(self, start_date, end_date, payer_account, usage_accounts, attributes=None, tag_cols=None):
         """Initialize the VPC generator."""
-        super().__init__(start_date, end_date, payer_account, usage_accounts, attributes)
+        super().__init__(start_date, end_date, payer_account, usage_accounts, attributes, tag_cols)
         self._resource_id = "vpn-{}".format(self.fake.ean8())
         self._product_sku = self.fake.pystr(min_chars=12, max_chars=12).upper()
         if self.attributes:

--- a/tests/test_aws_generator.py
+++ b/tests/test_aws_generator.py
@@ -200,6 +200,15 @@ class AWSGeneratorTestCase(TestCase):
         }
         self.two_hours_ago = (self.now - self.one_hour) - self.one_hour
 
+    def test_tag_cols(self):
+        """Test new tag gets assigned to AWS_COLUMNS."""
+        key = "resourceTags/user:new-key"
+        tag_cols = {key}
+        two_hours_ago = (self.now - self.one_hour) - self.one_hour
+        generator = TestGenerator(two_hours_ago, self.now, self.payer_account, self.usage_accounts, tag_cols=tag_cols)
+        self.assertIn(key, generator.AWS_COLUMNS)
+        self.assertNotIn("key-that-has-not-been-added", generator.AWS_COLUMNS)
+
 
 class TestRDSGenerator(AWSGeneratorTestCase):
     """Tests for the RDS Generator type."""

--- a/tests/test_aws_generator.py
+++ b/tests/test_aws_generator.py
@@ -19,7 +19,6 @@ from datetime import timedelta
 from unittest import TestCase
 
 from faker import Faker
-from nise.generators.aws import AWS_COLUMNS
 from nise.generators.aws import AWSGenerator
 from nise.generators.aws import DataTransferGenerator
 from nise.generators.aws import EBSGenerator
@@ -108,7 +107,7 @@ class AbstractGeneratorTestCase(TestCase):
         generator = TestGenerator(two_hours_ago, self.now, self.payer_account, self.usage_accounts)
         a_row = generator._init_data_row(two_hours_ago, self.now)
         self.assertIsInstance(a_row, dict)
-        for col in AWS_COLUMNS:
+        for col in generator.AWS_COLUMNS:
             self.assertIsNotNone(a_row.get(col))
 
     def test_init_data_row_start_none(self):


### PR DESCRIPTION
This PR allows for custom tags in the aws static yaml files.

When loading the yaml, we parse all the tag keys from each generator and put them into a set of tag keys. I made the AWS_COLUMNS a set and moved them into a class attribute. When instantiating a generator, the tag keys are added to the AWS_COLUMNS which can then be written to the csv files. The csv file now has a different order, but all the same information is there.

Testing:

1. Save as aws1.yml.
```yml
---
  generators:
    - EC2Generator:
        start_date: 2020-05-01
        processor_arch: 32-bit
        resource_id: 55555555
        product_sku: VEAJHRNKTJZQ
        region: us-east-1a
        tags:
          resourceTags/user:chicken: nuggets
          resourceTags/user:version: alpha

  accounts:
    payer: 9999999999999
    user:
      - 9999999999999

```
2. Run this command: 
```
nise report aws -w --static-report-file aws1.yml --aws-s3-bucket-name /path/to/koku/testing/local_providers/aws_local --aws-s3-report-name name
```
3. Create local source in koku:
```json
{
    "name": "ProviderAWS-chicken",
    "source_type": "AWS-local",
    "authentication": {
        "resource_name": "arn:aws:iam::111111111111:role/LocalOne"
    },
    "billing_source": {
        "bucket": "/tmp/local_bucket"
    }
}
```
4. Ingest data.
5. Check /tags/aws/ endpoint. See chicken:nuggets.

```
GET /api/cost-management/v1/tags/aws/
HTTP 200 OK
Allow: GET, HEAD, OPTIONS
Content-Type: application/json
Vary: HTTP_X_RH_IDENTITY, Accept

{
    "meta": {
        "count": 2,
        "key_only": false,
        "filter": {
            "time_scope_value": "-10",
            "time_scope_units": "day",
            "resolution": "daily"
        },
        "group_by": {},
        "order_by": {}
    },
    "links": {
        "first": "/api/cost-management/v1/tags/aws/?limit=100&offset=0",
        "next": null,
        "previous": null,
        "last": "/api/cost-management/v1/tags/aws/?limit=100&offset=0"
    },
    "data": [
        {
            "key": "version",
            "values": [
                "alpha"
            ]
        },
        {
            "key": "chicken",
            "values": [
                "nuggets"
            ]
        }
    ]
}
```


