### PR TITLE
COST-224: Refactor OCPGenerator to use a base jinja template

### DIFF
--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.0.13"
+__version__ = "2.1.0"
 VERSION = __version__.split(".")

--- a/nise/generators/aws/aws_generator.py
+++ b/nise/generators/aws/aws_generator.py
@@ -231,8 +231,17 @@ class AWSGenerator(AbstractGenerator):
         ("AWS GovCloud (US)", "us-gov-west-1", "us-gov-west-1a", "USGW1-EBS"),
     )
 
-    def __init__(self, start_date, end_date, payer_account, usage_accounts, attributes=None, tag_cols=None):
+    TEMPLATE = "nise/generators/aws/generator.j2"
+
+    # Not yet implemented.
+    TEMPLATE_KWARGS = {"NotImplemented": True}
+
+    def __init__(
+        self, start_date, end_date, payer_account, usage_accounts, attributes=None, tag_cols=None, user_config=None
+    ):
         """Initialize the generator."""
+        super().__init__(start_date, end_date, user_config=user_config)
+
         self.payer_account = payer_account
         self.usage_accounts = usage_accounts
         self.attributes = attributes
@@ -241,7 +250,6 @@ class AWSGenerator(AbstractGenerator):
         if tag_cols:
             self.RESOURCE_TAG_COLS.update(tag_cols)
             self.AWS_COLUMNS.update(tag_cols)
-        super().__init__(start_date, end_date)
 
     @staticmethod
     def timestamp(in_date):

--- a/nise/generators/aws/data_transfer_generator.py
+++ b/nise/generators/aws/data_transfer_generator.py
@@ -29,9 +29,14 @@ class DataTransferGenerator(AWSGenerator):
         ("{}-{}-AWS-Out-Bytes", "PublicIP-Out", "InterRegion Outbound"),
     )
 
-    def __init__(self, start_date, end_date, payer_account, usage_accounts, attributes=None, tag_cols=None):
+    def __init__(
+        self, start_date, end_date, payer_account, usage_accounts, attributes=None, tag_cols=None, user_config=None
+    ):
         """Initialize the data transfer generator."""
-        super().__init__(start_date, end_date, payer_account, usage_accounts, attributes, tag_cols)
+        super().__init__(
+            start_date, end_date, payer_account, usage_accounts, attributes, tag_cols, user_config=user_config
+        )
+
         self._amount = None
         self._rate = None
         self._product_sku = None

--- a/nise/generators/aws/ebs_generator.py
+++ b/nise/generators/aws/ebs_generator.py
@@ -29,9 +29,14 @@ class EBSGenerator(AWSGenerator):
         ("3000 for volumes <= 1 TiB", "10000", "160 MB/sec", "16 TiB", "SSD-backed", "General Purpose"),
     )
 
-    def __init__(self, start_date, end_date, payer_account, usage_accounts, attributes=None, tag_cols=None):
+    def __init__(
+        self, start_date, end_date, payer_account, usage_accounts, attributes=None, tag_cols=None, user_config=None
+    ):
         """Initialize the EBS generator."""
-        super().__init__(start_date, end_date, payer_account, usage_accounts, attributes, tag_cols)
+        super().__init__(
+            start_date, end_date, payer_account, usage_accounts, attributes, tag_cols, user_config=user_config
+        )
+
         self._resource_id = "vol-{}".format(self.fake.ean8())
         self._amount = uniform(0.2, 300.99)
         self._rate = round(uniform(0.02, 0.16), 3)

--- a/nise/generators/aws/ec2_generator.py
+++ b/nise/generators/aws/ec2_generator.py
@@ -68,9 +68,14 @@ class EC2Generator(AWSGenerator):
 
     ARCHS = ("32-bit", "64-bit")
 
-    def __init__(self, start_date, end_date, payer_account, usage_accounts, attributes=None, tag_cols=None):
+    def __init__(
+        self, start_date, end_date, payer_account, usage_accounts, attributes=None, tag_cols=None, user_config=None
+    ):
         """Initialize the EC2 generator."""
-        super().__init__(start_date, end_date, payer_account, usage_accounts, attributes, tag_cols)
+        super().__init__(
+            start_date, end_date, payer_account, usage_accounts, attributes, tag_cols, user_config=user_config
+        )
+
         self._processor_arch = choice(self.ARCHS)
         self._resource_id = "i-{}".format(self.fake.ean8())
         self._product_sku = self.fake.pystr(min_chars=12, max_chars=12).upper()

--- a/nise/generators/aws/generator.j2
+++ b/nise/generators/aws/generator.j2
@@ -1,0 +1,90 @@
+---
+generators:
+{% for dtg in data_transfer_gens %}  - DataTransferGenerator:
+      start_date: {{ dtg.start_date }}
+      end_date: {{ dtg.end_date }}
+      resource_id: {{ dtg.resource_id }}
+      product_sku: {{ dtg.product_sku }}
+      amount: {{ dtg.amount }}
+      rate: {{ dtg.rate }}
+      tags:{% for tag in dtg.tags %}
+        {{ tag.key }}: {{ tag.value }}{% endfor %}
+{% endfor %}
+{% for ebs in ebs_gens %}  - EBSGenerator:
+      start_date: {{ ebs.start_date }}
+      end_date: {{ ebs.end_date }}
+      resource_id: {{ ebs.resource_id }}
+      product_sku: {{ ebs.product_sku }}
+      amount: {{ ebs.amount }}
+      rate: {{ ebs.rate }}
+      tags:{% for tag in ebs.tags %}
+        {{ tag.key }}: {{ tag.value }}{% endfor %}
+{% endfor %}
+{% for ec2 in ec2_gens %}  - EC2Generator:
+      start_date: {{  ec2.start_date }}
+      end_date: {{  ec2.end_date }}
+      resource_id: {{  ec2.resource_id }}
+      product_sku: {{ ec2.product_sku }}
+      region: {{ ec2.region }}
+      processor_arch: {{  ec2.processor_arch }}
+      instance_type:
+        inst_type: {{ ec2.instance_type.inst_type }}
+        vcpu: {{ ec2.instance_type.vcpu }}
+        memory: {{ ec2.instance_type.memory }}
+        storage: {{ ec2.instance_type.storage }}
+        family: {{ ec2.instance_type.family }}
+        cost: {{ ec2.instance_type.cost }}
+        rate: {{ ec2.instance_type.rate }}
+      tags:{% for tag in ec2.tags %}
+        {{ tag.key }}: {{ tag.value }}{% endfor %}
+{% endfor %}
+{% for rds in rds_gens %}  - RDSGenerator:
+      start_date: {{ rds.start_date }}
+      end_date: {{ rds.end_date }}
+      resource_id: {{ rds.resource_id }}
+      product_sku: {{ rds.product_sku }}
+      region: {{ rds.region }}
+      processor_arch: {{ rds.processor_arch }}
+      instance_type:
+        inst_type: {{ rds.instance_type.inst_type }}
+        vcpu: {{ rds.instance_type.vcpu }}
+        memory: {{ rds.instance_type.memory }}
+        storage: {{ rds.instance_type.storage }}
+        family: {{ rds.instance_type.family }}
+        cost: {{ rds.instance_type.cost }}
+        rate: {{ rds.instance_type.rate }}
+      tags:{% for tag in rds.tags %}
+        {{ tag.key }}: {{ tag.value }}{% endfor %}
+{% endfor %}
+{% for r53 in route53_gens %}  - Route53Generator:
+      start_date: {{ r53.start_date }}
+      end_date: {{ r53.end_date }}
+      resource_id: {{ r53.resource_id }}
+      product_sku: {{ r53.product_sku }}
+      product_family: {{ r53.product_family }}
+      tags:{% for tag in r53.tags %}
+        {{ tag.key }}: {{ tag.value }}{% endfor %}
+{% endfor %}
+{% for s3 in s3_gens %}  - S3Generator:
+      start_date: {{ s3.start_date }}
+      end_date: {{ s3.end_date }}
+      resource_id: {{ s3.resource_id }}
+      product_sku: {{ s3.product_sku }}
+      amount: {{ s3.amount }}
+      rate: {{ s3.rate }}
+      tags:{% for tag in s3.tags %}
+        {{ tag.key }}: {{ tag.value }}{% endfor %}
+{% endfor %}
+{% for vpc in vpc_gens %}  - VPCGenerator:
+      start_date: {{ vpc.start_date }}
+      end_date: {{ vpc.end_date }}
+      resource_id: {{ vpc.resource_id }}
+      product_sku: {{ vpc.product_sku }}
+      tags:{% for tag in vpc.tags %}
+        {{ tag.key }}: {{ tag.value }}{% endfor %}
+{% endfor %}
+
+accounts:
+  payer: {{ payer }}
+  user:{% for user in users %}
+    - {{ user }}{% endfor %}

--- a/nise/generators/aws/rds_generator.py
+++ b/nise/generators/aws/rds_generator.py
@@ -68,9 +68,14 @@ class RDSGenerator(AWSGenerator):
 
     ARCHS = ("32-bit", "64-bit")
 
-    def __init__(self, start_date, end_date, payer_account, usage_accounts, attributes=None, tag_cols=None):
+    def __init__(
+        self, start_date, end_date, payer_account, usage_accounts, attributes=None, tag_cols=None, user_config=None
+    ):
         """Initialize the RDS generator."""
-        super().__init__(start_date, end_date, payer_account, usage_accounts, attributes, tag_cols)
+        super().__init__(
+            start_date, end_date, payer_account, usage_accounts, attributes, tag_cols, user_config=user_config
+        )
+
         self._processor_arch = choice(self.ARCHS)
         self._product_sku = self.fake.pystr(min_chars=12, max_chars=12).upper()
         self._instance_type = choice(self.INSTANCE_TYPES)

--- a/nise/generators/aws/route53_generator.py
+++ b/nise/generators/aws/route53_generator.py
@@ -29,9 +29,14 @@ ROUTE_53_PRODUCTS = list(ROUTE_53_PRODUCTS_DICT.values())
 class Route53Generator(AWSGenerator):
     """Generator for Route53 data."""
 
-    def __init__(self, start_date, end_date, payer_account, usage_accounts, attributes=None, tag_cols=None):
+    def __init__(
+        self, start_date, end_date, payer_account, usage_accounts, attributes=None, tag_cols=None, user_config=None
+    ):
         """Initialize the Route53 generator."""
-        super().__init__(start_date, end_date, payer_account, usage_accounts, attributes, tag_cols)
+        super().__init__(
+            start_date, end_date, payer_account, usage_accounts, attributes, tag_cols, user_config=user_config
+        )
+
         self._product_sku = self.fake.pystr(min_chars=12, max_chars=12).upper()
         self._product_family = None
         self._resource_id = self.fake.ean8()

--- a/nise/generators/aws/s3_generator.py
+++ b/nise/generators/aws/s3_generator.py
@@ -23,9 +23,14 @@ from nise.generators.aws.aws_generator import AWSGenerator
 class S3Generator(AWSGenerator):
     """Generator for S3 data."""
 
-    def __init__(self, start_date, end_date, payer_account, usage_accounts, attributes=None, tag_cols=None):
+    def __init__(
+        self, start_date, end_date, payer_account, usage_accounts, attributes=None, tag_cols=None, user_config=None
+    ):
         """Initialize the S3 generator."""
-        super().__init__(start_date, end_date, payer_account, usage_accounts, attributes, tag_cols)
+        super().__init__(
+            start_date, end_date, payer_account, usage_accounts, attributes, tag_cols, user_config=user_config
+        )
+
         self._amount = uniform(0.2, 6000.99)
         self._rate = round(uniform(0.02, 0.06), 3)
         self._product_sku = self.fake.pystr(min_chars=12, max_chars=12).upper()

--- a/nise/generators/aws/vpc_generator.py
+++ b/nise/generators/aws/vpc_generator.py
@@ -21,9 +21,14 @@ from nise.generators.aws.aws_generator import AWSGenerator
 class VPCGenerator(AWSGenerator):
     """Generator for VPC data."""
 
-    def __init__(self, start_date, end_date, payer_account, usage_accounts, attributes=None, tag_cols=None):
+    def __init__(
+        self, start_date, end_date, payer_account, usage_accounts, attributes=None, tag_cols=None, user_config=None
+    ):
         """Initialize the VPC generator."""
-        super().__init__(start_date, end_date, payer_account, usage_accounts, attributes, tag_cols)
+        super().__init__(
+            start_date, end_date, payer_account, usage_accounts, attributes, tag_cols, user_config=user_config
+        )
+
         self._resource_id = "vpn-{}".format(self.fake.ean8())
         self._product_sku = self.fake.pystr(min_chars=12, max_chars=12).upper()
         if self.attributes:

--- a/nise/generators/azure/azure_generator.py
+++ b/nise/generators/azure/azure_generator.py
@@ -88,8 +88,15 @@ class AzureGenerator(AbstractGenerator):
 
     SERVICE_NAMES = ["SQL Database", "Storage", "Virtual Machines", "Virtual Network"]
 
-    def __init__(self, start_date, end_date, payer_account, usage_accounts, attributes=None):  # noqa: C901
+    TEMPLATE = "nise/generators/azure/generator.j2"
+
+    # Not yet implemented.
+    TEMPLATE_KWARGS = {"NotImplemented": True}
+
+    def __init__(self, start_date, end_date, payer_account, usage_accounts, attributes=None, user_config=None):
         """Initialize the generator."""
+        super().__init__(start_date, end_date, user_config=user_config)
+
         self.payer_account = payer_account
         self.usage_accounts = usage_accounts
         self.attributes = attributes
@@ -124,7 +131,6 @@ class AzureGenerator(AbstractGenerator):
                 self._tags = attributes.get("tags")
             if attributes.get("meter_cache"):
                 self._meter_cache = attributes.get("meter_cache")
-        super().__init__(start_date, end_date)
 
     def _get_accts_str(self, service_name):
         """Return instance idea fields."""

--- a/nise/generators/azure/bandwidth_generator.py
+++ b/nise/generators/azure/bandwidth_generator.py
@@ -54,7 +54,7 @@ class BandwidthGenerator(AzureGenerator):
         },
     )
 
-    def __init__(self, start_date, end_date, payer_account, usage_accounts, attributes=None):
+    def __init__(self, start_date, end_date, payer_account, usage_accounts, attributes=None, user_config=None):
         """Initialize the data transfer generator."""
         self._service_name = "Bandwidth"
-        super().__init__(start_date, end_date, payer_account, usage_accounts, attributes)
+        super().__init__(start_date, end_date, payer_account, usage_accounts, attributes, user_config=user_config)

--- a/nise/generators/azure/generator.j2
+++ b/nise/generators/azure/generator.j2
@@ -1,0 +1,68 @@
+---
+generators:
+{% for bwg in bandwidth_gens %}  - BandwidthGenerator:
+      start_date: {{ bwg.start_date }}
+      end_date: {{ bwg.end_date }}
+      instance_id: {{ bwg.instance_id }}
+      meter_id: {{ bwg.meter_id }}
+      resource_location: {{ bwg.resource_location }}
+      usage_quantity: {{ bwg.usage_quantity }}
+      resource_rate: {{ bwg.resource_rate }}
+      pre_tax_cost: {{ bwg.pre_tax_cost }}
+      tags:{% for tag in bwg.tags %}
+        {{ tag.key }}: {{ tag.value }}{% endfor %}
+{% endfor %}
+{% for sql in sql_gens %}  - SQLGenerator:
+      start_date: {{ sql.start_date }}
+      end_date: {{ sql.end_date }}
+      instance_id: {{ sql.instance_id }}
+      meter_id: {{ sql.meter_id }}
+      resource_location: {{ sql.resource_location }}
+      usage_quantity: {{ sql.usage_quantity }}
+      resource_rate: {{ sql.resource_rate }}
+      pre_tax_cost: {{ sql.pre_tax_cost }}
+      tags:{% for tag in sql.tags %}
+        {{ tag.key }}: {{ tag.value }}{% endfor %}
+{% endfor %}
+{% for stor in storage_gens %}  - StorageGenerator:
+      start_date: {{ stor.start_date }}
+      end_date: {{ stor.end_date }}
+      instance_id: {{ stor.instance_id }}
+      meter_id: {{ stor.meter_id }}
+      resource_location: {{ stor.resource_location }}
+      usage_quantity: {{ stor.usage_quantity }}
+      resource_rate: {{ stor.resource_rate }}
+      pre_tax_cost: {{ stor.pre_tax_cost }}
+      tags:{% for tag in stor.tags %}
+        {{ tag.key }}: {{ tag.value }}{% endfor %}
+{% endfor %}
+{% for vmg in vmachine_gens %}  - VMGenerator:
+      start_date: {{ vmg.start_date }}
+      end_date: {{ vmg.end_date }}
+      instance_id: {{ vmg.instance_id }}
+      meter_id: {{ vmg.meter_id }}
+      resource_location: {{ vmg.resource_location }}
+      usage_quantity: {{ vmg.usage_quantity }}
+      resource_rate: {{ vmg.resource_rate }}
+      pre_tax_cost: {{ vmg.pre_tax_cost }}
+      tags:{% for tag in vmg.tags %}
+        {{ tag.key }}: {{ tag.value }}{% endfor %}
+{% endfor %}
+{% for vng in vnetwork_gens %}  - VNGenerator:
+      start_date: {{ vng.start_date }}
+      end_date: {{ vng.end_date }}
+      instance_id: {{ vng.instance_id }}
+      meter_id: {{ vng.meter_id }}
+      resource_location: {{ vng.resource_location }}
+      usage_quantity: {{ vng.usage_quantity }}
+      resource_rate: {{ vng.resource_rate }}
+      pre_tax_cost: {{ vng.pre_tax_cost }}
+      tags:{% for tag in vng.tags %}
+        {{ tag.key }}: {{ tag.value }}{% endfor %}
+{% endfor %}
+
+# SubscriptionGuid
+accounts:
+  payer: {{ payer }}
+  user:
+    - {{ payer }}

--- a/nise/generators/azure/sql_database_generator.py
+++ b/nise/generators/azure/sql_database_generator.py
@@ -35,7 +35,7 @@ class SQLGenerator(AzureGenerator):
     )
     ADDITIONAL_INFO = ({"ConsumptionMeter": "22222222-3333-4444-5555-666666666666"},)
 
-    def __init__(self, start_date, end_date, payer_account, usage_accounts, attributes=None):
+    def __init__(self, start_date, end_date, payer_account, usage_accounts, attributes=None, user_config=None):
         """Initialize the data transfer generator."""
         self._service_name = "SQL Database"
-        super().__init__(start_date, end_date, payer_account, usage_accounts, attributes)
+        super().__init__(start_date, end_date, payer_account, usage_accounts, attributes, user_config=user_config)

--- a/nise/generators/azure/storage_generator.py
+++ b/nise/generators/azure/storage_generator.py
@@ -62,7 +62,7 @@ class StorageGenerator(AzureGenerator):
     )
     ADDITIONAL_INFO = [None]
 
-    def __init__(self, start_date, end_date, payer_account, usage_accounts, attributes=None):
+    def __init__(self, start_date, end_date, payer_account, usage_accounts, attributes=None, user_config=None):
         """Initialize the data transfer generator."""
         self._service_name = "Storage"
-        super().__init__(start_date, end_date, payer_account, usage_accounts, attributes)
+        super().__init__(start_date, end_date, payer_account, usage_accounts, attributes, user_config=user_config)

--- a/nise/generators/azure/virtual_machine_generator.py
+++ b/nise/generators/azure/virtual_machine_generator.py
@@ -52,7 +52,7 @@ class VMGenerator(AzureGenerator):
         },
     )
 
-    def __init__(self, start_date, end_date, payer_account, usage_accounts, attributes=None):
+    def __init__(self, start_date, end_date, payer_account, usage_accounts, attributes=None, user_config=None):
         """Initialize the data transfer generator."""
         self._service_name = "Virtual Machines"
-        super().__init__(start_date, end_date, payer_account, usage_accounts, attributes)
+        super().__init__(start_date, end_date, payer_account, usage_accounts, attributes, user_config=user_config)

--- a/nise/generators/azure/virtual_network_generator.py
+++ b/nise/generators/azure/virtual_network_generator.py
@@ -35,7 +35,7 @@ class VNGenerator(AzureGenerator):
     )
     ADDITIONAL_INFO = ({"ConsumptionMeter": "f114cb19-ea64-40b5-bcd7-aee474b62853"},)
 
-    def __init__(self, start_date, end_date, payer_account, usage_accounts, attributes=None):
+    def __init__(self, start_date, end_date, payer_account, usage_accounts, attributes=None, user_config=None):
         """Initialize the data transfer generator."""
         self._service_name = "Virtual Network"
-        super().__init__(start_date, end_date, payer_account, usage_accounts, attributes)
+        super().__init__(start_date, end_date, payer_account, usage_accounts, attributes, user_config=user_config)

--- a/nise/generators/gcp/gcp_generator.py
+++ b/nise/generators/gcp/gcp_generator.py
@@ -31,7 +31,12 @@ GCP_REPORT_COLUMNS = (
 class GCPGenerator(AbstractGenerator):
     """Abstract class for GCP generators."""
 
-    def __init__(self, start_date, end_date, project, attributes=None):
+    TEMPLATE = "nise/generators/gcp/generator.j2"
+
+    # Not yet implemented.
+    TEMPLATE_KWARGS = {"NotImplemented": True}
+
+    def __init__(self, start_date, end_date, project, attributes=None, user_config=None):
         """
         Initialize the generator.
 
@@ -44,7 +49,8 @@ class GCPGenerator(AbstractGenerator):
             num_instances (int): number of instances to generate fake data for.
 
         """
-        super().__init__(start_date, end_date)
+        super().__init__(start_date, end_date, user_config=user_config)
+
         self.project = project
         self.num_instances = 1 if attributes else randint(2, 60)
         self.attributes = attributes

--- a/nise/generators/gcp/generator.j2
+++ b/nise/generators/gcp/generator.j2
@@ -1,0 +1,34 @@
+---
+generators:
+{% for csg in cloudstorage_gens %}  - CloudStorageGenerator:
+    Line Item: {{ csg.line_item }}
+    Measurement1: {{ csg.measurement }}
+    Measurement1 Total Consumption: {{ csg.measurement_total_consumption }}
+    Measurement1 Units: {{ csg.measurement_units }}
+    Cost: {{ csg.cost }}
+    Currency: {{ csg.currency }}
+    Description: {{ csg.description }}
+    Credit1: {{ csg.credit }}
+    Credit1 Amount: {{ csg.credit_amount }}
+    Credit1 Currency: {{ csg.credit_currency }}
+{% endfor %}
+{% for ceg in computeengine_gens %}  - ComputeEngineGenerator:
+    Line Item: {{ ceg.line_item }}
+    Measurement1: {{ ceg.measurement }}
+    Measurement1 Total Consumption: {{ ceg.measurement_total_consumption }}
+    Measurement1 Units: {{ ceg.measurement_units }}
+    Cost: {{ ceg.cost }}
+    Currency: {{ ceg.currency }}
+    Description: {{ ceg.description }}
+    Credit1: {{ ceg.credit }}
+    Credit1 Amount: {{ ceg.credit_amount }}
+    Credit1 Currency: {{ ceg.credit_currency }}
+{% endfor %}
+{% for project in project_gens %}  - ProjectGenerator:
+    Account ID: {{ project.account }}
+    Project: {{ project.number }}
+    Project Number: {{ project.number }}
+    Project ID: {{ project.id }}
+    Project Name: {{ project.id }}
+    Project Labels: {{ project.labels }}
+{% endfor %}

--- a/nise/generators/generator.py
+++ b/nise/generators/generator.py
@@ -16,10 +16,19 @@
 #
 """Defines the abstract generator."""
 import datetime
+import os
 from abc import ABC
 from abc import abstractmethod
+from pprint import pformat
 
 from faker import Faker
+from jinja2 import Environment
+from jinja2 import FunctionLoader
+from nise.jinja_ext import faker_passthrough
+from nise.util import deepupdate
+from nise.util import load_yaml
+from nise.util import LOG
+
 
 REPORT_TYPE = "report_type"
 
@@ -27,13 +36,50 @@ REPORT_TYPE = "report_type"
 class AbstractGenerator(ABC):
     """Defines a abstract class for generators."""
 
-    def __init__(self, start_date, end_date):
+    fake = Faker()
+
+    # Jinja template filename defined by each generator
+    TEMPLATE = None
+
+    # keyword args passed to TEMPLATE
+    TEMPLATE_KWARGS = None
+
+    def __init__(self, start_date, end_date, user_config=None):
         """Initialize the generator."""
+        if not self.TEMPLATE:
+            raise AttributeError("Class attribute 'TEMPLATE' must be defined.")
+
+        if not self.TEMPLATE_KWARGS:
+            raise AttributeError("Class attribute 'TEMPLATE_KWARGS' must be defined.")
+
+        # XXX: temporary conditional until all generators support using the jinja templating
+        if not self.TEMPLATE_KWARGS.get("NotImplemented"):
+            env = Environment(loader=FunctionLoader(self.load_template))
+            env.globals["faker"] = faker_passthrough
+
+            default_template = env.get_template(self.TEMPLATE)
+            if user_config:
+                user_template = env.get_template(user_config)
+                user_config = load_yaml(user_template.render(**self.TEMPLATE_KWARGS))
+                default_config = load_yaml(default_template.render(**self.TEMPLATE_KWARGS))
+                config = deepupdate(default_config, user_config)  # merge user-supplied static file with base template
+            else:
+                config = load_yaml(default_template.render(**self.TEMPLATE_KWARGS))
+
+            # remove top-level class name
+            self.config = []
+            for generators in config.get("generators"):
+                for key, val in generators.items():
+                    if key == type(self).__name__:
+                        self.config.append(val)
+
+            LOG.debug("Current config: %s", pformat(self.config))
+
         self.start_date = start_date
         self.end_date = end_date
         self.hours = self._set_hours()
         self.days = self._set_days()
-        self.fake = Faker()
+
         super().__init__()
 
     def _set_hours(self):
@@ -103,3 +149,14 @@ class AbstractGenerator(ABC):
     @abstractmethod
     def generate_data(self, report_type=None):
         """Responsible for generating data."""
+
+    def load_template(self, name):
+        """Responsible for loading the Jinja template."""
+        template = None
+        if os.path.exists(name):
+            try:
+                with open(name, "r") as fh:
+                    template = fh.read()
+            except (IOError, OSError, TypeError) as exc:
+                LOG.error(exc)
+        return template

--- a/nise/generators/ocp/generator.j2
+++ b/nise/generators/ocp/generator.j2
@@ -1,12 +1,11 @@
 ---
 generators:
   - OCPGenerator:
-      start_date: {{generator.start_date}}
-      end_date: {{generator.end_date}}
+      start_date: {{start_date}}
+      end_date: {{end_date}}
       nodes:
         {% for node in nodes %}{# start node loop #}
-        - node:
-          node_name: {{node.name}}
+        - node_name: {{node.node_name}}
           cpu_cores: {{node.cpu_cores}}
           memory_gig: {{node.memory_gig}}
           resource_id: {{node.resource_id}}
@@ -23,19 +22,37 @@ generators:
                   mem_limit_gig: {{pod.mem_limit_gig}}
                   pod_seconds: {{pod.pod_seconds}}
                   labels: {{pod.labels}}
-                {% endfor %} # end pod loop
+                  namespace: {{pod.namespace}}
+                  node: {{pod.node}}
+                  resource_id: {{pod.resource_id}}
+                  node_capacity_cpu_cores: {{pod.node_capacity_cpu_cores}}
+                  node_capacity_cpu_core_seconds: {{pod.node_capacity_cpu_core_seconds}}
+                  node_capacity_memory_bytes: {{pod.node_capacity_memory_bytes}}
+                  node_capacity_memory_byte_seconds: {{pod.node_capacity_memory_byte_seconds}}
+                  cpu_usage:
+                  {% for k, v in pod.cpu_usage.items() %}
+                    {{k}}: {{v}}
+                  {% endfor %}
+                  mem_usage_gig:
+                  {% for k, v in pod.mem_usage_gig.items() %}
+                    {{k}}: {{v}}
+                  {% endfor %}
+                {% endfor %}{# end pod loop #}
               volumes:
                 {% for volume in namespace.volumes %}{# start volume loop #}
                 - volume_name: {{volume.volume_name}}
+                  namespace: {{volume.namespace}}
                   storage_class: {{volume.storage_class}}
                   volume_request_gig: {{volume.volume_request_gig}}
                   labels: {{volume.labels}}
                   volume_claims:
                   {% for volume_claim in volume.volume_claims %}{# start volume-claim loop #}
                   - volume_claim_name: {{volume_claim.volume_claim_name}}
+                    namespace: {{volume_claim.namespace}}
                     pod_name: {{volume_claim.pod_name}}
                     labels: {{volume_claim.labels}}
                     capacity_gig: {{volume_claim.capacity_gig}}
+                    volume_claim_usage_gig: {{volume_claim.volume_claim_usage_gig}}
                   {% endfor %}{# end volume claim loop #}
                 {% endfor %}{# end volume loop #}
             {% endfor %}{# end namespace loop #}

--- a/nise/generators/ocp/ocp_generator.py
+++ b/nise/generators/ocp/ocp_generator.py
@@ -129,7 +129,7 @@ class OCPGenerator(AbstractGenerator):
     def _gen_nodes(self):
         """Create nodes for report."""
         nodes = []
-        for _ in enumerate(range(0, self.fake.pyint(2, 6))):
+        for _ in range(0, self.fake.pyint(2, 6)):
             node = {
                 "node_name": "node_" + self.fake.word(),
                 "cpu_cores": self.fake.pyint(2, 16),
@@ -148,7 +148,7 @@ class OCPGenerator(AbstractGenerator):
     def _gen_namespaces(self, node):
         """Create namespaces on specific nodes and keep relationship."""
         namespaces = []
-        names = ["ns_" + self.fake.word() for _ in enumerate(range(0, self.fake.pyint(1, 4)))]
+        names = ["ns_" + self.fake.word() for _ in range(0, self.fake.pyint(1, 4))]
         for name in names:
             pods = self._gen_pods(node, name)
             namespace = {"namespace_name": name, "pods": pods, "volumes": self._gen_volumes(pods)}
@@ -157,10 +157,10 @@ class OCPGenerator(AbstractGenerator):
 
     def _gen_openshift_labels(self, seeding=None):
         """Create pod labels for output data."""
-        self.apps = [self.fake.word() for _ in enumerate(range(0, self.fake.pyint(3, 6)))]
-        self.organizations = [self.fake.word() for _ in enumerate(range(0, self.fake.pyint(3, 6)))]
-        self.markets = [self.fake.word() for _ in enumerate(range(0, self.fake.pyint(3, 6)))]
-        self.versions = [self.fake.word() for _ in enumerate(range(0, self.fake.pyint(3, 6)))]
+        self.apps = [self.fake.word() for _ in range(0, self.fake.pyint(3, 6))]
+        self.organizations = [self.fake.word() for _ in range(0, self.fake.pyint(3, 6))]
+        self.markets = [self.fake.word() for _ in range(0, self.fake.pyint(3, 6))]
+        self.versions = [self.fake.word() for _ in range(0, self.fake.pyint(3, 6))]
         seeded_labels = {
             "environment": ["dev", "ci", "qa", "stage", "prod"],
             "app": self.apps,
@@ -170,7 +170,7 @@ class OCPGenerator(AbstractGenerator):
         }
         if seeding:
             seeded_labels = seeding
-        gen_label_keys = [self.fake.word() for _ in enumerate(range(0, self.fake.pyint(3, 6)))]
+        gen_label_keys = [self.fake.word() for _ in range(0, self.fake.pyint(3, 6))]
         all_label_keys = list(seeded_labels.keys()) + gen_label_keys
         num_labels = randint(2, len(all_label_keys))
         chosen_label_keys = choices(all_label_keys, k=num_labels)
@@ -193,7 +193,7 @@ class OCPGenerator(AbstractGenerator):
         pods = []
         cpu_used = 0
         mem_used = 0
-        for _ in enumerate(range(0, self.fake.pyint(2, 5))):
+        for _ in range(0, self.fake.pyint(2, 5)):
             cpu_cores = node.get("cpu_cores")
             if cpu_used >= cpu_cores * 0.95:
                 break
@@ -241,13 +241,13 @@ class OCPGenerator(AbstractGenerator):
     def _gen_volumes(self, pods):
         """Create volumes on specific namespaces and keep relationship."""
         volumes = []
-        for _ in enumerate(range(0, len(pods))):
+        for _ in range(0, len(pods)):
             volume_name = "vol_" + self.fake.word()
             volume_request_gig = self.fake.pyint(20, 100)
             volume_request = volume_request_gig * GIGABYTE
             volume_claims = []
             total_claims = 0
-            for _ in enumerate(range(0, len(pods))):
+            for _ in range(0, len(pods)):
                 if volume_request - total_claims <= GIGABYTE:
                     break
                 volume_claim_name = "vc_" + self.fake.word()

--- a/nise/generators/ocp/ocp_generator.py
+++ b/nise/generators/ocp/ocp_generator.py
@@ -21,7 +21,6 @@ from random import choice
 from random import choices
 from random import randint
 from random import uniform
-from string import ascii_lowercase
 
 from dateutil import parser
 from nise.generators.generator import AbstractGenerator
@@ -89,42 +88,22 @@ OCP_REPORT_TYPE_TO_COLS = {
 class OCPGenerator(AbstractGenerator):
     """Defines a abstract class for generators."""
 
-    def __init__(self, start_date, end_date, attributes):
-        """Initialize the generator."""
-        self._nodes = None
-        if attributes:
-            self._nodes = attributes.get("nodes")
+    TEMPLATE = "nise/generators/ocp/generator.j2"
 
-        super().__init__(start_date, end_date)
-        self.apps = [
-            self.fake.word(),
-            self.fake.word(),
-            self.fake.word(),
-            self.fake.word(),
-            self.fake.word(),
-            self.fake.word(),
-        ]
-        self.organizations = [self.fake.word(), self.fake.word(), self.fake.word(), self.fake.word()]
-        self.markets = [
-            self.fake.word(),
-            self.fake.word(),
-            self.fake.word(),
-            self.fake.word(),
-            self.fake.word(),
-            self.fake.word(),
-        ]
-        self.versions = [
-            self.fake.word(),
-            self.fake.word(),
-            self.fake.word(),
-            self.fake.word(),
-            self.fake.word(),
-            self.fake.word(),
-        ]
-        self.nodes = self._gen_nodes()
-        self.namespaces = self._gen_namespaces(self.nodes)
-        self.pods, self.namespace2pods = self._gen_pods(self.namespaces)
-        self.volumes = self._gen_volumes(self.namespaces, self.namespace2pods)
+    # Keyword args passed to TEMPLATE at render time.
+    TEMPLATE_KWARGS = {"start_date": None, "end_date": None, "nodes": []}
+
+    def __init__(self, start_date, end_date, user_config=None):
+        """Initialize the generator."""
+
+        # initialize TEMPLATE_KWARGS values
+        self._gen_nodes()
+
+        # super() renders the TEMPLATE
+        super().__init__(start_date, end_date, user_config=user_config)
+
+        self.nodes = [node for conf in self.config for node in conf.get("nodes")]
+
         self.ocp_report_generation = {
             OCP_POD_USAGE: {
                 "_generate_hourly_data": self._gen_hourly_pods_usage,
@@ -150,54 +129,38 @@ class OCPGenerator(AbstractGenerator):
     def _gen_nodes(self):
         """Create nodes for report."""
         nodes = []
-        if self._nodes:
-            for item in self._nodes:
-                memory_gig = item.get("memory_gig", randint(2, 8))
-                memory_bytes = memory_gig * GIGABYTE
-                resource_id = str(item.get("resource_id", self.fake.word()))
-                node = {
-                    "name": item.get("node_name", "node_" + self.fake.word()),
-                    "cpu_cores": item.get("cpu_cores", randint(2, 16)),
-                    "memory_bytes": memory_bytes,
-                    "resource_id": "i-" + resource_id,
-                    "namespaces": item.get("namespaces"),
-                    "node_labels": item.get("node_labels"),
-                }
-                nodes.append(node)
-        else:
-            num_nodes = randint(2, 6)
-            seeded_labels = {"node-role.kubernetes.io/master": [""], "node-role.kubernetes.io/infra": [""]}
-            for _ in range(num_nodes):
-                memory_gig = randint(2, 8)
-                memory_bytes = memory_gig * GIGABYTE
-                node = {
-                    "name": "node_" + self.fake.word(),
-                    "cpu_cores": randint(2, 16),
-                    "memory_bytes": memory_bytes,
-                    "resource_id": "i-" + self.fake.word(),
-                    "node_labels": self._gen_openshift_labels(seeding=seeded_labels),
-                }
-                nodes.append(node)
-        return nodes
+        for _ in enumerate(range(0, self.fake.pyint(2, 6))):
+            node = {
+                "node_name": "node_" + self.fake.word(),
+                "cpu_cores": self.fake.pyint(2, 16),
+                "memory_gig": self.fake.pyint(16, 256),
+                "resource_id": "i-" + self.fake.ean8(),
+                "namespaces": [],
+                "labels": self._gen_openshift_labels(),
+            }
+            nodes.append(node)
 
-    def _gen_namespaces(self, nodes):
+        for idx, node in enumerate(nodes):
+            nodes[idx]["namespaces"] = self._gen_namespaces(node)
+
+        self.TEMPLATE_KWARGS["nodes"] = nodes
+
+    def _gen_namespaces(self, node):
         """Create namespaces on specific nodes and keep relationship."""
-        namespaces = {}
-        for node in nodes:
-            if node.get("namespaces"):
-                for name, _ in node.get("namespaces").items():
-                    namespace = name
-                    namespaces[namespace] = node
-            else:
-                num_namespaces = randint(2, 12)
-                for _ in range(num_namespaces):
-                    namespace_suffix = choice(("ci", "qa", "prod", "proj", "dev", "staging"))
-                    namespace = self.fake.word() + "_" + namespace_suffix
-                    namespaces[namespace] = node
+        namespaces = []
+        names = ["ns_" + self.fake.word() for _ in enumerate(range(0, self.fake.pyint(1, 4)))]
+        for name in names:
+            pods = self._gen_pods(node, name)
+            namespace = {"namespace_name": name, "pods": pods, "volumes": self._gen_volumes(pods)}
+            namespaces.append(namespace)
         return namespaces
 
     def _gen_openshift_labels(self, seeding=None):
         """Create pod labels for output data."""
+        self.apps = [self.fake.word() for _ in enumerate(range(0, self.fake.pyint(3, 6)))]
+        self.organizations = [self.fake.word() for _ in enumerate(range(0, self.fake.pyint(3, 6)))]
+        self.markets = [self.fake.word() for _ in enumerate(range(0, self.fake.pyint(3, 6)))]
+        self.versions = [self.fake.word() for _ in enumerate(range(0, self.fake.pyint(3, 6)))]
         seeded_labels = {
             "environment": ["dev", "ci", "qa", "stage", "prod"],
             "app": self.apps,
@@ -207,14 +170,7 @@ class OCPGenerator(AbstractGenerator):
         }
         if seeding:
             seeded_labels = seeding
-        gen_label_keys = [
-            self.fake.word(),
-            self.fake.word(),
-            self.fake.word(),
-            self.fake.word(),
-            self.fake.word(),
-            self.fake.word(),
-        ]
+        gen_label_keys = [self.fake.word() for _ in enumerate(range(0, self.fake.pyint(3, 6)))]
         all_label_keys = list(seeded_labels.keys()) + gen_label_keys
         num_labels = randint(2, len(all_label_keys))
         chosen_label_keys = choices(all_label_keys, k=num_labels)
@@ -232,160 +188,94 @@ class OCPGenerator(AbstractGenerator):
             label_str += f"|{label_data}" if label_str else label_data
         return label_str
 
-    def _gen_pods(self, namespaces):
+    def _gen_pods(self, node, namespace):
         """Create pods on specific namespaces and keep relationship."""
-        pods = {}
-        namespace2pod = {}
-        for namespace, node in namespaces.items():
-            namespace2pod[namespace] = []
-            if node.get("namespaces"):
-                specified_pods = node.get("namespaces").get(namespace).get("pods")
-                for specified_pod in specified_pods:
-                    pod = specified_pod.get("pod_name", self.fake.word())
-                    namespace2pod[namespace].append(pod)
-                    cpu_cores = node.get("cpu_cores")
-                    memory_bytes = node.get("memory_bytes")
+        pods = []
+        cpu_used = 0
+        mem_used = 0
+        for _ in enumerate(range(0, self.fake.pyint(2, 5))):
+            cpu_cores = node.get("cpu_cores")
+            if cpu_used >= cpu_cores * 0.95:
+                break
 
-                    cpu_request = min(specified_pod.get("cpu_request", round(uniform(0.02, 1.0), 5)), cpu_cores)
-                    cpu_usage = specified_pod.get("cpu_usage", {})
-                    for key, value in cpu_usage.items():
-                        if value > cpu_request:
-                            cpu_usage[key] = cpu_request
+            memory_gig = node.get("memory_gig")
+            if mem_used >= memory_gig * 0.95:
+                break
 
-                    memory_gig = memory_bytes / GIGABYTE
-                    mem_request_gig = min(
-                        specified_pod.get("mem_request_gig", round(uniform(25.0, 80.0), 2)), memory_gig
-                    )
-                    memory_usage_gig = specified_pod.get("mem_usage_gig", {})
-                    for key, value in memory_usage_gig.items():
-                        if value > memory_gig:
-                            memory_usage_gig[key] = memory_gig
+            pod_name = "pod_" + self.fake.word()
 
-                    pods[pod] = {
-                        "namespace": namespace,
-                        "node": node.get("name"),
-                        "resource_id": node.get("resource_id"),
-                        "pod": pod,
-                        "node_capacity_cpu_cores": cpu_cores,
-                        "node_capacity_cpu_core_seconds": cpu_cores * HOUR,
-                        "node_capacity_memory_bytes": memory_bytes,
-                        "node_capacity_memory_byte_seconds": memory_bytes * HOUR,
-                        "cpu_request": cpu_request,
-                        "cpu_limit": min(
-                            specified_pod.get("cpu_limit", round(uniform(cpu_request, 1.0), 5)), cpu_cores
-                        ),
-                        "mem_request_gig": mem_request_gig,
-                        "mem_limit_gig": specified_pod.get("mem_limit_gig", round(uniform(mem_request_gig, 80.0), 2)),
-                        "pod_labels": specified_pod.get("labels", None),
-                        "cpu_usage": cpu_usage,
-                        "mem_usage_gig": memory_usage_gig,
-                        "pod_seconds": specified_pod.get("pod_seconds"),
-                    }
-            else:
-                num_pods = randint(2, 20)
-                for _ in range(num_pods):
-                    pod_suffix = "".join(choices(ascii_lowercase, k=5))
-                    pod_type = choice(("build", "deploy", pod_suffix))
-                    pod = self.fake.word() + "_" + pod_type
-                    namespace2pod[namespace].append(pod)
-                    cpu_cores = node.get("cpu_cores")
-                    memory_bytes = node.get("memory_bytes")
-                    memory_gig = memory_bytes / GIGABYTE
-                    cpu_request = min(round(uniform(0.02, 1.0), 5), cpu_cores)
-                    mem_request_gig = min(round(uniform(25.0, 80.0), 2), memory_gig)
-                    pods[pod] = {
-                        "namespace": namespace,
-                        "node": node.get("name"),
-                        "resource_id": node.get("resource_id"),
-                        "pod": pod,
-                        "node_capacity_cpu_cores": cpu_cores,
-                        "node_capacity_cpu_core_seconds": cpu_cores * HOUR,
-                        "node_capacity_memory_bytes": memory_bytes,
-                        "node_capacity_memory_byte_seconds": memory_bytes * HOUR,
-                        "cpu_request": cpu_request,
-                        "cpu_limit": round(uniform(cpu_request, 1.0), 5),
-                        "mem_request_gig": mem_request_gig,
-                        "mem_limit_gig": round(uniform(mem_request_gig, 80.0), 2),
-                        "pod_labels": self._gen_openshift_labels(),
-                    }
-        return pods, namespace2pod
+            cpu_request = round(uniform(0.02, cpu_cores), 5)
+            cpu_limit = round(uniform(cpu_request, cpu_cores), 5)
+            pod_cpu_usage = round(uniform(0.02, cpu_limit), 5)
+            cpu_usage = {"full_period": pod_cpu_usage}
+            cpu_used += pod_cpu_usage
 
-    def _gen_volumes(self, namespaces, namespace2pods):  # noqa: R0914,C901
+            mem_request_gig = round(uniform(1, memory_gig), 2)
+            mem_limit_gig = round(uniform(mem_request_gig, memory_gig), 2)
+            pod_mem_usage = round(uniform(1, mem_limit_gig), 2)
+            mem_usage_gig = {"full_period": pod_mem_usage}
+            mem_used += pod_mem_usage
+
+            pods.append(
+                {
+                    "namespace": namespace,
+                    "node": node.get("node_name"),
+                    "resource_id": node.get("resource_id"),
+                    "pod_name": pod_name,
+                    "node_capacity_cpu_cores": cpu_cores,
+                    "node_capacity_cpu_core_seconds": cpu_cores * HOUR,
+                    "node_capacity_memory_bytes": memory_gig * GIGABYTE,
+                    "node_capacity_memory_byte_seconds": memory_gig * GIGABYTE * HOUR,
+                    "cpu_request": cpu_request,
+                    "cpu_limit": cpu_limit,
+                    "mem_request_gig": mem_request_gig,
+                    "mem_limit_gig": mem_limit_gig,
+                    "labels": self._gen_openshift_labels(),
+                    "cpu_usage": cpu_usage,
+                    "mem_usage_gig": mem_usage_gig,
+                    "pod_seconds": self.fake.pyint(0, 3600),
+                }
+            )
+        return pods
+
+    def _gen_volumes(self, pods):
         """Create volumes on specific namespaces and keep relationship."""
-        volumes = {}
-        for namespace, node in namespaces.items():
-            storage_class_default = choice(("gp2", "fast", "slow", "gold"))
-            if node.get("namespaces"):
-                specified_volumes = node.get("namespaces").get(namespace).get("volumes", [])
-                for specified_volume in specified_volumes:
-                    volume = specified_volume.get("volume_name", self.fake.word())
-                    volume_request_gig = specified_volume.get("volume_request_gig")
-                    volume_request = volume_request_gig * GIGABYTE
-                    specified_vol_claims = specified_volume.get("volume_claims", [])
-                    volume_claims = {}
-                    total_claims = 0
-                    for specified_vc in specified_vol_claims:
-                        if volume_request - total_claims <= GIGABYTE:
-                            break
-                        vol_claim = specified_vc.get("volume_claim_name", self.fake.word())
-                        pod = specified_vc.get("pod_name")
-                        claim_capacity = min(
-                            specified_vc.get("capacity_gig") * GIGABYTE, (volume_request_gig * GIGABYTE - total_claims)
-                        )
-                        usage_gig = specified_vc.get("volume_claim_usage_gig")
-                        if usage_gig:
-                            for key, value in usage_gig.items():
-                                if value > claim_capacity / GIGABYTE:
-                                    usage_gig[key] = claim_capacity / GIGABYTE
-                        volume_claims[vol_claim] = {
-                            "namespace": namespace,
-                            "volume": volume,
-                            "labels": specified_vc.get("labels", None),
-                            "capacity": claim_capacity,
-                            "pod": pod,
-                            "volume_claim_usage_gig": usage_gig,
-                        }
-                        total_claims += claim_capacity
-                    volumes[volume] = {
-                        "namespace": namespace,
-                        "volume": volume,
-                        "storage_class": specified_volume.get("storage_class", storage_class_default),
-                        "volume_request": volume_request,
-                        "labels": specified_volume.get("labels", None),
-                        "volume_claims": volume_claims,
-                    }
-            else:
-                num_volumes = randint(1, 3)
-                num_vol_claims = randint(1, 2)
-                for _ in range(num_volumes):
-                    vol_suffix = "".join(choices(ascii_lowercase, k=10))
-                    volume = "pvc" + "-" + vol_suffix
-                    vol_request_gig = round(uniform(25.0, 80.0), 2)
-                    vol_request = vol_request_gig * GIGABYTE
-                    volume_claims = {}
-                    total_claims = 0
-                    for _ in range(num_vol_claims):
-                        if vol_request_gig - total_claims <= GIGABYTE:
-                            break
-                        vol_claim = self.fake.word()
-                        pod = choice(namespace2pods[namespace])
-                        claim_capacity = round(uniform(1.0, vol_request_gig), 2) * GIGABYTE
-                        volume_claims[vol_claim] = {
-                            "namespace": namespace,
-                            "volume": volume,
-                            "labels": self._gen_openshift_labels(),
-                            "capacity": claim_capacity,
-                            "pod": pod,
-                        }
-                        total_claims += claim_capacity
-                    volumes[volume] = {
-                        "namespace": namespace,
-                        "volume": volume,
-                        "storage_class": choice(("gp2", "fast", "slow", "gold")),
-                        "volume_request": vol_request,
+        volumes = []
+        for _ in enumerate(range(0, len(pods))):
+            volume_name = "vol_" + self.fake.word()
+            volume_request_gig = self.fake.pyint(20, 100)
+            volume_request = volume_request_gig * GIGABYTE
+            volume_claims = []
+            total_claims = 0
+            for _ in enumerate(range(0, len(pods))):
+                if volume_request - total_claims <= GIGABYTE:
+                    break
+                volume_claim_name = "vc_" + self.fake.word()
+                pod = choice(pods)
+                claim_capacity = min(
+                    self.fake.pyint(20, 100) * GIGABYTE, (volume_request_gig * GIGABYTE - total_claims)
+                )
+                volume_claims.append(
+                    {
+                        "namespace": pod.get("namespace"),
+                        "volume_claim_name": volume_claim_name,
                         "labels": self._gen_openshift_labels(),
-                        "volume_claims": volume_claims,
+                        "capacity_gig": claim_capacity / GIGABYTE,
+                        "pod_name": pod.get("pod_name"),
+                        "volume_claim_usage_gig": {"full_period": self.fake.pyint(1, claim_capacity) / GIGABYTE},
                     }
+                )
+                total_claims += claim_capacity
+            volumes.append(
+                {
+                    "namespace": pod.get("namespace"),
+                    "volume_name": volume_name,
+                    "storage_class": choice(("gp2", "fast", "slow", "gold")),
+                    "volume_request_gig": volume_request_gig,
+                    "labels": self._gen_openshift_labels(),
+                    "volume_claims": volume_claims,
+                }
+            )
         return volumes
 
     def _init_data_row(self, start, end, **kwargs):  # noqa: C901
@@ -399,7 +289,7 @@ class OCPGenerator(AbstractGenerator):
 
         bill_begin = start.replace(microsecond=0, second=0, minute=0, hour=0, day=1)
         bill_end = AbstractGenerator.next_month(bill_begin)
-        row = {}
+        row = self._add_common_usage_info({}, start, end)
         report_type = kwargs.get(REPORT_TYPE)
         for column in OCP_REPORT_TYPE_TO_COLS[report_type]:
             row[column] = ""
@@ -428,33 +318,37 @@ class OCPGenerator(AbstractGenerator):
 
     def _update_pod_data(self, row, start, end, **kwargs):
         """Update data with generator specific data."""
-        user_pod_seconds = kwargs.get("pod_seconds")
-        pod_seconds = user_pod_seconds if user_pod_seconds else randint(2, HOUR)
-        pod = kwargs.get("pod")
+        del kwargs["report_type"]
+        pod = kwargs.pop("pod")
 
-        cpu_request = pod.pop("cpu_request")
-        mem_request_gig = pod.pop("mem_request_gig")
+        pod_seconds = kwargs.pop("pod_seconds")
 
-        cpu_limit = min(pod.pop("cpu_limit"), cpu_request)
-        mem_limit_gig = min(pod.pop("mem_limit_gig"), mem_request_gig)
+        cpu_request = pod.get("cpu_request")
+        mem_request_gig = pod.get("mem_request_gig")
 
-        cpu_usage = self._get_usage_for_date(kwargs.get("cpu_usage"), start)
+        cpu_limit = min(pod.get("cpu_limit"), cpu_request)
+        mem_limit_gig = min(pod.get("mem_limit_gig"), mem_request_gig)
+
+        cpu_usage = self._get_usage_for_date(kwargs.pop("cpu_usage"), start)
         cpu = round(uniform(0.02, cpu_limit), 5)
         if cpu_usage:
             cpu = min(cpu_limit, cpu_request, cpu_usage)
 
-        mem_usage_gig = self._get_usage_for_date(kwargs.get("mem_usage_gig"), start)
+        mem_usage_gig = self._get_usage_for_date(kwargs.pop("mem_usage_gig"), start)
         mem = round(uniform(1, mem_limit_gig), 2)
         if mem_usage_gig:
             mem = min(mem_limit_gig, mem_request_gig, mem_usage_gig)
 
-        pod["pod_usage_cpu_core_seconds"] = pod_seconds * cpu
-        pod["pod_request_cpu_core_seconds"] = pod_seconds * cpu_request
-        pod["pod_limit_cpu_core_seconds"] = pod_seconds * cpu_limit
-        pod["pod_usage_memory_byte_seconds"] = pod_seconds * mem * GIGABYTE
-        pod["pod_request_memory_byte_seconds"] = pod_seconds * mem_request_gig * GIGABYTE
-        pod["pod_limit_memory_byte_seconds"] = pod_seconds * mem_limit_gig * GIGABYTE
-        row.update(pod)
+        kwargs["pod"] = pod.get("pod_name")
+        kwargs["pod_usage_cpu_core_seconds"] = pod_seconds * cpu
+        kwargs["pod_request_cpu_core_seconds"] = pod_seconds * cpu_request
+        kwargs["pod_limit_cpu_core_seconds"] = pod_seconds * cpu_limit
+        kwargs["pod_usage_memory_byte_seconds"] = pod_seconds * mem * GIGABYTE
+        kwargs["pod_request_memory_byte_seconds"] = pod_seconds * mem_request_gig * GIGABYTE
+        kwargs["pod_limit_memory_byte_seconds"] = pod_seconds * mem_limit_gig * GIGABYTE
+        kwargs["interval_start"] = start
+        kwargs["interval_end"] = end
+        row.update(kwargs)
         return row
 
     def _update_storage_data(self, row, start, end, **kwargs):
@@ -462,7 +356,7 @@ class OCPGenerator(AbstractGenerator):
         volume_claim_usage_gig = self._get_usage_for_date(kwargs.get("volume_claim_usage_gig"), start)
 
         volume_request = kwargs.get("volume_request")
-        vc_capacity_gig = min(kwargs.get("vc_capacity", 10.0), volume_request) / GIGABYTE
+        vc_capacity_gig = min(kwargs.get("vc_capacity", 10.0), volume_request)
 
         vc_usage_gig = round(uniform(2.0, vc_capacity_gig), 2)
         if volume_claim_usage_gig:
@@ -470,13 +364,15 @@ class OCPGenerator(AbstractGenerator):
         vc_usage = vc_usage_gig * GIGABYTE
 
         data = {
+            "interval_start": start,
+            "interval_end": end,
             "namespace": kwargs.get("namespace"),
             "pod": kwargs.get("pod"),
             "persistentvolumeclaim": kwargs.get("volume_claim"),
             "persistentvolume": kwargs.get("volume_name"),
             "storageclass": kwargs.get("storage_class"),
             "persistentvolumeclaim_capacity_bytes": kwargs.get("vc_capacity"),
-            "persistentvolumeclaim_capacity_byte_seconds": vc_capacity_gig * GIGABYTE * HOUR,
+            "persistentvolumeclaim_capacity_byte_seconds": vc_capacity_gig * HOUR,
             "volume_request_storage_byte_seconds": volume_request * HOUR,
             "persistentvolume_labels": kwargs.get("volume_labels"),
             "persistentvolumeclaim_labels": kwargs.get("volume_claim_labels"),
@@ -487,17 +383,20 @@ class OCPGenerator(AbstractGenerator):
 
     def _update_node_label_data(self, row, start, end, **kwargs):
         """Update data with generator specific data."""
-        data = {"node": kwargs.get("node"), "node_labels": kwargs.get("node_labels")}
+        data = {
+            "node": kwargs.get("node"),
+            "node_labels": kwargs.get("node_labels"),
+            "interval_start": start,
+            "interval_end": end,
+        }
         row.update(data)
         return row
 
     def _update_data(self, row, start, end, **kwargs):
         """Update data with generator specific data."""
-        row = self._add_common_usage_info(row, start, end)
-        if kwargs.get(REPORT_TYPE):
-            report_type = kwargs.get(REPORT_TYPE)
-            method = self.ocp_report_generation.get(report_type).get("_update_data")
-            row = method(row, start, end, **kwargs)
+        report_type = kwargs.get(REPORT_TYPE)
+        method = self.ocp_report_generation.get(report_type).get("_update_data")
+        row = method(row, start, end, **kwargs)
         return row
 
     def _gen_hourly_pods_usage(self, **kwargs):
@@ -505,75 +404,65 @@ class OCPGenerator(AbstractGenerator):
         for hour in self.hours:
             start = hour.get("start")
             end = hour.get("end")
-
-            if self._nodes:
-                for pod_name, _ in self.pods.items():
-                    cpu_usage = self.pods[pod_name].get("cpu_usage", None)
-                    mem_usage_gig = self.pods[pod_name].get("mem_usage_gig", None)
-                    pod_seconds = self.pods[pod_name].get("pod_seconds", None)
-                    pod = deepcopy(self.pods[pod_name])
-                    row = self._init_data_row(start, end, **kwargs)
-                    row = self._update_data(
-                        row,
-                        start,
-                        end,
-                        pod=pod,
-                        cpu_usage=cpu_usage,
-                        mem_usage_gig=mem_usage_gig,
-                        pod_seconds=pod_seconds,
-                        **kwargs,
-                    )
-                    row.pop("cpu_usage", None)
-                    row.pop("mem_usage_gig", None)
-                    row.pop("pod_seconds", None)
-                    yield row
-            else:
-                pod_count = len(self.pods)
-                num_pods = randint(2, pod_count)
-                pod_index_list = range(pod_count)
-                pod_choices = list(set(choices(pod_index_list, k=num_pods)))
-                pod_keys = list(self.pods.keys())
-                for pod_choice in pod_choices:
-                    pod_name = pod_keys[pod_choice]
-                    pod = deepcopy(self.pods[pod_name])
-                    row = self._init_data_row(start, end, **kwargs)
-                    row = self._update_data(row, start, end, pod=pod, **kwargs)
-                    yield row
+            for node in self.nodes:
+                for namespace in node.get("namespaces"):
+                    name = namespace.get("namespace_name")
+                    for pod in namespace.get("pods"):
+                        cpu_usage = pod.get("cpu_usage", None)
+                        mem_usage_gig = pod.get("mem_usage_gig", None)
+                        pod_seconds = pod.get("pod_seconds", None)
+                        row = self._init_data_row(start, end, **kwargs)
+                        row = self._update_data(
+                            row,
+                            start,
+                            end,
+                            pod=deepcopy(pod),
+                            cpu_usage=cpu_usage,
+                            mem_usage_gig=mem_usage_gig,
+                            pod_seconds=pod_seconds,
+                            namespace=name,
+                            node=node.get("node_name"),
+                            resource_id=node.get("resource_id"),
+                            node_capacity_cpu_cores=node.get("cpu_cores"),
+                            node_capacity_cpu_core_seconds=node.get("cpu_cores") * 3600,
+                            node_capacity_memory_bytes=node.get("memory_gig") * GIGABYTE,
+                            node_capacity_memory_byte_seconds=node.get("memory_gig") * GIGABYTE,
+                            pod_labels=pod.get("labels"),
+                            **kwargs,
+                        )
+                        row.pop("cpu_usage", None)
+                        row.pop("mem_usage_gig", None)
+                        row.pop("pod_seconds", None)
+                        yield row
 
     def _gen_hourly_storage_usage(self, **kwargs):
         """Create hourly data for storage usage."""
         for hour in self.hours:
             start = hour.get("start")
             end = hour.get("end")
-            for volume_name, volume in self.volumes.items():
-                namespace = volume.get("namespace", None)
-                storage_class = volume.get("storage_class", None)
-                volume_request = volume.get("volume_request", None)
-                vol_labels = volume.get("labels", None)
-                volume_claims = volume.get("volume_claims", [])
-                for vc_name, volume_claim in volume_claims.items():
-                    pod = volume_claim.get("pod")
-                    vc_labels = volume_claim.get("labels")
-                    capacity = volume_claim.get("capacity")
-                    volume_claim_usage_gig = volume_claim.get("volume_claim_usage_gig", None)
-                    row = self._init_data_row(start, end, **kwargs)
-                    row = self._update_data(
-                        row,
-                        start,
-                        end,
-                        volume_claim=vc_name,
-                        pod=pod,
-                        volume_claim_labels=vc_labels,
-                        vc_capacity=capacity,
-                        volume_claim_usage_gig=volume_claim_usage_gig,
-                        storage_class=storage_class,
-                        volume_name=volume_name,
-                        volume_request=volume_request,
-                        volume_labels=vol_labels,
-                        namespace=namespace,
-                        **kwargs,
-                    )
-                    yield row
+            for node in self.nodes:
+                for namespace in node.get("namespaces"):
+                    name = namespace.get("namespace_name")
+                    for volume in namespace.get("volumes"):
+                        for volume_claim in volume.get("volume_claims"):
+                            row = self._init_data_row(start, end, **kwargs)
+                            row = self._update_data(
+                                row,
+                                start,
+                                end,
+                                volume_claim=volume_claim.get("volume_claim_name"),
+                                pod=volume_claim.get("pod_name"),
+                                volume_claim_labels=volume_claim.get("labels"),
+                                vc_capacity=volume_claim.get("capacity_gig"),
+                                volume_claim_usage_gig=volume_claim.get("volume_claim_usage_gig"),
+                                storage_class=volume.get("storage_class"),
+                                volume_name=volume.get("volume_name"),
+                                volume_request=volume.get("volume_request_gig"),
+                                volume_labels=volume.get("labels"),
+                                namespace=name,
+                                **kwargs,
+                            )
+                            yield row
 
     def _gen_hourly_node_label_usage(self, **kwargs):
         """Create hourly data for nodel label report."""
@@ -583,7 +472,7 @@ class OCPGenerator(AbstractGenerator):
             for node in self.nodes:
                 row = self._init_data_row(start, end, **kwargs)
                 row = self._update_data(
-                    row, start, end, node_labels=node.get("node_labels"), node=node.get("name"), **kwargs
+                    row, start, end, node_labels=node.get("labels"), node=node.get("node_name"), **kwargs
                 )
                 yield row
 

--- a/nise/jinja_ext.py
+++ b/nise/jinja_ext.py
@@ -1,0 +1,35 @@
+#
+# Copyright 2020 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""Jinja2 extensions."""
+from faker import Faker
+
+FAKE = Faker()
+
+
+def faker_passthrough(provider, **kwargs):
+    """Expose faker inside of a Jinja template.
+
+    Example:
+
+        {{ faker('faker_provider', keyword_arg=1, keyword_arg=other) }}
+
+    The first argument MUST be the faker provider being called.
+
+    All keyword arguments are passed through to the Faker object using the named provider.
+
+    """
+    return getattr(FAKE, provider)(**kwargs)

--- a/nise/util/__init__.py
+++ b/nise/util/__init__.py
@@ -45,7 +45,7 @@ def deepupdate(original, update):
 
     original and update must have the same structure
     """
-    if not (isinstance(update, list) or isinstance(update, dict)):
+    if not isinstance(update, (list, dict)):
         return update
 
     if isinstance(update, dict):

--- a/nise/util/__init__.py
+++ b/nise/util/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018 Red Hat, Inc.
+# Copyright 2020 Red Hat, Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -15,8 +15,6 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 """Utility functions."""
-from collections import abc
-
 import yaml
 
 from .log import LOG  # noqa: F401
@@ -43,15 +41,22 @@ def load_yaml(objekt):
 
 
 def deepupdate(original, update):
-    """Recursively update a dict.
+    """Recursively update a nested dict/list.
 
-    Subdict's won't be overwritten but also updated.
+    original and update must have the same structure
     """
-    if not isinstance(original, abc.Mapping):
+    if not (isinstance(update, list) or isinstance(update, dict)):
         return update
-    for key, value in update.items():
-        if isinstance(value, abc.Mapping):
+
+    if isinstance(update, dict):
+        for key, value in update.items():
             original[key] = deepupdate(original.get(key, {}), value)
-        else:
-            original[key] = value
+
+    if isinstance(update, list):
+        for idx, item in enumerate(update):
+            if len(original) < idx:
+                original.append(item)
+            else:
+                original[idx] = deepupdate(original[idx], update[idx])
+
     return original

--- a/nise/yaml_generators/static/ocp_static_data.yml.j2
+++ b/nise/yaml_generators/static/ocp_static_data.yml.j2
@@ -5,40 +5,37 @@ generators:
       end_date: {{generator.end_date}}
       nodes:
         {% for node in generator.nodes %}# start node loop
-        - node:
-          node_name: {{node.name}}
+        - node_name: {{node.name}}
           cpu_cores: {{node.cpu_cores}}
           memory_gig: {{node.memory_gig}}
           resource_id: {{node.resource_id}}
+          labels: {{node.labels}}
           namespaces:
-            {% for namespace in node.namespaces %}# start namespace loop
-            {{namespace.name}}:
+            {% for namespace in node.namespaces %}{# start namespace loop #}
+            - namespace_name: {{namespace.namespace_name}}
               pods:
-                {% for pod in namespace.pods %}# start pod loop
-                - pod:
-                  pod_name: {{pod.name}}
+                {% for pod in namespace.pods %}{# start pod loop #}
+                - pod_name: {{pod.pod_name}}
                   cpu_request: {{pod.cpu_request}}
                   mem_request_gig: {{pod.mem_request_gig}}
                   cpu_limit: {{pod.cpu_limit}}
                   mem_limit_gig: {{pod.mem_limit_gig}}
                   pod_seconds: {{pod.pod_seconds}}
                   labels: {{pod.labels}}
-                {% endfor %}# end pod loop
+                {% endfor %}{# end pod loop #}
               volumes:
-                {% for volume in namespace.volumes %}# start volume loop
-                - volume:
-                  volume_name: {{volume.name}}
+                {% for volume in namespace.volumes %}{# start volume loop #}
+                - volume_name: {{volume.volume_name}}
                   storage_class: {{volume.storage_class}}
                   volume_request_gig: {{volume.volume_request_gig}}
                   labels: {{volume.labels}}
                   volume_claims:
                   {% for volume_claim in volume.volume_claims %}# start volume-claim loop
-                  - volume_claim:
-                    volume_claim_name: {{volume_claim.name}}
+                  - volume_claim_name: {{volume_claim.volume_claim_name}}
                     pod_name: {{volume_claim.pod_name}}
                     labels: {{volume_claim.labels}}
                     capacity_gig: {{volume_claim.capacity_gig}}
-                  {% endfor %}# end volume claim loop
-                {% endfor %}# end volume loop
-            {% endfor %}# end namespace loop
-        {% endfor %}# end node loop
+                  {% endfor %}{# end volume claim loop #}
+                {% endfor %}{# end volume loop #}
+            {% endfor %}{# end namespace loop #}
+        {% endfor %}{# end node loop #}

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -139,7 +139,7 @@ class MiscReportTestCase(TestCase):
 
     def test_get_generators(self):
         """Test the _get_generators helper function."""
-        generators = _get_generators(None)
+        generators = _get_generators()
         self.assertEqual(generators, [])
 
         generator_list = [{"EC2Generator": {"start_date": "2019-01-21", "end_date": "2019-01-22"}}]

--- a/tests/test_yaml_generators/test_yaml_ocp_generator.py
+++ b/tests/test_yaml_generators/test_yaml_ocp_generator.py
@@ -85,13 +85,13 @@ class OCPGeneratorTestCase(TestCase):
             return v_min <= val <= config_val
 
         def validate_data(data, config, check_func):
-            node_keys = sorted(["name", "cpu_cores", "memory_gig", "resource_id", "namespaces"])
-            namespace_keys = sorted(["name", "pods", "volumes"])
+            node_keys = sorted(["name", "cpu_cores", "labels", "memory_gig", "resource_id", "namespaces"])
+            namespace_keys = sorted(["namespace_name", "pods", "volumes"])
             pod_keys = sorted(
-                ["name", "cpu_request", "mem_request_gig", "cpu_limit", "mem_limit_gig", "pod_seconds", "labels"]
+                ["pod_name", "cpu_request", "mem_request_gig", "cpu_limit", "mem_limit_gig", "pod_seconds", "labels"]
             )
-            volume_keys = sorted(["name", "storage_class", "volume_request_gig", "labels", "volume_claims"])
-            volume_claim_keys = sorted(["name", "pod_name", "labels", "capacity_gig"])
+            volume_keys = sorted(["volume_name", "storage_class", "volume_request_gig", "labels", "volume_claims"])
+            volume_claim_keys = sorted(["volume_claim_name", "pod_name", "labels", "capacity_gig"])
 
             self.assertTrue(isinstance(data, self.module.dicta))
 
@@ -107,10 +107,10 @@ class OCPGeneratorTestCase(TestCase):
 
                 for namespace in node.namespaces:
                     self.assertEqual(sorted(namespace.keys()), namespace_keys)
-                    self.assertTrue(namespace.name is not None and namespace.name != "")
+                    self.assertTrue(namespace.namespace_name is not None and namespace.namespace_name != "")
                     self.assertTrue(check_func(len(namespace.pods), config.max_node_namespace_pods))
                     self.assertTrue(check_func(len(namespace.volumes), config.max_node_namespace_volumes))
-                    pod_names = [p.name for p in namespace.pods]
+                    pod_names = [p.pod_name for p in namespace.pods]
 
                     for pod in namespace.pods:
                         self.assertEqual(sorted(pod.keys()), pod_keys)
@@ -126,7 +126,7 @@ class OCPGeneratorTestCase(TestCase):
                             )
                         )
                         self.assertEqual(len(pod.labels.split("|")), config.max_node_namespace_pod_labels)
-                        self.assertTrue(pod.name is not None and pod.name != "")
+                        self.assertTrue(pod.pod_name is not None and pod.pod_name != "")
 
                     for volume in namespace.volumes:
                         self.assertEqual(sorted(volume.keys()), volume_keys)
@@ -135,7 +135,7 @@ class OCPGeneratorTestCase(TestCase):
                             check_func(volume.volume_request_gig, config.max_node_namespace_volume_request_gig)
                         )
                         self.assertEqual(len(volume.labels.split("|")), config.max_node_namespace_volume_labels)
-                        self.assertTrue(volume.name is not None and volume.name != "")
+                        self.assertTrue(volume.volume_name is not None and volume.volume_name != "")
                         self.assertTrue(
                             check_func(len(volume.volume_claims), config.max_node_namespace_volume_volume_claims)
                         )
@@ -146,7 +146,9 @@ class OCPGeneratorTestCase(TestCase):
                                 len(volume_claim.labels.split("|")),
                                 config.max_node_namespace_volume_volume_claim_labels,
                             )
-                            self.assertTrue(volume_claim.name is not None and volume_claim.name != "")
+                            self.assertTrue(
+                                volume_claim.volume_claim_name is not None and volume_claim.volume_claim_name != ""
+                            )
                             self.assertTrue(volume_claim.pod_name in pod_names)
                             self.assertTrue(
                                 check_func(


### PR DESCRIPTION
This PR is the first in a series. This implements a base Jinja template that defines the configuration for each Generator. This PR implements the change for the OCPGenerator only. The other Generators are unaffected by this change. There is some initial plumbing done in the other generators, but it is not yet used. Future PRs will implement the necessary integration for the other generators.

There are some minor naming changes that impact the structure of the static files. So, this PR won't be merged until corresponding updates are staged for the IQE test suite.

This PR does three main things. 

The first benefit, is that it removes unnecessary branching between the "with static file" and "without static file" code paths. 

Second, less branching increases the consistency of the output. There are fewer places for bugs to hide. 

Third, this enables static files to only need to define the details that a user cares about. Any parameters left undefined by the user are generated and included as part of the base template.