### PR TITLE
Allow volume on multiple nodes

### DIFF
--- a/examples/ocp_on_azure/ocp_static_data.yml
+++ b/examples/ocp_on_azure/ocp_static_data.yml
@@ -72,6 +72,17 @@ generators:
                   labels: label_environment:qe|label_app:banking|label_version:MilkyWay
               volumes:
                 - volume:
+                  volume_name: pvc-volume_1
+                  storage_class: gp2
+                  volume_request_gig: 20
+                  labels: label_environment:Jupiter|label_app:mobile|label_version:Mars|label_storageclass:Baldur
+                  volume_claims:
+                  - volume_claim:
+                    volume_claim_name: pod_name1_data
+                    pod_name: pod_name3
+                    labels: label_environment:Jupiter|label_app:mobile|label_version:Mars|label_storageclass:Baldur
+                    capacity_gig: 20
+                - volume:
                   volume_name: pvc-volume_3
                   storage_class: gp2
                   volume_request_gig: 20
@@ -99,6 +110,17 @@ generators:
                   pod_seconds: 3600
                   labels: label_environment:Mars|label_app:weather|label_version:Andromeda
               volumes:
+                - volume:
+                  volume_name: pvc-volume_1
+                  storage_class: gp2
+                  volume_request_gig: 20
+                  labels: label_environment:Jupiter|label_app:mobile|label_version:Mars|label_storageclass:Baldur
+                  volume_claims:
+                  - volume_claim:
+                    volume_claim_name: pod_name1_data
+                    pod_name: pod_name4
+                    labels: label_environment:Jupiter|label_app:mobile|label_version:Mars|label_storageclass:Baldur
+                    capacity_gig: 20
                 - volume:
                   volume_name: pvc-volume_4
                   storage_class: gp2

--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.4.6"
+__version__ = "2.4.7"
 VERSION = __version__.split(".")


### PR DESCRIPTION
## Summary
This allows us to create static files with a persistent volume mounted on multiple nodes without overwriting the data. We now store a list of dictionaries for volumes so as to not overwrite the key. 