### PR TITLE
Fix setting of timezone to UTC

### DIFF
--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.2.2"
+__version__ = "2.2.3"
 VERSION = __version__.split(".")

--- a/nise/__main__.py
+++ b/nise/__main__.py
@@ -19,6 +19,7 @@ import argparse
 import calendar
 import datetime
 import os
+import time
 from pprint import pformat
 
 from dateutil import parser as date_parser
@@ -35,6 +36,7 @@ from nise.yaml_gen import add_yaml_parser_args
 from nise.yaml_gen import yaml_main
 
 os.environ["TZ"] = "UTC"
+time.tzset()
 
 
 class NiseError(Exception):


### PR DESCRIPTION
`os.environ["TZ"] = "UTC" ` does not work without `time.tzset() `
This change should synchronize time zone settings between nise and cost_management plugin