### PR TITLE
Update the aws generators to fix ocp on aws raw calc errors

### DIFF
--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.4.4"
+__version__ = "2.4.5"
 VERSION = __version__.split(".")

--- a/nise/generators/aws/data_transfer_generator.py
+++ b/nise/generators/aws/data_transfer_generator.py
@@ -112,17 +112,17 @@ class DataTransferGenerator(AWSGenerator):
         self._add_tag_data(row)
         return row
 
-    def _generate_hourly_data(self, **kwargs):
-        """Create houldy data."""
-        data = []
-        for hour in self.hours:
-            start = hour.get("start")
-            end = hour.get("end")
-            row = self._init_data_row(start, end)
-            row = self._update_data(row, start, end)
-            if self.fake.pybool():
-                data.append(row)
-        return data
+    # def _generate_hourly_data(self, **kwargs):
+    #     """Create houldy data."""
+    #     data = []
+    #     for hour in self.hours:
+    #         start = hour.get("start")
+    #         end = hour.get("end")
+    #         row = self._init_data_row(start, end)
+    #         row = self._update_data(row, start, end)
+    #         if self.fake.pybool():
+    #             data.append(row)
+    #     return data
 
     def generate_data(self, report_type=None):
         """Responsibile for generating data."""

--- a/nise/generators/aws/route53_generator.py
+++ b/nise/generators/aws/route53_generator.py
@@ -44,6 +44,10 @@ class Route53Generator(AWSGenerator):
                 self._resource_id = self.attributes.get("resource_id")
             if self.attributes.get("tags"):
                 self._tags = self.attributes.get("tags")
+            if attributes.get("cost"):
+                self._cost = float(attributes.get("cost"))
+            if attributes.get("rate"):
+                self._rate = float(attributes.get("rate"))
 
     def _get_arn(self):
         """Create an amazon resource name."""
@@ -52,9 +56,13 @@ class Route53Generator(AWSGenerator):
     def _update_data(self, row, start, end, **kwargs):
         """Update data with generator specific data."""
         if self._product_family:
-            product_family, usage_type, rate, cost = ROUTE_53_PRODUCTS_DICT.get(self._product_family)
+            product_family, usage_type, default_rate, default_cost = ROUTE_53_PRODUCTS_DICT.get(self._product_family)
         else:
-            product_family, usage_type, rate, cost = choices(ROUTE_53_PRODUCTS, weights=[1, 10])[0]
+            product_family, usage_type, default_rate, default_cost = choices(ROUTE_53_PRODUCTS, weights=[1, 10])[0]
+
+        rate = self._rate if self._rate else default_rate
+        cost = self._cost if self._cost else default_cost
+
         operation = self.fake.pystr(min_chars=1, max_chars=6).upper()
         if usage_type == "HostedZone":
             operation = usage_type

--- a/nise/generators/aws/route53_generator.py
+++ b/nise/generators/aws/route53_generator.py
@@ -35,6 +35,8 @@ class Route53Generator(AWSGenerator):
         self._product_sku = self.fake.pystr(min_chars=12, max_chars=12).upper()
         self._product_family = None
         self._resource_id = self.fake.ean8()
+        self._rate = None
+        self._cost = None
         if self.attributes:
             if self.attributes.get("product_family"):
                 self._product_family = self.attributes.get("product_family")
@@ -44,10 +46,10 @@ class Route53Generator(AWSGenerator):
                 self._resource_id = self.attributes.get("resource_id")
             if self.attributes.get("tags"):
                 self._tags = self.attributes.get("tags")
-            if attributes.get("cost"):
-                self._cost = float(attributes.get("cost"))
-            if attributes.get("rate"):
-                self._rate = float(attributes.get("rate"))
+            if self.attributes.get("cost"):
+                self._cost = self.attributes.get("cost")
+            if self.attributes.get("rate"):
+                self._rate = self.attributes.get("rate")
 
     def _get_arn(self):
         """Create an amazon resource name."""
@@ -60,8 +62,8 @@ class Route53Generator(AWSGenerator):
         else:
             product_family, usage_type, default_rate, default_cost = choices(ROUTE_53_PRODUCTS, weights=[1, 10])[0]
 
-        rate = self._rate if self._rate else default_rate
-        cost = self._cost if self._cost else default_cost
+        rate = float(self._rate) if self._rate else default_rate
+        cost = float(self._cost) if self._cost else default_cost
 
         operation = self.fake.pystr(min_chars=1, max_chars=6).upper()
         if usage_type == "HostedZone":

--- a/nise/generators/aws/vpc_generator.py
+++ b/nise/generators/aws/vpc_generator.py
@@ -26,6 +26,8 @@ class VPCGenerator(AWSGenerator):
         super().__init__(start_date, end_date, payer_account, usage_accounts, attributes, tag_cols)
         self._resource_id = "vpn-{}".format(self.fake.ean8())
         self._product_sku = self.fake.pystr(min_chars=12, max_chars=12).upper()
+        self._rate = None
+        self._cost = None
         if self.attributes:
             if self.attributes.get("resource_id"):
                 self._resource_id = "vpn-{}".format(self.attributes.get("resource_id"))
@@ -33,17 +35,17 @@ class VPCGenerator(AWSGenerator):
                 self._product_sku = self.attributes.get("product_sku")
             if self.attributes.get("tags"):
                 self._tags = self.attributes.get("tags")
-            if attributes.get("cost"):
-                self._cost = float(attributes.get("cost"))
-            if attributes.get("rate"):
-                self._rate = float(attributes.get("rate"))
+            if self.attributes.get("cost"):
+                self._cost = self.attributes.get("cost")
+            if self.attributes.get("rate"):
+                self._rate = self.attributes.get("rate")
 
     def _update_data(self, row, start, end, **kwargs):
         """Update data with generator specific data."""
         default_cost = 0.05
         default_rate = 0.05
-        rate = self._rate if self._rate else default_rate
-        cost = self._cost if self._cost else default_cost
+        rate = float(self._rate) if self._rate else default_rate
+        cost = float(self._cost) if self._cost else default_cost
         location, aws_region, avail_zone, _ = self._get_location()
         row = self._add_common_usage_info(row, start, end)
         region_short_code = self._generate_region_short_code(aws_region)

--- a/nise/generators/aws/vpc_generator.py
+++ b/nise/generators/aws/vpc_generator.py
@@ -33,11 +33,17 @@ class VPCGenerator(AWSGenerator):
                 self._product_sku = self.attributes.get("product_sku")
             if self.attributes.get("tags"):
                 self._tags = self.attributes.get("tags")
+            if attributes.get("cost"):
+                self._cost = float(attributes.get("cost"))
+            if attributes.get("rate"):
+                self._rate = float(attributes.get("rate"))
 
     def _update_data(self, row, start, end, **kwargs):
         """Update data with generator specific data."""
-        cost = 0.05
-        rate = 0.05
+        default_cost = 0.05
+        default_rate = 0.05
+        rate = self._rate if self._rate else default_rate
+        cost = self._cost if self._cost else default_cost
         location, aws_region, avail_zone, _ = self._get_location()
         row = self._add_common_usage_info(row, start, end)
         region_short_code = self._generate_region_short_code(aws_region)
@@ -54,7 +60,7 @@ class VPCGenerator(AWSGenerator):
         row["lineItem/UnblendedCost"] = cost
         row["lineItem/BlendedRate"] = rate
         row["lineItem/BlendedCost"] = cost
-        row["lineItem/LineItemDescription"] = "$0.05 per VPN Connection-Hour"
+        row["lineItem/LineItemDescription"] = f"${self._rate} per VPN Connection-Hour"
         row["product/ProductName"] = "Amazon Virtual Private Cloud"
         row["product/clockSpeed"] = ""
         row["product/currentGeneration"] = ""


### PR DESCRIPTION
Example Yaml to use:
```
---
generators:
  - VPCGenerator:
      start_date: today
      cost: 0.01
      rate: 0.01
      tags:
        resourceTags/user:openshift_project: ocp-nod
  - Route53Generator:
      start_date: today
      costt: 0.01
      rate: 0.01
      tags:
        resourceTags/user:app: nod
        resourceTags/user:storage_class: dua
        resourceTags/user:test: nice
        resourceTags/user:git: commit
        resourceTags/user:stack: overflow
        resourceTags/user:volume: stor_nod
  - DataTransferGenerator:
      start_date: today
      product_sku: AERJHRNCCCCC
      product_code: AmazonDynamoDB
      product_name: Amazon DynamoDB
      amount: 10
      rate: 0.01
      tags:
        resourceTags/user:app: nod
        resourceTags/user:storage_class: dua
        resourceTags/user:test: nice
        resourceTags/user:git: commit
        resourceTags/user:stack: overflow
        resourceTags/user:volume: stor_nod
finalized_report:
  invoice_id: 987654321
accounts:
  payer: 9999999999999
  user:
    - 9999999999999
```

-----

Needs:
- To be able to set the rate & cost for vpc generator in aws
- To be able to set the rate & cost for route53 generator in aws
- Need consistent hours for the data transfer generator for aws