### PR TITLE
Respect CLI dates when using static YML

### DIFF
--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.2.0"
+__version__ = "2.2.1"
 VERSION = __version__.split(".")

--- a/nise/__main__.py
+++ b/nise/__main__.py
@@ -452,11 +452,14 @@ def _load_static_report_data(options):
     static_report_data = load_yaml(options.get("static_report_file"))
     for generator_dict in static_report_data.get("generators"):
         for _, attributes in generator_dict.items():
-            generated_start_date = calculate_start_date(attributes.get("start_date"))
+            start_date = get_start_date(attributes, options)
+            generated_start_date = calculate_start_date(start_date)
             start_dates.append(generated_start_date)
 
             if attributes.get("end_date"):
                 generated_end_date = calculate_end_date(generated_start_date, attributes.get("end_date"))
+            elif options.get("end_date"):
+                generated_end_date = calculate_end_date(generated_start_date, options.get("end_date"))
             else:
                 generated_end_date = today()
             if options.get("provider") == "azure":
@@ -480,6 +483,15 @@ def _load_static_report_data(options):
 
     return True
 
+
+def get_start_date(attributes, options):
+    """Gets a start date from from yml or cli, returns None if neither"""
+    if attributes.get("start_date"):
+        return attributes.get("start_date")
+    elif options.get("start_date"):
+        return options.get("start_date")
+    else:
+        return None
 
 def calculate_start_date(start_date):
     """Return a datetime for the start date."""

--- a/nise/__main__.py
+++ b/nise/__main__.py
@@ -493,6 +493,7 @@ def get_start_date(attributes, options):
     else:
         return None
 
+
 def calculate_start_date(start_date):
     """Return a datetime for the start date."""
     if start_date == "last_month":

--- a/nise/__main__.py
+++ b/nise/__main__.py
@@ -458,7 +458,7 @@ def _load_static_report_data(options):
 
             if attributes.get("end_date"):
                 generated_end_date = calculate_end_date(generated_start_date, attributes.get("end_date"))
-            elif options.get("end_date"):
+            elif options.get("end_date") and options.get("end_date").date() != today().date():
                 generated_end_date = calculate_end_date(generated_start_date, options.get("end_date"))
             else:
                 generated_end_date = today()


### PR DESCRIPTION
When using a static yml file, cli start and end dates were ignored. This changes that and will prioritize dates in the yml first then use the cli dates if they are not defined in the yml.

Testing: 
This yml (remove the .txt, github won't let you upload a yml) has a defined start and end date for the first generator but not any of the following ones. Using the following: 
`nise report aws --static-report-file /PATH/TO/YML/example_aws_data.yml -s 2020-10-04 -e 2020-10-10 -w`
will generate a csv and you will see the start and end dates align with what is in the yml for info from the first generator, followed by the cli arguments for the rest.
[example_aws_data.yml.txt](https://github.com/project-koku/nise/files/5373005/example_aws_data.yml.txt)
