### PR TITLE
COST-587: Update nise to generate new Azure export files.

### DIFF
--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.1.6"
+__version__ = "2.2.0"
 VERSION = __version__.split(".")

--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.0.18"
+__version__ = "2.1.6"
 VERSION = __version__.split(".")

--- a/nise/__main__.py
+++ b/nise/__main__.py
@@ -129,7 +129,7 @@ def add_azure_parser_args(parser):
         dest="version_two",
         action="store_true",
         required=False,
-        help="Writes the monthly files.",
+        help="Generate version two of the azure report.",
     )
 
 

--- a/nise/__main__.py
+++ b/nise/__main__.py
@@ -123,6 +123,14 @@ def add_azure_parser_args(parser):
         default=os.getenv("AZURE_STORAGE_ACCOUNT"),
         help="Azure container to place the data.",
     )
+    parser.add_argument(
+        "-v2",
+        "--version-two",
+        dest="version_two",
+        action="store_true",
+        required=False,
+        help="Writes the monthly files.",
+    )
 
 
 def add_gcp_parser_args(parser):

--- a/nise/generators/azure/__init__.py
+++ b/nise/generators/azure/__init__.py
@@ -16,6 +16,7 @@
 #
 """Module for azure data generators."""
 from nise.generators.azure.azure_generator import AZURE_COLUMNS  # noqa: F401
+from nise.generators.azure.azure_generator import AZURE_COLUMNS_V2  # noqa: F401
 from nise.generators.azure.azure_generator import AzureGenerator  # noqa: F401
 from nise.generators.azure.bandwidth_generator import BandwidthGenerator  # noqa: F401
 from nise.generators.azure.sql_database_generator import SQLGenerator  # noqa: F401

--- a/nise/generators/azure/azure_generator.py
+++ b/nise/generators/azure/azure_generator.py
@@ -50,6 +50,61 @@ AZURE_COLUMNS = (
     "UnitOfMeasure",
 )
 
+AZURE_COLUMNS_V2 = (
+    "InvoiceSectionName",
+    "AccountName",
+    "AccountOwnerId",
+    "SubscriptionId",
+    "SubscriptionName",
+    "ResourceGroup",
+    "ResourceLocation",
+    "Date",
+    "ProductName",
+    "MeterCategory",
+    "MeterSubCategory",
+    "MeterId",
+    "MeterName",
+    "MeterRegion",
+    "UnitOfMeasure",
+    "Quantity",
+    "EffectivePrice",
+    "CostInBillingCurrency",
+    "CostCenter",
+    "ConsumedService",
+    "ResourceId",
+    "Tags",
+    "OfferId",
+    "AdditionalInfo",
+    "ServiceInfo1",
+    "ServiceInfo2",
+    "ResourceName",
+    "ReservationId",
+    "ReservationName",
+    "UnitPrice",
+    "ProductOrderId",
+    "ProductOrderName",
+    "Term",
+    "PublisherType",
+    "PublisherName",
+    "ChargeType",
+    "Frequency",
+    "PricingModel",
+    "AvailabilityZone",
+    "BillingAccountId",
+    "BillingAccountName",
+    "BillingCurrencyCode",
+    "BillingPeriodStartDate",
+    "BillingPeriodEndDate",
+    "BillingProfileId",
+    "BillingProfileName",
+    "InvoiceSectionId",
+    "IsAzureCreditEligible",
+    "PartNumber",
+    "PayGPrice",
+    "PlanName",
+    "ServiceFamily",
+)
+
 
 class AzureGenerator(AbstractGenerator):
     """Defines an abstract class for generators."""
@@ -106,6 +161,7 @@ class AzureGenerator(AbstractGenerator):
         self._consumed = None
         self._resource_type = None
         self._meter_cache = {}
+        self.azure_columns = AZURE_COLUMNS
 
         if attributes:
             if attributes.get("instance_id"):
@@ -124,6 +180,8 @@ class AzureGenerator(AbstractGenerator):
                 self._tags = attributes.get("tags")
             if attributes.get("meter_cache"):
                 self._meter_cache = attributes.get("meter_cache")
+            if attributes.get("version_two"):
+                self.azure_columns = AZURE_COLUMNS_V2
         super().__init__(start_date, end_date)
 
     def _get_accts_str(self, service_name):
@@ -194,10 +252,8 @@ class AzureGenerator(AbstractGenerator):
             raise ValueError("end must be a date object.")
 
         row = {}
-        for column in AZURE_COLUMNS:
+        for column in self.azure_columns:
             row[column] = ""
-            if column == "SubscriptionGuid":
-                row[column] = self.payer_account
         return row
 
     def _get_location(self):
@@ -210,8 +266,12 @@ class AzureGenerator(AbstractGenerator):
 
     def _add_common_usage_info(self, row, start, end, **kwargs):
         """Add common usage information."""
-        row["SubscriptionGuid"] = self.payer_account
-        row["UsageDateTime"] = start
+        if self.azure_columns == AZURE_COLUMNS_V2:
+            row["SubscriptionId"] = self.payer_account
+            row["Date"] = start.date().strftime("%m/%d/%Y")
+        else:
+            row["SubscriptionGuid"] = self.payer_account
+            row["UsageDateTime"] = start
         return row
 
     def _add_tag_data(self, row):
@@ -251,26 +311,36 @@ class AzureGenerator(AbstractGenerator):
         row["ResourceGroup"] = resource_group
         row["ResourceLocation"] = azure_region
         row["MeterCategory"] = self._service_name
-        row["MeterSubcategory"] = meter_sub
         row["MeterId"] = str(meter_id)
         row["MeterName"] = meter_name
         row["MeterRegion"] = meter_region
-        row["UsageQuantity"] = str(amount)
-        row["ResourceRate"] = str(rate)
-        row["PreTaxCost"] = str(cost)
         row["ConsumedService"] = self._consumed
-        row["ResourceType"] = self._resource_type
-        row["InstanceId"] = instance_id
         row["OfferId"] = ""
         row["AdditionalInfo"] = json.dumps(additional_info)
         row["ServiceInfo1"] = ""
         row["ServiceInfo2"] = service_info_2
-        row["ServiceName"] = self._service_name
-        row["ServiceTier"] = service_tier
-        row["Currency"] = "USD"
         row["UnitOfMeasure"] = units_of_measure
+        row = self._map_header_to_report_version(row, meter_sub, str(amount), str(rate), str(cost), instance_id)
         self._add_tag_data(row)
 
+        return row
+
+    def _map_header_to_report_version(self, row, meter_sub, amount, rate, cost, instance_id):
+        if self.azure_columns == AZURE_COLUMNS_V2:
+            row["MeterSubCategory"] = meter_sub
+            row["Quantity"] = amount
+            row["EffectivePrice"] = rate
+            row["CostInBillingCurrency"] = cost
+            row["ResourceId"] = instance_id
+            row["BillingCurrencyCode"] = "MC"
+        else:
+            row["MeterSubcategory"] = meter_sub
+            row["UsageQuantity"] = amount
+            row["ResourceRate"] = rate
+            row["PreTaxCost"] = cost
+            row["InstanceId"] = instance_id
+            row["Currency"] = "USD"
+            row["ResourceType"] = self._resource_type
         return row
 
     def _generate_hourly_data(self, **kwargs):

--- a/nise/generators/azure/azure_generator.py
+++ b/nise/generators/azure/azure_generator.py
@@ -320,12 +320,14 @@ class AzureGenerator(AbstractGenerator):
         row["ServiceInfo1"] = ""
         row["ServiceInfo2"] = service_info_2
         row["UnitOfMeasure"] = units_of_measure
-        row = self._map_header_to_report_version(row, meter_sub, str(amount), str(rate), str(cost), instance_id)
+        row = self._map_header_to_report_version(
+            row, meter_sub, str(amount), str(rate), str(cost), instance_id, service_tier
+        )
         self._add_tag_data(row)
 
         return row
 
-    def _map_header_to_report_version(self, row, meter_sub, amount, rate, cost, instance_id):
+    def _map_header_to_report_version(self, row, meter_sub, amount, rate, cost, instance_id, service_tier):
         if self.azure_columns == AZURE_COLUMNS_V2:
             row["MeterSubCategory"] = meter_sub
             row["Quantity"] = amount
@@ -340,7 +342,10 @@ class AzureGenerator(AbstractGenerator):
             row["PreTaxCost"] = cost
             row["InstanceId"] = instance_id
             row["Currency"] = "USD"
+            # Version one specific
             row["ResourceType"] = self._resource_type
+            row["ServiceName"] = self._service_name
+            row["ServiceTier"] = service_tier
         return row
 
     def _generate_hourly_data(self, **kwargs):

--- a/nise/report.py
+++ b/nise/report.py
@@ -23,7 +23,6 @@ import gzip
 import importlib
 import json
 import os
-import pprint
 import random
 import shutil
 import string
@@ -68,8 +67,6 @@ from nise.upload import upload_to_azure_container
 from nise.upload import upload_to_gcp_storage
 from nise.upload import upload_to_s3
 from nise.util import LOG
-
-pp = pprint.PrettyPrinter()
 
 
 def create_temporary_copy(path, temp_file_name, temp_dir_name="None"):

--- a/nise/report.py
+++ b/nise/report.py
@@ -23,6 +23,7 @@ import gzip
 import importlib
 import json
 import os
+import pprint
 import random
 import shutil
 import string
@@ -47,7 +48,6 @@ from nise.generators.aws import RDSGenerator
 from nise.generators.aws import Route53Generator
 from nise.generators.aws import S3Generator
 from nise.generators.aws import VPCGenerator
-from nise.generators.azure import AZURE_COLUMNS
 from nise.generators.azure import BandwidthGenerator
 from nise.generators.azure import SQLGenerator
 from nise.generators.azure import StorageGenerator
@@ -68,6 +68,8 @@ from nise.upload import upload_to_azure_container
 from nise.upload import upload_to_gcp_storage
 from nise.upload import upload_to_s3
 from nise.util import LOG
+
+pp = pprint.PrettyPrinter()
 
 
 def create_temporary_copy(path, temp_file_name, temp_dir_name="None"):
@@ -526,6 +528,7 @@ def azure_create_report(options):  # noqa: C901
     storage_account_name = options.get("azure_account_name")
     azure_prefix_name = options.get("azure_prefix_name")
     azure_report_name = options.get("azure_report_name")
+    version_two = options.get("version_two", False)
     write_monthly = options.get("write_monthly", False)
     for month in months:
         data = []
@@ -552,7 +555,9 @@ def azure_create_report(options):  # noqa: C901
             if attributes.get("meter_cache"):
                 meter_cache.update(attributes.get("meter_cache"))  # needed so that meter_cache can be defined in yaml
             attributes["meter_cache"] = meter_cache
+            attributes["version_two"] = version_two
             gen = generator_cls(gen_start_date, gen_end_date, payer_account, usage_accounts, attributes)
+            azure_columns = gen.azure_columns
             data += gen.generate_data()
             meter_cache = gen.get_meter_cache()
 
@@ -562,7 +567,7 @@ def azure_create_report(options):  # noqa: C901
         local_path, output_file_name = _generate_azure_filename()
         date_range = _generate_azure_date_range(month)
 
-        _write_csv(local_path, data, AZURE_COLUMNS)
+        _write_csv(local_path, data, azure_columns)
         monthly_files.append(local_path)
 
         if azure_container_name:


### PR DESCRIPTION
I added a `-v2` flag to use the version two of the report.
- ` -v2, --version-two    Generate version two of the azure report.`


### How to test
```
nise yaml azure -o azure_test.yaml
make install && nise report azure -w --static-report-file azure_test.yaml -v2
```

I added the -w flag so that way the monthly files would be produced. Then I pull that csv up on my computer to compare the different headers and values between azure report version one and azure report version two.

What I have left to do:

- [x] Run one of these azure reports through the koku server to make sure its processed correctly.

----
### Smoke Tests
```===== 3957 passed, 80 skipped, 1736 deselected in 1884.97s (0:31:24) =====```