### PR TITLE
fix intermittent failing capacity test

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -2,6 +2,7 @@ name: Unit Tests
 
 on:
   pull_request:
+  push:
     branches:
       - master
       - 2.0

--- a/tests/test_ocp_generator.py
+++ b/tests/test_ocp_generator.py
@@ -35,6 +35,7 @@ from nise.generators.ocp.ocp_generator import OCPGenerator
 
 MAX_VOL_GIGS = 80
 
+
 class OCPGeneratorTestCase(TestCase):
     """TestCase class for OCP Generator."""
 

--- a/tests/test_ocp_generator.py
+++ b/tests/test_ocp_generator.py
@@ -90,12 +90,12 @@ class OCPGeneratorTestCase(TestCase):
                             "volumes": [
                                 {
                                     "volume_name": f"vol_{self.fake.word()}",
-                                    "volume_request_gig": self.fake.pyint(1, 100),
+                                    "volume_request_gig": self.fake.pyint(1, 80),
                                     "volume_claims": [
                                         {
                                             "volume_claim_name": f"volumeclaim_{self.fake.word()}",
                                             "pod_name": f"pod_{self.fake.word()}",
-                                            "capacity_gig": self.fake.pyint(1, 100),
+                                            "capacity_gig": self.fake.pyint(1, 80),
                                             "volume_claim_usage_gig": self._usage_dict(),
                                             "labels": (
                                                 f"label_{self.fake.word()}:{self.fake.word()}",

--- a/tests/test_ocp_generator.py
+++ b/tests/test_ocp_generator.py
@@ -33,6 +33,7 @@ from nise.generators.ocp.ocp_generator import OCP_STORAGE_COLUMNS
 from nise.generators.ocp.ocp_generator import OCP_STORAGE_USAGE
 from nise.generators.ocp.ocp_generator import OCPGenerator
 
+MAX_VOL_GIGS = 80
 
 class OCPGeneratorTestCase(TestCase):
     """TestCase class for OCP Generator."""
@@ -90,12 +91,12 @@ class OCPGeneratorTestCase(TestCase):
                             "volumes": [
                                 {
                                     "volume_name": f"vol_{self.fake.word()}",
-                                    "volume_request_gig": self.fake.pyint(1, 80),
+                                    "volume_request_gig": self.fake.pyint(1, MAX_VOL_GIGS),
                                     "volume_claims": [
                                         {
                                             "volume_claim_name": f"volumeclaim_{self.fake.word()}",
                                             "pod_name": f"pod_{self.fake.word()}",
-                                            "capacity_gig": self.fake.pyint(1, 80),
+                                            "capacity_gig": self.fake.pyint(1, MAX_VOL_GIGS),
                                             "volume_claim_usage_gig": self._usage_dict(),
                                             "labels": (
                                                 f"label_{self.fake.word()}:{self.fake.word()}",
@@ -442,7 +443,7 @@ class OCPGeneratorTestCase(TestCase):
                                 if attributes:
                                     for value in claim.get("volume_claim_usage_gig").values():
                                         self.assertLessEqual(value * GIGABYTE, capacity)
-                        self.assertLessEqual(total_capacity, volume.get("volume_request_gig", 80.0 * GIGABYTE))
+                        self.assertLessEqual(total_capacity, volume.get("volume_request_gig", MAX_VOL_GIGS * GIGABYTE))
 
     def test_generate_hourly_data(self):
         """Test that generate_hourly_data calls the test method."""


### PR DESCRIPTION
The request and capacity gig attributes could be up to 100, but the test was asserting less than or equal to 80. This PR brings these values into alignment. 