### PR TITLE
Clarify OCP upload error

### DIFF
--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.2.1"
+__version__ = "2.2.2"
 VERSION = __version__.split(".")

--- a/nise/__main__.py
+++ b/nise/__main__.py
@@ -386,9 +386,10 @@ def _validate_ocp_arguments(parser, options):
             insights_user is None or insights_password is None
         ):
             msg = (
-                "The environment must have \nINSIGHTS_USER and "
-                "INSIGHTS_PASSWORD or\nINSIGHTS_ACCOUNT_ID and INSIGHTS_ORG_ID"
-                "defined when {} {} is supplied."
+                f"\n\t--insights-upload {insights_upload} was supplied as an argument\n"
+                "\tbut this directory does not exist locally. Attempting to upload to Ingress instead, but\n"
+                "\tthe environment must have \n\t\tINSIGHTS_USER and INSIGHTS_PASSWORD\n\tor\n"
+                "\t\tINSIGHTS_ACCOUNT_ID and INSIGHTS_ORG_ID\n\tdefined when attempting an upload to Ingress.\n"
             )
             msg = msg.format("--insights-upload", insights_upload)
             parser.error(msg)


### PR DESCRIPTION
This PR clarifies an error that is printed when `--insights-upload` is supplied as an argument when the intention is place the reports locally, but the directory does not exist. Now the error says:

```
(nise) ╭─mskarbek@mskarbek-mac ~/Documents/code/nise ‹master*› 
╰─$ nise report ocp --insights-upload /this/is/a/fake/folder --ocp-cluster-id my-cluster -s 2020-10-01
usage: nise [-h] [-l] [-v] {report,yaml} ...
nise: error: 
        --insights-upload /this/is/a/fake/folder was supplied as an argument
        but this directory does not exist locally. Attempting to upload to Ingress instead, but
        the environment must have 
                INSIGHTS_USER and INSIGHTS_PASSWORD
        or
                INSIGHTS_ACCOUNT_ID and INSIGHTS_ORG_ID
        defined when attempting an upload to Ingress.

```