### PR TITLE
fixed typo in Doc file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,7 @@ venv.bak/
 # mypy
 .mypy_cache/
 
+.idea
 .vscode
 *.sw[po]
 *.code-workspace

--- a/docs/cost_usage_report_generation.rst
+++ b/docs/cost_usage_report_generation.rst
@@ -141,7 +141,7 @@ To upload report files to ingress service::
 
 To move the generated data into a specific local directory::
 
-    nise reprot ocp  -s 2020-06-03 --ocp-cluster-id test-001 --insights-upload  /local/path/dir
+    nise report ocp  -s 2020-06-03 --ocp-cluster-id test-001 --insights-upload  /local/path/dir
 
 To use a static yaml to generate data::
 


### PR DESCRIPTION
Simple doc typo fix "report" was spelled wrong in one of the examples.