### PR TITLE
COST-423: Fix nise data generation hours part two

### DIFF
--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.0.16"
+__version__ = "2.0.17"
 VERSION = __version__.split(".")

--- a/nise/__main__.py
+++ b/nise/__main__.py
@@ -34,6 +34,8 @@ from nise.util import LOG_VERBOSITY
 from nise.yaml_gen import add_yaml_parser_args
 from nise.yaml_gen import yaml_main
 
+os.environ["TZ"] = "UTC"
+
 
 class NiseError(Exception):
     """A Nise Exception class."""

--- a/nise/report.py
+++ b/nise/report.py
@@ -336,14 +336,14 @@ def _create_generator_dates_from_yaml(attributes, month):
         hour=23, minute=59, second=59
     ):
         gen_start_date = month.get("start")
-        gen_end_date = attributes.get("end_date").replace(hour=23, minute=59)
+        gen_end_date = attributes.get("end_date")
 
     # Generator is within month
     if attributes.get("start_date") >= month.get("start") and attributes.get("end_date") <= month.get("end").replace(
         hour=23, minute=59, second=59
     ):
         gen_start_date = attributes.get("start_date")
-        gen_end_date = attributes.get("end_date").replace(hour=23, minute=59)
+        gen_end_date = attributes.get("end_date")
 
     # Generator starts within month and ends in next month
     if attributes.get("start_date") >= month.get("start") and attributes.get("end_date") > month.get("end").replace(


### PR DESCRIPTION
Looking into why this smoke test is failing:

```
________________ test_api_ocp_source_crud_upload_service ________________ 

supplied = 32.0, expected = 48.0, tolerance = 1

    def tolerance_value(supplied, expected, tolerance):
        """Function for asserting raw calc values with a small tolerance as hourly dependent
        data/results can increment during a test or rounding issues."""
>       assert abs(expected - supplied) <= tolerance, "Raw calculated value does not match report value"
E       AssertionError: Raw calculated value does not match report value
E       assert 16.0 <= 1
E        +  where 16.0 = abs((48.0 - 32.0))

lib64/python3.6/site-packages/iqe_cost_management/fixtures/helpers.py:690: AssertionError
```