### PR TITLE
Azure: Define meter_cache in azure yamls

### DIFF
--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.0.14"
+__version__ = "2.0.15"
 VERSION = __version__.split(".")

--- a/nise/report.py
+++ b/nise/report.py
@@ -549,6 +549,8 @@ def azure_create_report(options):  # noqa: C901
 
             gen_start_date, gen_end_date = _create_generator_dates_from_yaml(attributes, month)
 
+            if attributes.get("meter_cache"):
+                meter_cache.update(attributes.get("meter_cache"))  # needed so that meter_cache can be defined in yaml
             attributes["meter_cache"] = meter_cache
             gen = generator_cls(gen_start_date, gen_end_date, payer_account, usage_accounts, attributes)
             data += gen.generate_data()


### PR DESCRIPTION
- this enables us to define a meter_cache so that we can specify a particular `SERVICE_METER` for a given generator.