### PR TITLE
add branch 2.0

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -2,7 +2,9 @@ name: pre-commit
 
 on:
   pull_request:
-    branches: [master]
+    branches:
+      - master
+      - 2.0
 
 jobs:
   pre-commit:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - 2.0
 
 jobs:
   build-n-publish:

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -2,7 +2,9 @@ name: Unit Tests
 
 on:
   pull_request:
-    branches: [master]
+    branches:
+      - master
+      - 2.0
 
 jobs:
   build:


### PR DESCRIPTION
Add branch 2.0 to github actions. Allows us to run actions against branch 2.0.