### PR TITLE
Examples are not using the correct cli args

### DIFF
--- a/docs/working_with_masu.rst
+++ b/docs/working_with_masu.rst
@@ -29,7 +29,7 @@ To create and ingest OCP sample data, there are three required pieces of informa
 
 ::
 
-  nise --ocp --ocp-cluster-id $(cluster_id) --insights-upload testing/pvc_dir/insights_local --static-report-file $(srf_yaml)
+  nise report ocp --ocp-cluster-id $(cluster_id) --insights-upload testing/pvc_dir/insights_local --static-report-file $(srf_yaml)
 .. highlight:: none
 
 **Step Two: Create the Provider**
@@ -72,7 +72,7 @@ To create and ingest AWS sample data, there are three required pieces of informa
 
 ::
 
-  nise --aws --static-report-file $(srf_yaml) --aws-s3-bucket-name testing/local_providers/aws_local --aws-s3-report-name $(report_name)
+  nise report aws --static-report-file $(srf_yaml) --aws-s3-bucket-name testing/local_providers/aws_local --aws-s3-report-name $(report_name)
 .. highlight:: none
 
 **Step Three: Create the AWS provider**


### PR DESCRIPTION
**Example of current command shown**
`> nise --ocp --ocp-cluster-id ${CLUSTER_ID} --insights-upload ${INSIGHTS_LOCAL_DIR} --static-report-file examples/ocp_on_aws/aws_static_data.yml 
usage: nise [-h] [-l] [-v] {report,yaml} ...
nise: error: argument command: invalid choice: 'dd-test-cluster' (choose from 'report', 'yaml')
`


**Example of valid command:**
`> nise report ocp --ocp-cluster-id ${CLUSTER_ID} --insights-upload ${INSIGHTS_LOCAL_DIR} --static-report-file examples/ocp_on_aws/ocp_static_data.yml`