### PR TITLE
Update OCP manifest to match latest version of operator

### DIFF
--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.4.9"
+__version__ = "2.4.10"
 VERSION = __version__.split(".")

--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.4.8"
+__version__ = "2.4.9"
 VERSION = __version__.split(".")

--- a/nise/ocp-template-manifest.json
+++ b/nise/ocp-template-manifest.json
@@ -5,5 +5,7 @@
     "date": "{{ report_datetime }}",
     "files": ["{{ files }}"],
     "start": "{{ start }}",
-    "end": "{{ end }}"
+    "end": "{{ end }}",
+    "certified": "{{ certified }}",
+    "cr_status": "{{ cr_status }}"
 }

--- a/nise/report.py
+++ b/nise/report.py
@@ -766,13 +766,8 @@ def ocp_create_report(options):  # noqa: C901
                 "clusterID": "4e009161-4f40-42c8-877c-3e59f6baea3d",
                 "clusterVersion": "stable-4.6",
                 "api_url": "https://cloud.redhat.com",
-                "authentication": {
-                    "type": "token"
-                },
-                "packaging": {
-                    "max_reports_to_store": 30,
-                    "max_size_MB": 100
-                },
+                "authentication": {"type": "token"},
+                "packaging": {"max_reports_to_store": 30, "max_size_MB": 100},
                 "upload": {
                     "ingress_path": "/api/ingress/v1/upload",
                     "upload": True,
@@ -790,13 +785,13 @@ def ocp_create_report(options):  # noqa: C901
                 "reports": {
                     "report_month": "07",
                     "last_hour_queried": "2021-07-28 11:00:00 - 2021-07-28 11:59:59",
-                    "data_collected": True
+                    "data_collected": True,
                 },
                 "source": {
                     "sources_path": "/api/sources/v1.0/",
                     "name": "INSERT-SOURCE-NAME",
                     "create_source": False,
-                    "check_cycle": 1440
+                    "check_cycle": 1440,
                 },
             }
             manifest_values = {
@@ -808,7 +803,7 @@ def ocp_create_report(options):  # noqa: C901
                 "end": gen_end_date,
                 "version": __version__,
                 "certified": False,
-                "cr_status": cr_status
+                "cr_status": cr_status,
             }
             manifest_data = ocp_generate_manifest(manifest_values)
             temp_manifest = _write_manifest(manifest_data)

--- a/nise/report.py
+++ b/nise/report.py
@@ -762,6 +762,43 @@ def ocp_create_report(options):  # noqa: C901
                 temp_files[temp_filename] = temp_usage_file
 
             manifest_file_names = ", ".join(f'"{w}"' for w in temp_files)
+            cr_status = {
+                "clusterID": "4e009161-4f40-42c8-877c-3e59f6baea3d",
+                "clusterVersion": "stable-4.6",
+                "api_url": "https://cloud.redhat.com",
+                "authentication": {
+                    "type": "token"
+                },
+                "packaging": {
+                    "max_reports_to_store": 30,
+                    "max_size_MB": 100
+                },
+                "upload": {
+                    "ingress_path": "/api/ingress/v1/upload",
+                    "upload": True,
+                    "upload_wait": 27,
+                    "upload_cycle": 360,
+                },
+                "operator_commit": __version__,
+                "prometheus": {
+                    "prometheus_configured": True,
+                    "prometheus_connected": True,
+                    "last_query_start_time": "2021-07-28T12:22:37Z",
+                    "last_query_success_time": "2021-07-28T12:22:37Z",
+                    "service_address": "https://thanos-querier.openshift-monitoring.svc:9091",
+                },
+                "reports": {
+                    "report_month": "07",
+                    "last_hour_queried": "2021-07-28 11:00:00 - 2021-07-28 11:59:59",
+                    "data_collected": True
+                },
+                "source": {
+                    "sources_path": "/api/sources/v1.0/",
+                    "name": "INSERT-SOURCE-NAME",
+                    "create_source": False,
+                    "check_cycle": 1440
+                },
+            }
             manifest_values = {
                 "ocp_cluster_id": cluster_id,
                 "ocp_assembly_id": ocp_assembly_id,
@@ -770,6 +807,8 @@ def ocp_create_report(options):  # noqa: C901
                 "start": gen_start_date,
                 "end": gen_end_date,
                 "version": __version__,
+                "certified": False,
+                "cr_status": cr_status
             }
             manifest_data = ocp_generate_manifest(manifest_values)
             temp_manifest = _write_manifest(manifest_data)


### PR DESCRIPTION
### Testing 

1. Pull this branch and build the client: 
```
python setup.py install
```
2. Run this command pointing at a directory that exists: 
```
nise report ocp  --ocp-cluster-id my-ocp-cluster --static-report-file examples/ocp_on_aws/ocp_static_data.yml --insights-upload test2
```
3. View the manifest that is generated: 
```
(nise) ashleybrookeaiken@aaiken-mac nise % cat test2/my-ocp-cluster/20190701-20190801/manifest.json 
{
    "uuid": "bbf2e24e-2e0e-4a63-8077-1659f9d6320a",
    "cluster_id": "my-ocp-cluster",
    "version": "2.4.10",
    "date": "2019-07-01 00:00:00",
    "files": ["bbf2e24e-2e0e-4a63-8077-1659f9d6320a_openshift_report.0.csv", "bbf2e24e-2e0e-4a63-8077-1659f9d6320a_openshift_report.1.csv", "bbf2e24e-2e0e-4a63-8077-1659f9d6320a_openshift_report.2.csv", "bbf2e24e-2e0e-4a63-8077-1659f9d6320a_openshift_report.3.csv"],
    "start": "2019-07-01 00:00:00",
    "end": "2019-07-31 00:00:00",
    "certified": "False",
    "cr_status": "{'clusterID': '4e009161-4f40-42c8-877c-3e59f6baea3d', 'clusterVersion': 'stable-4.6', 'api_url': 'https://cloud.redhat.com', 'authentication': {'type': 'token'}, 'packaging': {'max_reports_to_store': 30, 'max_size_MB': 100}, 'upload': {'ingress_path': '/api/ingress/v1/upload', 'upload': True, 'upload_wait': 27, 'upload_cycle': 360}, 'operator_commit': '2.4.10', 'prometheus': {'prometheus_configured': True, 'prometheus_connected': True, 'last_query_start_time': '2021-07-28T12:22:37Z', 'last_query_success_time': '2021-07-28T12:22:37Z', 'service_address': 'https://thanos-querier.openshift-monitoring.svc:9091'}, 'reports': {'report_month': '07', 'last_hour_queried': '2021-07-28 11:00:00 - 2021-07-28 11:59:59', 'data_collected': True}, 'source': {'sources_path': '/api/sources/v1.0/', 'name': 'INSERT-SOURCE-NAME', 'create_source': False, 'check_cycle': 1440}}"
}
```