### PR TITLE
Nise enhancements to help QE and some yaml fixes

### DIFF
--- a/nise/generators/gcp/cloud_storage_generator.py
+++ b/nise/generators/gcp/cloud_storage_generator.py
@@ -84,15 +84,7 @@ class CloudStorageGenerator(GCPGenerator):
 
     def generate_data(self, report_type=None):
         """Generate GCP compute data for some days."""
-        days = self._create_days_list(self.start_date, self.end_date)
-        data = {}
-        for day in days:
-            rows = []
-            row = self._init_data_row(day["start"], day["end"])
-            row = self._update_data(row)
-            rows.append(row)
-            data[day["start"]] = rows
-        return data
+        return self._generate_hourly_data()
 
 
 class JSONLCloudStorageGenerator(CloudStorageGenerator):
@@ -159,13 +151,4 @@ class JSONLCloudStorageGenerator(CloudStorageGenerator):
 
     def generate_data(self, report_type=None):
         """Generate GCP compute data for some days."""
-        days = self._create_days_list(self.start_date, self.end_date)
-        data = {}
-        for day in days:
-            rows = []
-            for _ in range(self.num_instances):
-                row = self._init_data_row(day["start"], day["end"])
-                row = self._update_data(row)
-                rows.append(row)
-            data[day["start"]] = rows
-        return data
+        return self._generate_hourly_data()

--- a/nise/generators/gcp/cloud_storage_generator.py
+++ b/nise/generators/gcp/cloud_storage_generator.py
@@ -62,7 +62,12 @@ class CloudStorageGenerator(GCPGenerator):
 
         # All upper and lower bound values were estimated for each unit
         # Currently our only usage unit & pricing unit is bytes-seconds & gibibyte month
-        amount = self.fake.pyint(min_value=1000, max_value=100000)
+        if self.attributes:
+            if self.attributes.get("usage.amount"):
+                amount = self.attributes.get("usage.amount")
+                amount_defined = True
+        if not amount_defined:
+            amount = self.fake.pyint(min_value=1000, max_value=100000)
         row["usage.amount"] = amount
         row["usage.amount_in_pricing_units"] = amount * 0.00244752
         row["credits"] = "[]"
@@ -120,26 +125,14 @@ class JSONLCloudStorageGenerator(CloudStorageGenerator):
         usage["pricing_unit"] = pricing_unit
         row["labels"] = choice(self.LABELS)
         row["system_labels"] = choice(self.SYSTEM_LABELS)
-        usage["amount"] = 0
-
-        # All upper and lower bound values were estimated for each unit
-        if usage_unit == "byte-seconds":
-            amount = self.fake.pyint(min_value=1000, max_value=100000)
-            usage["amount"] = amount
-            if pricing_unit == "gibibyte month":
-                usage["amount_in_pricing_units"] = amount * 0.00244752
-            elif pricing_unit == "gibibyte hour":
-                usage["amount_in_pricing_units"] = amount * (3.3528 * 10 ** -6)
-        elif usage_unit == "bytes":
-            amount = self.fake.pyint(min_value=1000, max_value=10000000)
-            usage["amount"] = amount
-            if pricing_unit == "gibibyte":
-                usage["amount_in_pricing_units"] = amount * (9.31323 * 10 ** -0)
-        elif usage_unit == "seconds":
-            amount = self.fake.pyfloat(max_value=3600, positive=True)
-            usage["amount"] = amount
-            if pricing_unit == "hour":
-                usage["amount_in_pricing_units"] = amount / 3600.00
+        if self.attributes:
+            if self.attributes.get("usage.amount"):
+                amount = self.attributes.get("usage.amount")
+                amount_defined = True
+            if not amount_defined:
+                amount = self.fake.pyint(min_value=1000, max_value=100000)
+        usage["amount"] = amount
+        usage["amount_in_pricing_units"] = amount * 0.00244752
 
         row["usage"] = usage
         row["credits"] = {}

--- a/nise/generators/gcp/cloud_storage_generator.py
+++ b/nise/generators/gcp/cloud_storage_generator.py
@@ -65,7 +65,7 @@ class CloudStorageGenerator(GCPGenerator):
         amount_defined = False
         if self.attributes:
             if self.attributes.get("usage.amount"):
-                amount = self.attributes.get("usage.amount")
+                amount = float(self.attributes.get("usage.amount"))
                 amount_defined = True
         if not amount_defined:
             amount = self.fake.pyint(min_value=1000, max_value=100000)
@@ -130,10 +130,10 @@ class JSONLCloudStorageGenerator(CloudStorageGenerator):
         amount_defined = False
         if self.attributes:
             if self.attributes.get("usage.amount"):
-                amount = self.attributes.get("usage.amount")
+                amount = float(self.attributes.get("usage.amount"))
                 amount_defined = True
-            if not amount_defined:
-                amount = self.fake.pyint(min_value=1000, max_value=100000)
+        if not amount_defined:
+            amount = self.fake.pyint(min_value=1000, max_value=100000)
         usage["amount"] = amount
         usage["amount_in_pricing_units"] = amount * 0.00244752
 

--- a/nise/generators/gcp/cloud_storage_generator.py
+++ b/nise/generators/gcp/cloud_storage_generator.py
@@ -127,6 +127,7 @@ class JSONLCloudStorageGenerator(CloudStorageGenerator):
         usage["pricing_unit"] = pricing_unit
         row["labels"] = choice(self.LABELS)
         row["system_labels"] = choice(self.SYSTEM_LABELS)
+        amount_defined = False
         if self.attributes:
             if self.attributes.get("usage.amount"):
                 amount = self.attributes.get("usage.amount")

--- a/nise/generators/gcp/cloud_storage_generator.py
+++ b/nise/generators/gcp/cloud_storage_generator.py
@@ -51,24 +51,28 @@ class CloudStorageGenerator(GCPGenerator):
         row["service.id"] = service[1]
         row["sku.id"] = sku[0]
         row["sku.description"] = sku[1]
-        row["cost"] = round(uniform(0, 0.01), 7)
         usage_unit = sku[2]
         pricing_unit = sku[3]
         row["usage.unit"] = usage_unit
         row["usage.pricing_unit"] = pricing_unit
         row["labels"] = choice(self.LABELS)
         row["system_labels"] = choice(self.SYSTEM_LABELS)
-        row["usage.amount"] = 0
-        if self.attributes and self.attributes.get("usage.amount"):
-            amount = self.attributes.get("usage.amount")
-        else:
-            amount = self._gen_usage_unit_amount(usage_unit)
-        row["usage.amount"] = amount
-        row["usage.amount_in_pricing_units"] = self._gen_pricing_unit_amount(pricing_unit, amount)
         row["credits"] = "[]"
         row["cost_type"] = "regular"
         row["currency"] = "USD"
         row["currency_conversion_rate"] = 1
+        if self.attributes and self.attributes.get("usage.amount"):
+            row["usage.amount"] = self.attributes.get("usage.amount")
+        else:
+            row["usage.amount"] = self._gen_usage_unit_amount(usage_unit)
+        if self.attributes and self.attributes.get("usage.amount_in_pricing_units"):
+            row["usage.amount_in_pricing_units"] = self.attributes.get("usage.amount_in_pricing_units")
+        else:
+            row["usage.amount_in_pricing_units"] = self._gen_pricing_unit_amount(pricing_unit, row["usage.amount"])
+        if self.attributes and self.attributes.get("price"):
+            row["cost"] = row["usage.amount_in_pricing_units"] * self.attributes.get("price")
+        else:
+            row["cost"] = round(uniform(0, 0.01), 7)
         usage_date = datetime.strptime(row.get("usage_start_time"), "%Y-%m-%dT%H:%M:%S")
         row["invoice.month"] = f"{usage_date.year}{usage_date.month:02d}"
 
@@ -122,11 +126,17 @@ class JSONLCloudStorageGenerator(CloudStorageGenerator):
         row["labels"] = choice(self.LABELS)
         row["system_labels"] = choice(self.SYSTEM_LABELS)
         if self.attributes and self.attributes.get("usage.amount"):
-            amount = self.attributes.get("usage.amount")
+            usage["amount"] = self.attributes.get("usage.amount")
         else:
-            amount = self._gen_usage_unit_amount(usage_unit)
-        usage["amount"] = amount
-        usage["amount_in_pricing_units"] = self._gen_pricing_unit_amount(pricing_unit, amount)
+            usage["amount"] = self._gen_usage_unit_amount(usage_unit)
+        if self.attributes and self.attributes.get("usage.amount_in_pricing_units"):
+            usage["amount_in_pricing_units"] = self.attributes.get("usage.amount_in_pricing_units")
+        else:
+            usage["amount_in_pricing_units"] = self._gen_pricing_unit_amount(pricing_unit, usage["amount"])
+        if self.attributes and self.attributes.get("price"):
+            row["cost"] = usage["amount_in_pricing_units"] * self.attributes.get("price")
+        else:
+            row["cost"] = round(uniform(0, 0.01), 7)
         row["usage"] = usage
         row["credits"] = {}
         row["cost_type"] = "regular"

--- a/nise/generators/gcp/cloud_storage_generator.py
+++ b/nise/generators/gcp/cloud_storage_generator.py
@@ -59,9 +59,10 @@ class CloudStorageGenerator(GCPGenerator):
         row["labels"] = choice(self.LABELS)
         row["system_labels"] = choice(self.SYSTEM_LABELS)
         row["usage.amount"] = 0
-        amount = self._gen_usage_unit_amount(usage_unit)
         if self.attributes and self.attributes.get("usage.amount"):
             amount = self.attributes.get("usage.amount")
+        else:
+            amount = self._gen_usage_unit_amount(usage_unit)
         row["usage.amount"] = amount
         row["usage.amount_in_pricing_units"] = self._gen_pricing_unit_amount(pricing_unit, amount)
         row["credits"] = "[]"
@@ -120,9 +121,10 @@ class JSONLCloudStorageGenerator(CloudStorageGenerator):
         usage["pricing_unit"] = pricing_unit
         row["labels"] = choice(self.LABELS)
         row["system_labels"] = choice(self.SYSTEM_LABELS)
-        amount = self._gen_usage_unit_amount(usage_unit)
         if self.attributes and self.attributes.get("usage.amount"):
             amount = self.attributes.get("usage.amount")
+        else:
+            amount = self._gen_usage_unit_amount(usage_unit)
         row["usage.amount"] = amount
         row["usage.amount_in_pricing_units"] = self._gen_pricing_unit_amount(pricing_unit, amount)
         row["usage"] = usage

--- a/nise/generators/gcp/cloud_storage_generator.py
+++ b/nise/generators/gcp/cloud_storage_generator.py
@@ -59,18 +59,11 @@ class CloudStorageGenerator(GCPGenerator):
         row["labels"] = choice(self.LABELS)
         row["system_labels"] = choice(self.SYSTEM_LABELS)
         row["usage.amount"] = 0
-
-        # All upper and lower bound values were estimated for each unit
-        # Currently our only usage unit & pricing unit is bytes-seconds & gibibyte month
-        amount_defined = False
-        if self.attributes:
-            if self.attributes.get("usage.amount"):
-                amount = float(self.attributes.get("usage.amount"))
-                amount_defined = True
-        if not amount_defined:
-            amount = self.fake.pyint(min_value=1000, max_value=100000)
+        amount = self._gen_usage_unit_amount(usage_unit)
+        if self.attributes and self.attributes.get("usage.amount"):
+            amount = self.attributes.get("usage.amount")
         row["usage.amount"] = amount
-        row["usage.amount_in_pricing_units"] = amount * 0.00244752
+        row["usage.amount_in_pricing_units"] = self._gen_pricing_unit_amount(pricing_unit, amount)
         row["credits"] = "[]"
         row["cost_type"] = "regular"
         row["currency"] = "USD"
@@ -127,16 +120,11 @@ class JSONLCloudStorageGenerator(CloudStorageGenerator):
         usage["pricing_unit"] = pricing_unit
         row["labels"] = choice(self.LABELS)
         row["system_labels"] = choice(self.SYSTEM_LABELS)
-        amount_defined = False
-        if self.attributes:
-            if self.attributes.get("usage.amount"):
-                amount = float(self.attributes.get("usage.amount"))
-                amount_defined = True
-        if not amount_defined:
-            amount = self.fake.pyint(min_value=1000, max_value=100000)
-        usage["amount"] = amount
-        usage["amount_in_pricing_units"] = amount * 0.00244752
-
+        amount = self._gen_usage_unit_amount(usage_unit)
+        if self.attributes and self.attributes.get("usage.amount"):
+            amount = self.attributes.get("usage.amount")
+        row["usage.amount"] = amount
+        row["usage.amount_in_pricing_units"] = self._gen_pricing_unit_amount(pricing_unit, amount)
         row["usage"] = usage
         row["credits"] = {}
         row["cost_type"] = "regular"

--- a/nise/generators/gcp/cloud_storage_generator.py
+++ b/nise/generators/gcp/cloud_storage_generator.py
@@ -152,6 +152,9 @@ class JSONLCloudStorageGenerator(CloudStorageGenerator):
             for key in self.attributes:
                 if key in self.column_labels:
                     row[key] = self.attributes[key]
+                elif key.split(".")[0] in self.column_labels:
+                    outer_key, inner_key = key.split(".")
+                    row[outer_key][inner_key] = self.attributes[key]
         return row
 
     def generate_data(self, report_type=None):

--- a/nise/generators/gcp/cloud_storage_generator.py
+++ b/nise/generators/gcp/cloud_storage_generator.py
@@ -62,6 +62,7 @@ class CloudStorageGenerator(GCPGenerator):
 
         # All upper and lower bound values were estimated for each unit
         # Currently our only usage unit & pricing unit is bytes-seconds & gibibyte month
+        amount_defined = False
         if self.attributes:
             if self.attributes.get("usage.amount"):
                 amount = self.attributes.get("usage.amount")
@@ -74,7 +75,8 @@ class CloudStorageGenerator(GCPGenerator):
         row["cost_type"] = "regular"
         row["currency"] = "USD"
         row["currency_conversion_rate"] = 1
-        row["invoice.month"] = f"{self.start_date.year}{self.start_date.month}"
+        usage_date = datetime.strptime(row.get("usage_start_time"), "%Y-%m-%dT%H:%M:%S")
+        row["invoice.month"] = f"{usage_date.year}{usage_date.month:02d}"
 
         if self.attributes:
             for key in self.attributes:

--- a/nise/generators/gcp/cloud_storage_generator.py
+++ b/nise/generators/gcp/cloud_storage_generator.py
@@ -125,8 +125,8 @@ class JSONLCloudStorageGenerator(CloudStorageGenerator):
             amount = self.attributes.get("usage.amount")
         else:
             amount = self._gen_usage_unit_amount(usage_unit)
-        row["usage.amount"] = amount
-        row["usage.amount_in_pricing_units"] = self._gen_pricing_unit_amount(pricing_unit, amount)
+        usage["amount"] = amount
+        usage["amount_in_pricing_units"] = self._gen_pricing_unit_amount(pricing_unit, amount)
         row["usage"] = usage
         row["credits"] = {}
         row["cost_type"] = "regular"

--- a/nise/generators/gcp/compute_engine_generator.py
+++ b/nise/generators/gcp/compute_engine_generator.py
@@ -72,23 +72,30 @@ class ComputeEngineGenerator(GCPGenerator):
         row["usage.pricing_unit"] = pricing_unit
         row["labels"] = choice(self.LABELS)
         row["system_labels"] = choice(self.SYSTEM_LABELS)
-        row["usage.amount"] = 0
+        amount_defined = False
+        if self.attributes:
+            if self.attributes.get("usage.amount"):
+                amount = self.attributes.get("usage.amount")
+                amount_defined = True
 
         # All upper and lower bound values were estimated for each unit
         if usage_unit == "byte-seconds":
-            amount = self.fake.pyint(min_value=1000, max_value=100000)
+            if not amount_defined:
+                amount = self.fake.pyint(min_value=1000, max_value=100000)
             row["usage.amount"] = amount
             if pricing_unit == "gibibyte month":
                 row["usage.amount_in_pricing_units"] = amount * 0.00244752
             elif pricing_unit == "gibibyte hour":
                 row["usage.amount_in_pricing_units"] = amount * (3.3528 * 10 ** -6)
         elif usage_unit == "bytes":
-            amount = self.fake.pyint(min_value=1000, max_value=10000000)
+            if not amount_defined:
+                amount = self.fake.pyint(min_value=1000, max_value=10000000)
             row["usage.amount"] = amount
             if pricing_unit == "gibibyte":
                 row["usage.amount_in_pricing_units"] = amount * (9.31323 * 10 ** -0)
         elif usage_unit == "seconds":
-            amount = self.fake.pyfloat(max_value=3600, positive=True)
+            if not amount_defined:
+                amount = self.fake.pyfloat(max_value=3600, positive=True)
             row["usage.amount"] = amount
             if pricing_unit == "hour":
                 row["usage.amount_in_pricing_units"] = amount / 3600.00
@@ -158,23 +165,30 @@ class JSONLComputeEngineGenerator(ComputeEngineGenerator):
         usage["pricing_unit"] = pricing_unit
         row["labels"] = choice(self.LABELS)
         row["system_labels"] = choice(self.SYSTEM_LABELS)
-        usage["amount"] = 0
+        amount_defined = False
+        if self.attributes:
+            if self.attributes.get("usage.amount"):
+                amount = self.attributes.get("usage.amount")
+                amount_defined = True
 
         # All upper and lower bound values were estimated for each unit
         if usage_unit == "byte-seconds":
-            amount = self.fake.pyint(min_value=1000, max_value=100000)
+            if not amount_defined:
+                amount = self.fake.pyint(min_value=1000, max_value=100000)
             usage["amount"] = amount
             if pricing_unit == "gibibyte month":
                 usage["amount_in_pricing_units"] = amount * 0.00244752
             elif pricing_unit == "gibibyte hour":
                 usage["amount_in_pricing_units"] = amount * (3.3528 * 10 ** -6)
         elif usage_unit == "bytes":
-            amount = self.fake.pyint(min_value=1000, max_value=10000000)
+            if not amount_defined:
+                amount = self.fake.pyint(min_value=1000, max_value=10000000)
             usage["amount"] = amount
             if pricing_unit == "gibibyte":
                 usage["amount_in_pricing_units"] = amount * (9.31323 * 10 ** -0)
         elif usage_unit == "seconds":
-            amount = self.fake.pyfloat(max_value=3600, positive=True)
+            if not amount_defined:
+                amount = self.fake.pyfloat(max_value=3600, positive=True)
             usage["amount"] = amount
             if pricing_unit == "hour":
                 usage["amount_in_pricing_units"] = amount / 3600.00

--- a/nise/generators/gcp/compute_engine_generator.py
+++ b/nise/generators/gcp/compute_engine_generator.py
@@ -87,7 +87,9 @@ class ComputeEngineGenerator(GCPGenerator):
                 if key in self.column_labels:
                     row[key] = self.attributes[key]
         if row["usage.pricing_unit"] == "hour":
-            instance_type = self.attributes.get("instance_type")
+            instance_type = None
+            if self.attributes and self.attributes.get("instance_type"):
+                instance_type = self.attributes.get("instance_type")
             row["system_labels"] = self.determine_system_labels(instance_type)
         return row
 
@@ -162,7 +164,9 @@ class JSONLComputeEngineGenerator(ComputeEngineGenerator):
                 if key in self.column_labels:
                     row[key] = self.attributes[key]
         if pricing_unit == "hour":
-            instance_type = self.attributes.get("instance_type")
+            instance_type = None
+            if self.attributes and self.attributes.get("instance_type"):
+                instance_type = self.attributes.get("instance_type")
             row["system_labels"] = self.determine_system_labels(instance_type, return_list=True)
         return row
 

--- a/nise/generators/gcp/compute_engine_generator.py
+++ b/nise/generators/gcp/compute_engine_generator.py
@@ -72,9 +72,10 @@ class ComputeEngineGenerator(GCPGenerator):
         row["usage.pricing_unit"] = pricing_unit
         row["labels"] = choice(self.LABELS)
         row["system_labels"] = choice(self.SYSTEM_LABELS)
-        amount = self._gen_usage_unit_amount(usage_unit)
         if self.attributes and self.attributes.get("usage.amount"):
             amount = self.attributes.get("usage.amount")
+        else:
+            amount = self._gen_usage_unit_amount(usage_unit)
         row["usage.amount"] = amount
         row["usage.amount_in_pricing_units"] = self._gen_pricing_unit_amount(pricing_unit, amount)
         row["credits"] = "[]"
@@ -143,9 +144,10 @@ class JSONLComputeEngineGenerator(ComputeEngineGenerator):
         usage["pricing_unit"] = pricing_unit
         row["labels"] = choice(self.LABELS)
         row["system_labels"] = choice(self.SYSTEM_LABELS)
-        amount = self._gen_usage_unit_amount(usage_unit)
         if self.attributes and self.attributes.get("usage.amount"):
             amount = self.attributes.get("usage.amount")
+        else:
+            amount = self._gen_usage_unit_amount(usage_unit)
         usage["amount"] = amount
         usage["amount_in_pricing_units"] = self._gen_pricing_unit_amount(pricing_unit, amount)
         row["usage"] = usage

--- a/nise/generators/gcp/compute_engine_generator.py
+++ b/nise/generators/gcp/compute_engine_generator.py
@@ -173,6 +173,9 @@ class JSONLComputeEngineGenerator(ComputeEngineGenerator):
             for key in self.attributes:
                 if key in self.column_labels:
                     row[key] = self.attributes[key]
+                elif key.split(".")[0] in self.column_labels:
+                    outer_key, inner_key = key.split(".")
+                    row[outer_key][inner_key] = self.attributes[key]
         if pricing_unit == "hour":
             instance_type = None
             if self.attributes and self.attributes.get("instance_type"):

--- a/nise/generators/gcp/compute_engine_generator.py
+++ b/nise/generators/gcp/compute_engine_generator.py
@@ -29,13 +29,10 @@ class ComputeEngineGenerator(GCPGenerator):
     SERVICE = ("Compute Engine", "6F81-5844-456A")  # Service Description and Service ID
 
     SKU = (  # (ID, Description, Usage Unit, Pricing Unit)
-        ("C0CF-3E3B-57FB", "Licensing Fee for Debian 10 Buster (CPU cost)", "seconds", "hour"),
+        ("CF4E-A0C7-E3BF", "Instance Core running in Americas", "seconds", "hour"),
         ("D973-5D65-BAB2", "Storage PD Capacity", "byte-seconds", "gibibyte month"),
         ("D0CC-50DF-59D2", "Network Inter Zone Ingress", "bytes", "gibibyte"),
         ("F449-33EC-A5EF", "E2 Instance Ram running in Americas", "byte-seconds", "gibibyte hour"),
-        ("C054-7F72-A02E", "External IP Charge on a Standard VM", "seconds", "hour"),
-        ("CF4E-A0C7-E3BF", "E2 Instance Core running in Americas", "seconds", "hour"),
-        ("0C5C-D8E4-38C1", "Licensing Fee for Debian 10 Buster (CPU cost)", "seconds", "hour"),
         ("CD20-B4CA-0F7C", "Licensing Fee for Debian 10 Buster (RAM cost)", "byte-seconds", "gibiyte hour"),
         ("6B8F-E63D-832B", "Network Internet Egress from Americas to APAC", "bytes", "gibibyte"),
         ("DFA5-B5C6-36D6", "Network Internet Egress from Americas to EMEA", "bytes", "gibibyte"),
@@ -126,7 +123,7 @@ class JSONLComputeEngineGenerator(ComputeEngineGenerator):
 
     def _update_data(self, row):  # noqa: C901
         """Update a data row with compute values."""
-        row["system_labels"] = ([])
+        row["system_labels"] = []
         sku_choice = self._determine_sku()
         service = {}
         service["description"] = self.SERVICE[0]
@@ -166,7 +163,7 @@ class JSONLComputeEngineGenerator(ComputeEngineGenerator):
                     row[key] = self.attributes[key]
         if pricing_unit == "hour":
             instance_type = self.attributes.get("instance_type")
-            row["system_labels"] =  self.determine_system_labels(instance_type, return_list=True)
+            row["system_labels"] = self.determine_system_labels(instance_type, return_list=True)
         return row
 
     def generate_data(self, report_type=None):

--- a/nise/generators/gcp/compute_engine_generator.py
+++ b/nise/generators/gcp/compute_engine_generator.py
@@ -75,7 +75,7 @@ class ComputeEngineGenerator(GCPGenerator):
         amount_defined = False
         if self.attributes:
             if self.attributes.get("usage.amount"):
-                amount = self.attributes.get("usage.amount")
+                amount = float(self.attributes.get("usage.amount"))
                 amount_defined = True
 
         # All upper and lower bound values were estimated for each unit
@@ -169,7 +169,7 @@ class JSONLComputeEngineGenerator(ComputeEngineGenerator):
         amount_defined = False
         if self.attributes:
             if self.attributes.get("usage.amount"):
-                amount = self.attributes.get("usage.amount")
+                amount = float(self.attributes.get("usage.amount"))
                 amount_defined = True
 
         # All upper and lower bound values were estimated for each unit

--- a/nise/generators/gcp/compute_engine_generator.py
+++ b/nise/generators/gcp/compute_engine_generator.py
@@ -104,7 +104,8 @@ class ComputeEngineGenerator(GCPGenerator):
         row["cost_type"] = "regular"
         row["currency"] = "USD"
         row["currency_conversion_rate"] = 1
-        row["invoice.month"] = f"{self.start_date.year}{self.start_date.month}"
+        usage_date = datetime.strptime(row.get("usage_start_time"), "%Y-%m-%dT%H:%M:%S")
+        row["invoice.month"] = f"{usage_date.year}{usage_date.month:02d}"
 
         if self.attributes:
             for key in self.attributes:

--- a/nise/generators/gcp/compute_engine_generator.py
+++ b/nise/generators/gcp/compute_engine_generator.py
@@ -180,7 +180,7 @@ class JSONLComputeEngineGenerator(ComputeEngineGenerator):
             for key in self.attributes:
                 if key in self.column_labels:
                     row[key] = self.attributes[key]
-        if row["usage.pricing_unit"] == "hour":
+        if pricing_unit == "hour":
             row["system_labels"] = self.SYSTEM_LABELS[0]
         else:
             row["system_labels"] = self.SYSTEM_LABELS[1]

--- a/nise/generators/gcp/compute_engine_generator.py
+++ b/nise/generators/gcp/compute_engine_generator.py
@@ -72,34 +72,11 @@ class ComputeEngineGenerator(GCPGenerator):
         row["usage.pricing_unit"] = pricing_unit
         row["labels"] = choice(self.LABELS)
         row["system_labels"] = choice(self.SYSTEM_LABELS)
-        amount_defined = False
-        if self.attributes:
-            if self.attributes.get("usage.amount"):
-                amount = float(self.attributes.get("usage.amount"))
-                amount_defined = True
-
-        # All upper and lower bound values were estimated for each unit
-        if usage_unit == "byte-seconds":
-            if not amount_defined:
-                amount = self.fake.pyint(min_value=1000, max_value=100000)
-            row["usage.amount"] = amount
-            if pricing_unit == "gibibyte month":
-                row["usage.amount_in_pricing_units"] = amount * 0.00244752
-            elif pricing_unit == "gibibyte hour":
-                row["usage.amount_in_pricing_units"] = amount * (3.3528 * 10 ** -6)
-        elif usage_unit == "bytes":
-            if not amount_defined:
-                amount = self.fake.pyint(min_value=1000, max_value=10000000)
-            row["usage.amount"] = amount
-            if pricing_unit == "gibibyte":
-                row["usage.amount_in_pricing_units"] = amount * (9.31323 * 10 ** -0)
-        elif usage_unit == "seconds":
-            if not amount_defined:
-                amount = self.fake.pyfloat(max_value=3600, positive=True)
-            row["usage.amount"] = amount
-            if pricing_unit == "hour":
-                row["usage.amount_in_pricing_units"] = amount / 3600.00
-
+        amount = self._gen_usage_unit_amount(usage_unit)
+        if self.attributes and self.attributes.get("usage.amount"):
+            amount = self.attributes.get("usage.amount")
+        row["usage.amount"] = amount
+        row["usage.amount_in_pricing_units"] = self._gen_pricing_unit_amount(pricing_unit, amount)
         row["credits"] = "[]"
         row["cost_type"] = "regular"
         row["currency"] = "USD"
@@ -166,34 +143,11 @@ class JSONLComputeEngineGenerator(ComputeEngineGenerator):
         usage["pricing_unit"] = pricing_unit
         row["labels"] = choice(self.LABELS)
         row["system_labels"] = choice(self.SYSTEM_LABELS)
-        amount_defined = False
-        if self.attributes:
-            if self.attributes.get("usage.amount"):
-                amount = float(self.attributes.get("usage.amount"))
-                amount_defined = True
-
-        # All upper and lower bound values were estimated for each unit
-        if usage_unit == "byte-seconds":
-            if not amount_defined:
-                amount = self.fake.pyint(min_value=1000, max_value=100000)
-            usage["amount"] = amount
-            if pricing_unit == "gibibyte month":
-                usage["amount_in_pricing_units"] = amount * 0.00244752
-            elif pricing_unit == "gibibyte hour":
-                usage["amount_in_pricing_units"] = amount * (3.3528 * 10 ** -6)
-        elif usage_unit == "bytes":
-            if not amount_defined:
-                amount = self.fake.pyint(min_value=1000, max_value=10000000)
-            usage["amount"] = amount
-            if pricing_unit == "gibibyte":
-                usage["amount_in_pricing_units"] = amount * (9.31323 * 10 ** -0)
-        elif usage_unit == "seconds":
-            if not amount_defined:
-                amount = self.fake.pyfloat(max_value=3600, positive=True)
-            usage["amount"] = amount
-            if pricing_unit == "hour":
-                usage["amount_in_pricing_units"] = amount / 3600.00
-
+        amount = self._gen_usage_unit_amount(usage_unit)
+        if self.attributes and self.attributes.get("usage.amount"):
+            amount = self.attributes.get("usage.amount")
+        usage["amount"] = amount
+        usage["amount_in_pricing_units"] = self._gen_pricing_unit_amount(pricing_unit, amount)
         row["usage"] = usage
         row["credits"] = {}
         row["cost_type"] = "regular"

--- a/nise/generators/gcp/compute_engine_generator.py
+++ b/nise/generators/gcp/compute_engine_generator.py
@@ -100,16 +100,7 @@ class ComputeEngineGenerator(GCPGenerator):
 
     def generate_data(self, report_type=None):
         """Generate GCP compute data for some days."""
-        days = self._create_days_list(self.start_date, self.end_date)
-        data = {}
-        for day in days:
-            rows = []
-            for _ in range(self.num_instances):
-                row = self._init_data_row(day["start"], day["end"])
-                row = self._update_data(row)
-                rows.append(row)
-            data[day["start"]] = rows
-        return data
+        return self._generate_hourly_data()
 
 
 class JSONLComputeEngineGenerator(ComputeEngineGenerator):
@@ -185,13 +176,4 @@ class JSONLComputeEngineGenerator(ComputeEngineGenerator):
 
     def generate_data(self, report_type=None):
         """Generate GCP compute data for some days."""
-        days = self._create_days_list(self.start_date, self.end_date)
-        data = {}
-        for day in days:
-            rows = []
-            for _ in range(self.num_instances):
-                row = self._init_data_row(day["start"], day["end"])
-                row = self._update_data(row)
-                rows.append(row)
-            data[day["start"]] = rows
-        return data
+        return self._generate_hourly_data()

--- a/nise/generators/gcp/gcp_generator.py
+++ b/nise/generators/gcp/gcp_generator.py
@@ -21,6 +21,8 @@ from random import randint
 
 from nise.generators.generator import AbstractGenerator
 
+from random import choice
+
 GCP_REPORT_COLUMNS = (
     "billing_account_id",
     "service.id",
@@ -72,6 +74,12 @@ GCP_REPORT_COLUMNS_JSONL = (
     "cost_type",
 )
 
+GCP_INSTANCE_TYPES = (
+    "e2-medium",
+    "n1-standard-4",
+    "m2-megamem-416",
+    "a2-highgpu-1g"
+)
 
 class GCPGenerator(AbstractGenerator):
     """Abstract class for GCP generators."""
@@ -168,6 +176,20 @@ class GCPGenerator(AbstractGenerator):
         if pricing_unit == "hour":
             return amount / 3600.00
         return 0
+
+    def determine_system_labels(self, instance_type, return_list=False):
+        """Determine the system labels if instance-type exists."""
+        if not instance_type:
+            instance_type = choice(GCP_INSTANCE_TYPES)
+        system_label_format = [
+                {"key": "compute.googleapis.com/cores", "value": "2"},
+                {"key": "compute.googleapis.com/machine_spec", "value": instance_type},
+                {"key": "compute.googleapis.com/memory", "value": "4096"}
+        ]
+        if return_list:
+            return system_label_format
+        else:
+            return str(system_label_format)
 
     def _add_common_usage_info(self, row, start, end, **kwargs):
         """Not needed for GCP."""

--- a/nise/generators/gcp/gcp_generator.py
+++ b/nise/generators/gcp/gcp_generator.py
@@ -169,7 +169,6 @@ class GCPGenerator(AbstractGenerator):
             return amount / 3600.00
         return 0
 
-
     def _add_common_usage_info(self, row, start, end, **kwargs):
         """Not needed for GCP."""
 

--- a/nise/generators/gcp/gcp_generator.py
+++ b/nise/generators/gcp/gcp_generator.py
@@ -146,6 +146,30 @@ class GCPGenerator(AbstractGenerator):
         row.update(self.project)
         return row
 
+    def _gen_usage_unit_amount(self, usage_unit):
+        """Generate the correct amount for usage unit."""
+        # All upper and lower bound values were estimated for each unit
+        if usage_unit == "byte-seconds":
+            return self.fake.pyint(min_value=1000, max_value=100000)
+        if usage_unit == "bytes":
+            return self.fake.pyint(min_value=1000, max_value=10000000)
+        if usage_unit == "seconds":
+            return self.fake.pyfloat(max_value=3600, positive=True)
+        return 0
+
+    def _gen_pricing_unit_amount(self, pricing_unit, amount):
+        """Generate the correct amount in pricing units."""
+        if pricing_unit == "gibibyte month":
+            row["usage.amount_in_pricing_units"] = amount * 0.00244752
+        if pricing_unit == "gibibyte hour":
+            row["usage.amount_in_pricing_units"] = amount * (3.3528 * 10 ** -6)
+        if pricing_unit == "gibibyte":
+            row["usage.amount_in_pricing_units"] = amount * (9.31323 * 10 ** -0)
+        if pricing_unit == "hour":
+                row["usage.amount_in_pricing_units"] = amount / 3600.00
+        return 0
+
+
     def _add_common_usage_info(self, row, start, end, **kwargs):
         """Not needed for GCP."""
 

--- a/nise/generators/gcp/gcp_generator.py
+++ b/nise/generators/gcp/gcp_generator.py
@@ -133,7 +133,7 @@ class GCPGenerator(AbstractGenerator):
 
         row = {}
         # Initialize the start and end time measured
-        time_bill_start = start + datetime.timedelta(hours=randint(1, 23))
+        time_bill_start = start
         time_bill_end = time_bill_start + datetime.timedelta(hours=1)
         for column in self.column_labels:
             row[column] = ""
@@ -195,3 +195,9 @@ class GCPGenerator(AbstractGenerator):
 
     def _generate_hourly_data(self, **kwargs):
         """Not needed for GCP."""
+        for hour in self.hours:
+            start = hour.get("start")
+            end = hour.get("end")
+            row = self._init_data_row(start, end)
+            row = self._update_data(row)
+            yield row

--- a/nise/generators/gcp/gcp_generator.py
+++ b/nise/generators/gcp/gcp_generator.py
@@ -160,13 +160,13 @@ class GCPGenerator(AbstractGenerator):
     def _gen_pricing_unit_amount(self, pricing_unit, amount):
         """Generate the correct amount in pricing units."""
         if pricing_unit == "gibibyte month":
-            row["usage.amount_in_pricing_units"] = amount * 0.00244752
+            return amount * 0.00244752
         if pricing_unit == "gibibyte hour":
-            row["usage.amount_in_pricing_units"] = amount * (3.3528 * 10 ** -6)
+            return amount * (3.3528 * 10 ** -6)
         if pricing_unit == "gibibyte":
-            row["usage.amount_in_pricing_units"] = amount * (9.31323 * 10 ** -0)
+            return amount * (9.31323 * 10 ** -0)
         if pricing_unit == "hour":
-                row["usage.amount_in_pricing_units"] = amount / 3600.00
+            return amount / 3600.00
         return 0
 
 

--- a/nise/generators/gcp/gcp_generator.py
+++ b/nise/generators/gcp/gcp_generator.py
@@ -17,11 +17,10 @@
 """Abstract class for gcp data generation."""
 import datetime
 from abc import abstractmethod
+from random import choice
 from random import randint
 
 from nise.generators.generator import AbstractGenerator
-
-from random import choice
 
 GCP_REPORT_COLUMNS = (
     "billing_account_id",
@@ -74,12 +73,8 @@ GCP_REPORT_COLUMNS_JSONL = (
     "cost_type",
 )
 
-GCP_INSTANCE_TYPES = (
-    "e2-medium",
-    "n1-standard-4",
-    "m2-megamem-416",
-    "a2-highgpu-1g"
-)
+GCP_INSTANCE_TYPES = ("e2-medium", "n1-standard-4", "m2-megamem-416", "a2-highgpu-1g")
+
 
 class GCPGenerator(AbstractGenerator):
     """Abstract class for GCP generators."""
@@ -182,9 +177,9 @@ class GCPGenerator(AbstractGenerator):
         if not instance_type:
             instance_type = choice(GCP_INSTANCE_TYPES)
         system_label_format = [
-                {"key": "compute.googleapis.com/cores", "value": "2"},
-                {"key": "compute.googleapis.com/machine_spec", "value": instance_type},
-                {"key": "compute.googleapis.com/memory", "value": "4096"}
+            {"key": "compute.googleapis.com/cores", "value": "2"},
+            {"key": "compute.googleapis.com/machine_spec", "value": instance_type},
+            {"key": "compute.googleapis.com/memory", "value": "4096"},
         ]
         if return_list:
             return system_label_format

--- a/nise/report.py
+++ b/nise/report.py
@@ -857,8 +857,7 @@ def gcp_create_report(options):  # noqa: C901
                 {"generator": JSONLCloudStorageGenerator, "attributes": None},
                 {"generator": JSONLComputeEngineGenerator, "attributes": None},
             ]
-            account = "{}-{}".format(fake.word(), fake.word())
-
+            account = fake.word()
             project_generator = JSONLProjectGenerator(account)
             projects = project_generator.generate_projects()
 
@@ -871,7 +870,7 @@ def gcp_create_report(options):  # noqa: C901
             {"generator": CloudStorageGenerator, "attributes": None},
             {"generator": ComputeEngineGenerator, "attributes": None},
         ]
-        account = "{}-{}".format(fake.word(), fake.word())
+        account = fake.word()
 
         project_generator = ProjectGenerator(account)
         projects = project_generator.generate_projects()

--- a/tests/test_gcp_generator.py
+++ b/tests/test_gcp_generator.py
@@ -30,10 +30,18 @@ class TestGCPGenerator(TestCase):
             "currency_conversion_rate": 1,
             "cost_type": "regular",
         }
+        self.usage_attributes = {
+            "currency": fake.currency_code(),
+            "currency_conversion_rate": 1,
+            "cost_type": "regular",
+            "usage.amount": 10,
+            "usage.amount_in_pricing_units": 10,
+            "price": 2,
+        }
         self.now = datetime.now().replace(microsecond=0, second=0, minute=0)
         self.yesterday = self.now - timedelta(days=1)
 
-    def test_cloud_storage_init_with_attributes(self):  # Cloud storage not currently implemented
+    def test_cloud_storage_init_with_attributes(self):
         """Test the init with attribute for Cloud Storage."""
 
         generator = CloudStorageGenerator(self.yesterday, self.now, self.project, attributes=self.attributes)
@@ -42,13 +50,31 @@ class TestGCPGenerator(TestCase):
         self.assertEqual(list_data[0]["cost"], self.attributes["cost"])
         self.assertEqual(list_data[0]["currency"], self.attributes["currency"])
 
-    def test_jsonl_cloud_storage_init_with_attributes(self):  # Cloud storage not currently implemented
+    def test_cloud_storage_init_with_usage_attributes(self):
+        """Test the init with usage attribute for Cloud Storage."""
+        generator = CloudStorageGenerator(self.yesterday, self.now, self.project, attributes=self.usage_attributes)
+        generated_data = generator.generate_data()
+        list_data = list(generated_data)
+        self.assertEqual(list_data[0]["cost"], self.usage_attributes["usage.amount"] * self.usage_attributes["price"])
+        self.assertEqual(list_data[0]["currency"], self.usage_attributes["currency"])
+
+    def test_jsonl_cloud_storage_init_with_attributes(self):
         """Test the init with attribute for JSONL Cloud Storage."""
         generator = JSONLCloudStorageGenerator(self.yesterday, self.now, self.project, attributes=self.attributes)
         generated_data = generator.generate_data()
         list_data = list(generated_data)
         self.assertEqual(list_data[0]["cost"], self.attributes["cost"])
         self.assertEqual(list_data[0]["currency"], self.attributes["currency"])
+
+    def test_jsonl_cloud_storage_init_with_usage_attributes(self):
+        """Test the init with usage attribute for JSONL Cloud Storage."""
+        generator = JSONLCloudStorageGenerator(
+            self.yesterday, self.now, self.project, attributes=self.usage_attributes
+        )
+        generated_data = generator.generate_data()
+        list_data = list(generated_data)
+        self.assertEqual(list_data[0]["cost"], self.usage_attributes["usage.amount"] * self.usage_attributes["price"])
+        self.assertEqual(list_data[0]["currency"], self.usage_attributes["currency"])
 
     def test_compute_engine_init_with_attributes(self):
         """Test the init with attribute for Compute Engine."""
@@ -59,6 +85,14 @@ class TestGCPGenerator(TestCase):
         self.assertEqual(list_data[0]["cost"], self.attributes["cost"])
         self.assertEqual(list_data[0]["currency"], self.attributes["currency"])
 
+    def test_compute_engine_init_with_usage_attributes(self):
+        """Test the init with usage attributes for Compute Engine."""
+        generator = ComputeEngineGenerator(self.yesterday, self.now, self.project, attributes=self.usage_attributes)
+        generated_data = generator.generate_data()
+        list_data = list(generated_data)
+        self.assertEqual(list_data[0]["cost"], self.usage_attributes["usage.amount"] * self.usage_attributes["price"])
+        self.assertEqual(list_data[0]["currency"], self.usage_attributes["currency"])
+
     def test_jsonl_compute_engine_init_with_attributes(self):
         """Test the init with attribute for JSONL Compute Engine."""
         generator = JSONLComputeEngineGenerator(self.yesterday, self.now, self.project, attributes=self.attributes)
@@ -66,6 +100,16 @@ class TestGCPGenerator(TestCase):
         list_data = list(generated_data)
         self.assertEqual(list_data[0]["cost"], self.attributes["cost"])
         self.assertEqual(list_data[0]["currency"], self.attributes["currency"])
+
+    def test_jsonl_compute_engine_init_with_usage_attributes(self):
+        """Test the init with attribute for JSONL Compute Engine."""
+        generator = JSONLComputeEngineGenerator(
+            self.yesterday, self.now, self.project, attributes=self.usage_attributes
+        )
+        generated_data = generator.generate_data()
+        list_data = list(generated_data)
+        self.assertEqual(list_data[0]["cost"], self.usage_attributes["usage.amount"] * self.usage_attributes["price"])
+        self.assertEqual(list_data[0]["currency"], self.usage_attributes["currency"])
 
     def test_set_hours_invalid_start(self):
         """Test that the start date must be a date object."""

--- a/tests/test_gcp_generator.py
+++ b/tests/test_gcp_generator.py
@@ -28,8 +28,6 @@ class TestGCPGenerator(TestCase):
             "cost": fake.pyint(),
             "currency": fake.currency_code(),
             "currency_conversion_rate": 1,
-            "usage.amount": fake.pydecimal(positive=True),
-            "usage.unit": fake.word(),
             "cost_type": "regular",
         }
         self.now = datetime.now().replace(microsecond=0, second=0, minute=0)

--- a/tests/test_gcp_generator.py
+++ b/tests/test_gcp_generator.py
@@ -38,30 +38,34 @@ class TestGCPGenerator(TestCase):
 
         generator = CloudStorageGenerator(self.yesterday, self.now, self.project, attributes=self.attributes)
         generated_data = generator.generate_data()
-        self.assertEqual(generated_data[self.yesterday][0]["cost"], self.attributes["cost"])
-        self.assertEqual(generated_data[self.yesterday][0]["currency"], self.attributes["currency"])
+        list_data = list(generated_data)
+        self.assertEqual(list_data[0]["cost"], self.attributes["cost"])
+        self.assertEqual(list_data[0]["currency"], self.attributes["currency"])
 
     def test_jsonl_cloud_storage_init_with_attributes(self):  # Cloud storage not currently implemented
         """Test the init with attribute for JSONL Cloud Storage."""
         generator = JSONLCloudStorageGenerator(self.yesterday, self.now, self.project, attributes=self.attributes)
         generated_data = generator.generate_data()
-        self.assertEqual(generated_data[self.yesterday][0]["cost"], self.attributes["cost"])
-        self.assertEqual(generated_data[self.yesterday][0]["currency"], self.attributes["currency"])
+        list_data = list(generated_data)
+        self.assertEqual(list_data[0]["cost"], self.attributes["cost"])
+        self.assertEqual(list_data[0]["currency"], self.attributes["currency"])
 
     def test_compute_engine_init_with_attributes(self):
         """Test the init with attribute for Compute Engine."""
 
         generator = ComputeEngineGenerator(self.yesterday, self.now, self.project, attributes=self.attributes)
         generated_data = generator.generate_data()
-        self.assertEqual(generated_data[self.yesterday][0]["cost"], self.attributes["cost"])
-        self.assertEqual(generated_data[self.yesterday][0]["currency"], self.attributes["currency"])
+        list_data = list(generated_data)
+        self.assertEqual(list_data[0]["cost"], self.attributes["cost"])
+        self.assertEqual(list_data[0]["currency"], self.attributes["currency"])
 
     def test_jsonl_compute_engine_init_with_attributes(self):
         """Test the init with attribute for JSONL Compute Engine."""
         generator = JSONLComputeEngineGenerator(self.yesterday, self.now, self.project, attributes=self.attributes)
         generated_data = generator.generate_data()
-        self.assertEqual(generated_data[self.yesterday][0]["cost"], self.attributes["cost"])
-        self.assertEqual(generated_data[self.yesterday][0]["currency"], self.attributes["currency"])
+        list_data = list(generated_data)
+        self.assertEqual(list_data[0]["cost"], self.attributes["cost"])
+        self.assertEqual(list_data[0]["currency"], self.attributes["currency"])
 
     def test_set_hours_invalid_start(self):
         """Test that the start date must be a date object."""


### PR DESCRIPTION
A lot of discussions with QE led to some nise changes that include yaml gen benefits and some consistency between bigq and csv gen. Some of those changes include:

- Specifying `usage.amount`, `usage.amount_in_pricing_units` in a yaml now works and bases calculated values off those inputs. 
- Specifying both a `usage.amount_in_pricing_units `and a `price` in the yaml will result in a cost that is the pricing unit amount times the price. 
- Specifying a `usage.unit` will now select an SKU with a matching usage unit. 
- System labels apply to the appropriate things
- `billing_account_id` now only generates one word instead of multiple to handle the 20 character max on koku
- A little adjustment to ensure local and bigq match better, there were some minor differences
- Testing updates based on the changes

Here is an example yml with some of the usage data that is now usable (remove the .txt github does not allow the uploading of ymls): 
[usage_example.yml.txt](https://github.com/project-koku/nise/files/6024185/usage_example.yml.txt)
