### PR TITLE
Updating GCP credits schema mode

### DIFF
--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.4.3"
+__version__ = "2.4.4"
 VERSION = __version__.split(".")

--- a/nise/upload.py
+++ b/nise/upload.py
@@ -254,7 +254,7 @@ def gcp_bucket_to_dataset(gcp_bucket_name, file_name, dataset_name, table_name):
                         {"name": "id", "type": "STRING", "mode": "NULLABLE"},
                         {"name": "type", "type": "STRING", "mode": "NULLABLE"},
                     ],
-                    "mode": "NULLABLE",
+                    "mode": "REPEATED",
                 },
                 {
                     "name": "invoice",


### PR DESCRIPTION
Real GCP BigQuery tables have a `REPEATABLE` as the credit mode.  This was causing GCP-trino processing failures.