### PR TITLE
update pre-commit

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,10 +14,4 @@ jobs:
     - uses: actions/setup-python@v2
       with:
         python-version: '3.6'
-    - name: set PY
-      run: echo "::set-env name=PY::$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')"
-    - uses: actions/cache@v1
-      with:
-        path: ~/.cache/pre-commit
-        key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
-    - uses: pre-commit/action@v1.0.1
+    - uses: pre-commit/action@v2.0.0


### PR DESCRIPTION
The pre-commit action was updated to v2.0.0. This new version handles caching, so caching was removed from our action.

This PR also addresses a [deprecation warning](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/).