### PR TITLE
date fix 4

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -12,7 +12,9 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Set up Python 3.6
         uses: actions/setup-python@v1
         with:

--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.0.10"
+__version__ = "2.0.11"
 VERSION = __version__.split(".")

--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.0.11"
+__version__ = "2.0.12"
 VERSION = __version__.split(".")

--- a/nise/__main__.py
+++ b/nise/__main__.py
@@ -520,6 +520,8 @@ def calculate_end_date(start_date, end_date):
             generated_end_date = offset_date
         else:
             generated_end_date = min(start_date + relativedelta(days=offset), today())
+    if generated_end_date < start_date:
+        raise ValueError("Static yaml error: End date must be after start date.")
     return generated_end_date
 
 

--- a/nise/__main__.py
+++ b/nise/__main__.py
@@ -456,9 +456,8 @@ def _load_static_report_data(options):
     static_report_data = load_yaml_file(options.get("static_report_file"))
     for generator_dict in static_report_data.get("generators"):
         for _, attributes in generator_dict.items():
-            if attributes.get("start_date"):
-                generated_start_date = calculate_start_date(attributes.get("start_date"))
-                start_dates.append(generated_start_date)
+            generated_start_date = calculate_start_date(attributes.get("start_date"))
+            start_dates.append(generated_start_date)
 
             if attributes.get("end_date"):
                 generated_end_date = calculate_end_date(generated_start_date, attributes.get("end_date"))

--- a/tests/aws_static_report.yml
+++ b/tests/aws_static_report.yml
@@ -34,12 +34,6 @@ generators:
       amount: 10
       rate: 3
       resource_id: 12345678
-  - DataTransferGenerator:
-      start_date: '8'
-      end_date: '08-01-2018'
-      product_sku: VEAJHRNCCCCC
-      amount: 10
-      rate: 3
 
 finalized_report:
   invoice_id: 123456789


### PR DESCRIPTION
- fix for
```
UnboundLocalError: local variable 'generated_start_date' referenced before assignment
```
which is caused when a start_date is not defined in the static yaml file. The `calculate_start_date` function handles a `None` argument, so there is no reason to check if the start_date is defined before calling the function.

- Validate that the generated end-date falls after the start date in `calculate_end_date`.

- This PR also fixes the publish workflow. The tag information was not being checked out so the workflow was trying to publish even if the version had not been updated.

Testing:
1. Generate a yaml:
```
nise yaml ocp -o ocp.yml
```
2. Open the yaml, and remove the start_date.
3. Generate data:
```
nise report ocp --ocp-cluster-id my-ocp-cluster --static-report-file ocp.yml
```
4. See sucess.
5. Open the yaml, and change the end_date to some date in the previous month (e.g. 2020-05-31)
6. Try generating data again:
```
nise report ocp --ocp-cluster-id my-ocp-cluster --static-report-file ocp.yml
```
7. See error:
```
ValueError: Static yaml error: End date must be after start date.
```