### PR TITLE
Add type to header

### DIFF
--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.4.2"
+__version__ = "2.4.3"
 VERSION = __version__.split(".")

--- a/nise/report.py
+++ b/nise/report.py
@@ -234,25 +234,32 @@ def post_payload_to_ingest_service(insights_upload, local_path):
     insights_org_id = os.environ.get("INSIGHTS_ORG_ID")
     insights_user = os.environ.get("INSIGHTS_USER")
     insights_password = os.environ.get("INSIGHTS_PASSWORD")
+    content_type = "application/vnd.redhat.hccm.tar+tgz"
     if os.path.isfile(local_path):
         file_info = os.stat(local_path)
         filesize = _convert_bytes(file_info.st_size)
     LOG.info(f"Upload File: ({local_path}) filesize is {filesize}.")
     with open(local_path, "rb") as upload_file:
         if insights_account_id and insights_org_id:
-            header = {"identity": {"account_number": insights_account_id, "internal": {"org_id": insights_org_id}}}
+            header = {
+                "identity": {
+                    "account_number": insights_account_id,
+                    "internal": {"org_id": insights_org_id},
+                    "type": content_type,
+                }
+            }
             headers = {"x-rh-identity": base64.b64encode(json.dumps(header).encode("UTF-8"))}
             return requests.post(
                 insights_upload,
                 data={},
-                files={"file": ("payload.tar.gz", upload_file, "application/vnd.redhat.hccm.tar+tgz")},
+                files={"file": ("payload.tar.gz", upload_file, content_type)},
                 headers=headers,
             )
 
         return requests.post(
             insights_upload,
             data={},
-            files={"file": ("payload.tar.gz", upload_file, "application/vnd.redhat.hccm.tar+tgz")},
+            files={"file": ("payload.tar.gz", upload_file, content_type)},
             auth=(insights_user, insights_password),
             verify=False,
         )

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -193,6 +193,7 @@ class MiscReportTestCase(TestCase):
         """Test that the identity header path is taken."""
         insights_account_id = os.environ.get("INSIGHTS_ACCOUNT_ID")
         insights_org_id = os.environ.get("INSIGHTS_ORG_ID")
+        content_type = "application/vnd.redhat.hccm.tar+tgz"
 
         temp_file = NamedTemporaryFile(mode="w", delete=False)
         headers = ["col1", "col2"]
@@ -200,7 +201,13 @@ class MiscReportTestCase(TestCase):
         _write_csv(temp_file.name, data, headers)
 
         insights_upload = {}
-        header = {"identity": {"account_number": insights_account_id, "internal": {"org_id": insights_org_id}}}
+        header = {
+            "identity": {
+                "account_number": insights_account_id,
+                "internal": {"org_id": insights_org_id},
+                "type": content_type,
+            }
+        }
         headers = {"x-rh-identity": base64.b64encode(json.dumps(header).encode("UTF-8"))}
 
         post_payload_to_ingest_service(insights_upload, temp_file.name)


### PR DESCRIPTION
## Summary
Pass in the `type` in the identity header to pass validation in middleware. 