### PR TITLE
Return a dictionary for JSONL labels

### DIFF
--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.4.12"
+__version__ = "2.4.13"
 VERSION = __version__.split(".")

--- a/nise/generators/gcp/gcp_generator.py
+++ b/nise/generators/gcp/gcp_generator.py
@@ -211,7 +211,10 @@ class GCPGenerator(AbstractGenerator):
     def determine_labels(self, labels):
         """Determine the labels based on tags param."""
         if not self._labels:
-            return json.dumps(choice(labels))
+            if self.return_list:
+                return choice(labels)
+            else:
+                return json.dumps(choice(labels))
         label_format = []
         for label in self._labels:
             if "key" not in label and "value" not in label:


### PR DESCRIPTION
## Summary
When the return_list variable is true (when sending to BigQuery) we should return a dictionary, not a JSON string. 