### PR TITLE
Negative storage capacity

### DIFF
--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.0.10"
+__version__ = "2.0.11"
 VERSION = __version__.split(".")


### PR DESCRIPTION
Fix negative capacity in the `storage_usage` files.

Testing:
1. Create large yaml: 
```
nise yaml ocp -o large.yml -c default -r
```
2. Use yaml to create cost and usage reports:
```
nise report ocp --ocp-cluster-id my-ocp-cluster --static-report-file large.yml -w
```
3. Look in any of the `storage_usage` files and see that none of `persistentvolumeclaim_capacity_bytes`, `persistentvolumeclaim_capacity_byte_seconds`, `volume_request_storage_byte_seconds`, or `persistentvolumeclaim_usage_byte_seconds` are negative