### PR TITLE
Add currency support

### DIFF
--- a/example_aws-marketplace_static_data.yml
+++ b/example_aws-marketplace_static_data.yml
@@ -1,0 +1,24 @@
+---
+  generators:
+    - MarketplaceGenerator:
+        start_date: 2020-12-01
+        processor_arch: 32-bit
+        resource_id: 55555555
+        product_sku: VEAJHRNKTJZQ
+        region: us-east-1a
+        tags:
+          resourceTags/aws:createdBy: AssumedRole:AROAYSLL3JVQ6DYUNKWQJ:1637692740557658269
+        instance_type:
+          inst_type: m5.large
+          vcpu: 2
+          memory: '8 GiB'
+          storage: 'EBS Only'
+          family: 'General Purpose'
+          cost: 1.000
+          rate: 0.500
+
+  accounts:
+    payer: 9999999999999
+    user:
+      - 9999999999999
+    currency_code: USD

--- a/example_aws_static_data.yml
+++ b/example_aws_static_data.yml
@@ -56,3 +56,4 @@
     payer: 9999999999999
     user:
       - 9999999999999
+    currency_code: USD #can be changed when testing with foreign currency codes

--- a/example_azure_static_data.yml
+++ b/example_azure_static_data.yml
@@ -25,9 +25,9 @@ generators:
       additional_info: {"ConsumptionMeter": "1111aaaa-22bb-33cc-44dd-555555eeeeee"}
 
 
-
 # SubscriptionGuid
 accounts:
   payer: 38f1d748-3ac7-4b7f-a5ae-8b5ff16db82c
   user:
     - 38f1d748-3ac7-4b7f-a5ae-8b5ff16db82c
+  currency_code: USD #can be changed when testing with foreign currency codes

--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.6.1"
+__version__ = "2.7.0"
 VERSION = __version__.split(".")

--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.5.6"
+__version__ = "2.5.7"
 VERSION = __version__.split(".")

--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.5.4"
+__version__ = "2.5.5"
 VERSION = __version__.split(".")

--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.5.7"
+__version__ = "2.6.0"
 VERSION = __version__.split(".")

--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.5.5"
+__version__ = "2.5.6"
 VERSION = __version__.split(".")

--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.5.3"
+__version__ = "2.5.4"
 VERSION = __version__.split(".")

--- a/nise/__main__.py
+++ b/nise/__main__.py
@@ -52,6 +52,29 @@ def valid_date(date_string):
         raise argparse.ArgumentTypeError(msg)
     return valid
 
+def valid_currency(currency):
+    """Validate the currency passed in."""
+    valid_currencies = [
+        "aud",
+        "cad",
+        "chf",
+        "cny",
+        "dkk",
+        "eur",
+        "gbp",
+        "hkd",
+        "jpy",
+        "nok",
+        "nzd",
+        "sek",
+        "sgd",
+        "usd",
+        "zar"
+    ]
+    if currency.lower() in valid_currencies:
+        return currency.upper()
+    msg = f"{currency} is an unsupported currency code."
+    raise argparse.ArgumentTypeError(msg)
 
 def today():
     """Create the date of today."""
@@ -205,7 +228,15 @@ def create_parser():
     yaml_parser = subparsers.add_parser("yaml", help="Generate a yaml for creating cost usage reports.")
 
     add_yaml_parser_args(yaml_parser)
-
+    report_parser.add_argument(
+        "-c",
+        "--currency",
+        dest="currency",
+        required=False,
+        type=valid_currency,
+        default="USD",
+        help="Sets the currency code on the reports",
+    )
     parent_parser = argparse.ArgumentParser()
     parent_parser.add_argument(
         "-s",

--- a/nise/__main__.py
+++ b/nise/__main__.py
@@ -52,6 +52,7 @@ def valid_date(date_string):
         raise argparse.ArgumentTypeError(msg)
     return valid
 
+
 def valid_currency(currency):
     """Validate the currency passed in."""
     valid_currencies = [
@@ -69,12 +70,13 @@ def valid_currency(currency):
         "sek",
         "sgd",
         "usd",
-        "zar"
+        "zar",
     ]
     if currency.lower() in valid_currencies:
         return currency.upper()
     msg = f"{currency} is an unsupported currency code."
     raise argparse.ArgumentTypeError(msg)
+
 
 def today():
     """Create the date of today."""

--- a/nise/__main__.py
+++ b/nise/__main__.py
@@ -236,7 +236,6 @@ def create_parser():
         dest="currency",
         required=False,
         type=valid_currency,
-        default="USD",
         help="Sets the currency code on the reports",
     )
     parent_parser = argparse.ArgumentParser()

--- a/nise/__main__.py
+++ b/nise/__main__.py
@@ -274,7 +274,7 @@ def create_parser():
         dest="currency",
         required=False,
         type=valid_currency,
-        help="Sets the currency code on the reports",
+        help="Sets the currency code on the reports, this will also override any currency in static ymls",
     )
     parent_parser = argparse.ArgumentParser()
     parent_parser.add_argument(

--- a/nise/generators/aws/aws_generator.py
+++ b/nise/generators/aws/aws_generator.py
@@ -248,7 +248,7 @@ class AWSGenerator(AbstractGenerator):
         ("AWS GovCloud (US)", "us-gov-west-1", "us-gov-west-1a", "USGW1-EBS"),
     )
 
-    def __init__(self, start_date, end_date, payer_account, currency,  usage_accounts, attributes=None, tag_cols=None):
+    def __init__(self, start_date, end_date, payer_account, currency, usage_accounts, attributes=None, tag_cols=None):
         """Initialize the generator."""
         self.payer_account = payer_account
         self.currency = currency

--- a/nise/generators/aws/aws_generator.py
+++ b/nise/generators/aws/aws_generator.py
@@ -248,9 +248,10 @@ class AWSGenerator(AbstractGenerator):
         ("AWS GovCloud (US)", "us-gov-west-1", "us-gov-west-1a", "USGW1-EBS"),
     )
 
-    def __init__(self, start_date, end_date, payer_account, usage_accounts, attributes=None, tag_cols=None):
+    def __init__(self, start_date, end_date, payer_account, currency,  usage_accounts, attributes=None, tag_cols=None):
         """Initialize the generator."""
         self.payer_account = payer_account
+        self.currency = currency
         self.usage_accounts = usage_accounts
         self.attributes = attributes
         self._tags = None
@@ -330,6 +331,7 @@ class AWSGenerator(AbstractGenerator):
         row["lineItem/LineItemType"] = "Usage"
         row["lineItem/UsageStartDate"] = start
         row["lineItem/UsageEndDate"] = end
+        row["lineItem/CurrencyCode"] = self.currency
         return row
 
     def _add_tag_data(self, row):

--- a/nise/generators/aws/aws_generator.py
+++ b/nise/generators/aws/aws_generator.py
@@ -205,7 +205,7 @@ class AWSGenerator(AbstractGenerator):
         + tuple(RESOURCE_TAG_COLS)
     )
 
-    def __init__(self, start_date, end_date, payer_account, currency, usage_accounts, attributes=None, tag_cols=None):
+    def __init__(self, start_date, end_date, currency, payer_account, usage_accounts, attributes=None, tag_cols=None):
         """Initialize the generator."""
         self.payer_account = payer_account
         self.currency = currency

--- a/nise/generators/aws/data_transfer_generator.py
+++ b/nise/generators/aws/data_transfer_generator.py
@@ -29,9 +29,9 @@ class DataTransferGenerator(AWSGenerator):
         ("{}-{}-AWS-Out-Bytes", "PublicIP-Out", "InterRegion Outbound"),
     )
 
-    def __init__(self, start_date, end_date, payer_account, currency, usage_accounts, attributes=None, tag_cols=None):
+    def __init__(self, start_date, end_date, currency, payer_account, usage_accounts, attributes=None, tag_cols=None):
         """Initialize the data transfer generator."""
-        super().__init__(start_date, end_date, payer_account, currency, usage_accounts, attributes, tag_cols)
+        super().__init__(start_date, end_date, currency, payer_account, usage_accounts, attributes, tag_cols)
         self._amount = None
         self._rate = None
         self._saving = None

--- a/nise/generators/aws/data_transfer_generator.py
+++ b/nise/generators/aws/data_transfer_generator.py
@@ -29,9 +29,9 @@ class DataTransferGenerator(AWSGenerator):
         ("{}-{}-AWS-Out-Bytes", "PublicIP-Out", "InterRegion Outbound"),
     )
 
-    def __init__(self, start_date, end_date, payer_account, usage_accounts, attributes=None, tag_cols=None):
+    def __init__(self, start_date, end_date, payer_account, currency, usage_accounts, attributes=None, tag_cols=None):
         """Initialize the data transfer generator."""
-        super().__init__(start_date, end_date, payer_account, usage_accounts, attributes, tag_cols)
+        super().__init__(start_date, end_date, payer_account, currency, usage_accounts, attributes, tag_cols)
         self._amount = None
         self._rate = None
         self._saving = None
@@ -92,7 +92,6 @@ class DataTransferGenerator(AWSGenerator):
         row["lineItem/Operation"] = operation
         row["lineItem/ResourceId"] = resource_id
         row["lineItem/UsageAmount"] = str(amount)
-        row["lineItem/CurrencyCode"] = "USD"
         row["lineItem/UnblendedRate"] = str(rate)
         row["lineItem/UnblendedCost"] = str(cost)
         row["lineItem/BlendedRate"] = str(rate)

--- a/nise/generators/aws/ebs_generator.py
+++ b/nise/generators/aws/ebs_generator.py
@@ -29,9 +29,9 @@ class EBSGenerator(AWSGenerator):
         ("3000 for volumes <= 1 TiB", "10000", "160 MB/sec", "16 TiB", "SSD-backed", "General Purpose"),
     )
 
-    def __init__(self, start_date, end_date, payer_account, currency, usage_accounts, attributes=None, tag_cols=None):
+    def __init__(self, start_date, end_date, currency, payer_account, usage_accounts, attributes=None, tag_cols=None):
         """Initialize the EBS generator."""
-        super().__init__(start_date, end_date, payer_account, currency, usage_accounts, attributes, tag_cols)
+        super().__init__(start_date, end_date, currency, payer_account, usage_accounts, attributes, tag_cols)
         self._resource_id = "vol-{}".format(self.fake.ean8())
         self._amount = uniform(0.2, 300.99)
         self._rate = round(uniform(0.02, 0.16), 3)

--- a/nise/generators/aws/ebs_generator.py
+++ b/nise/generators/aws/ebs_generator.py
@@ -29,9 +29,9 @@ class EBSGenerator(AWSGenerator):
         ("3000 for volumes <= 1 TiB", "10000", "160 MB/sec", "16 TiB", "SSD-backed", "General Purpose"),
     )
 
-    def __init__(self, start_date, end_date, payer_account, usage_accounts, attributes=None, tag_cols=None):
+    def __init__(self, start_date, end_date, payer_account, currency, usage_accounts, attributes=None, tag_cols=None):
         """Initialize the EBS generator."""
-        super().__init__(start_date, end_date, payer_account, usage_accounts, attributes, tag_cols)
+        super().__init__(start_date, end_date, payer_account, currency, usage_accounts, attributes, tag_cols)
         self._resource_id = "vol-{}".format(self.fake.ean8())
         self._amount = uniform(0.2, 300.99)
         self._rate = round(uniform(0.02, 0.16), 3)
@@ -69,7 +69,6 @@ class EBSGenerator(AWSGenerator):
         row["lineItem/Operation"] = "CreateVolume"
         row["lineItem/ResourceId"] = self._resource_id
         row["lineItem/UsageAmount"] = str(amount)
-        row["lineItem/CurrencyCode"] = "USD"
         row["lineItem/UnblendedRate"] = str(rate)
         row["lineItem/UnblendedCost"] = str(cost)
         row["lineItem/BlendedRate"] = str(rate)

--- a/nise/generators/aws/ec2_generator.py
+++ b/nise/generators/aws/ec2_generator.py
@@ -72,9 +72,9 @@ class EC2Generator(AWSGenerator):
 
     ARCHS = ("32-bit", "64-bit")
 
-    def __init__(self, start_date, end_date, payer_account, usage_accounts, attributes=None, tag_cols=None):
+    def __init__(self, start_date, end_date, payer_account, currency, usage_accounts, attributes=None, tag_cols=None):
         """Initialize the EC2 generator."""
-        super().__init__(start_date, end_date, payer_account, usage_accounts, attributes, tag_cols)
+        super().__init__(start_date, end_date, payer_account, currency, usage_accounts, attributes, tag_cols)
         self._processor_arch = choice(self.ARCHS)
         self._resource_id = "i-{}".format(self.fake.ean8())
         self._product_sku = self.fake.pystr(min_chars=12, max_chars=12).upper()
@@ -115,7 +115,6 @@ class EC2Generator(AWSGenerator):
         row["lineItem/AvailabilityZone"] = avail_zone
         row["lineItem/ResourceId"] = self._resource_id
         row["lineItem/UsageAmount"] = "1"
-        row["lineItem/CurrencyCode"] = "USD"
         row["lineItem/UnblendedRate"] = rate
         row["lineItem/UnblendedCost"] = cost
         row["lineItem/BlendedRate"] = rate

--- a/nise/generators/aws/ec2_generator.py
+++ b/nise/generators/aws/ec2_generator.py
@@ -72,9 +72,9 @@ class EC2Generator(AWSGenerator):
 
     ARCHS = ("32-bit", "64-bit")
 
-    def __init__(self, start_date, end_date, payer_account, currency, usage_accounts, attributes=None, tag_cols=None):
+    def __init__(self, start_date, end_date, currency, payer_account, usage_accounts, attributes=None, tag_cols=None):
         """Initialize the EC2 generator."""
-        super().__init__(start_date, end_date, payer_account, currency, usage_accounts, attributes, tag_cols)
+        super().__init__(start_date, end_date, currency, payer_account, usage_accounts, attributes, tag_cols)
         self._processor_arch = choice(self.ARCHS)
         self._resource_id = "i-{}".format(self.fake.ean8())
         self._product_sku = self.fake.pystr(min_chars=12, max_chars=12).upper()

--- a/nise/generators/aws/marketplace_generator.py
+++ b/nise/generators/aws/marketplace_generator.py
@@ -182,7 +182,7 @@ class MarketplaceGenerator(AbstractGenerator):
         + tuple(RESOURCE_TAG_COLS)
     )
 
-    def __init__(self, start_date, end_date, payer_account, usage_accounts, attributes=None, tag_cols=None):
+    def __init__(self, start_date, end_date, currency, payer_account, usage_accounts, attributes=None, tag_cols=None):
         super().__init__(start_date, end_date)
         """Initialize the generator."""
         self.payer_account = payer_account
@@ -194,6 +194,7 @@ class MarketplaceGenerator(AbstractGenerator):
         self._rate = round(uniform(0.02, 0.06), 3)
         self._product_sku = self.fake.pystr(min_chars=12, max_chars=12).upper()
         self._resource_id = "i-{}".format(self.fake.ean8())
+        self._currency = currency
 
         if self.attributes:
             if self.attributes.get("amount"):
@@ -334,7 +335,7 @@ class MarketplaceGenerator(AbstractGenerator):
         row["lineItem/AvailabilityZone"] = avail_zone
         row["lineItem/ResourceId"] = amazon_resource_name
         row["lineItem/UsageAmount"] = "1"
-        row["lineItem/CurrencyCode"] = "USD"
+        row["lineItem/CurrencyCode"] = self._currency
         row["lineItem/UnblendedRate"] = rate
         row["lineItem/UnblendedCost"] = cost
         row["lineItem/BlendedRate"] = rate

--- a/nise/generators/aws/rds_generator.py
+++ b/nise/generators/aws/rds_generator.py
@@ -68,9 +68,9 @@ class RDSGenerator(AWSGenerator):
 
     ARCHS = ("32-bit", "64-bit")
 
-    def __init__(self, start_date, end_date, payer_account, usage_accounts, attributes=None, tag_cols=None):
+    def __init__(self, start_date, end_date, payer_account, currency, usage_accounts, attributes=None, tag_cols=None):
         """Initialize the RDS generator."""
-        super().__init__(start_date, end_date, payer_account, usage_accounts, attributes, tag_cols)
+        super().__init__(start_date, end_date, payer_account,currency,  usage_accounts, attributes, tag_cols)
         self._processor_arch = choice(self.ARCHS)
         self._product_sku = self.fake.pystr(min_chars=12, max_chars=12).upper()
         self._instance_type = choice(self.INSTANCE_TYPES)
@@ -115,7 +115,6 @@ class RDSGenerator(AWSGenerator):
         row["lineItem/AvailabilityZone"] = avail_zone
         row["lineItem/ResourceId"] = self._get_arn(avail_zone)
         row["lineItem/UsageAmount"] = "1"
-        row["lineItem/CurrencyCode"] = "USD"
         row["lineItem/UnblendedRate"] = rate
         row["lineItem/UnblendedCost"] = cost
         row["lineItem/BlendedRate"] = rate

--- a/nise/generators/aws/rds_generator.py
+++ b/nise/generators/aws/rds_generator.py
@@ -70,7 +70,7 @@ class RDSGenerator(AWSGenerator):
 
     def __init__(self, start_date, end_date, payer_account, currency, usage_accounts, attributes=None, tag_cols=None):
         """Initialize the RDS generator."""
-        super().__init__(start_date, end_date, payer_account,currency,  usage_accounts, attributes, tag_cols)
+        super().__init__(start_date, end_date, payer_account, currency,  usage_accounts, attributes, tag_cols)
         self._processor_arch = choice(self.ARCHS)
         self._product_sku = self.fake.pystr(min_chars=12, max_chars=12).upper()
         self._instance_type = choice(self.INSTANCE_TYPES)

--- a/nise/generators/aws/rds_generator.py
+++ b/nise/generators/aws/rds_generator.py
@@ -70,7 +70,7 @@ class RDSGenerator(AWSGenerator):
 
     def __init__(self, start_date, end_date, payer_account, currency, usage_accounts, attributes=None, tag_cols=None):
         """Initialize the RDS generator."""
-        super().__init__(start_date, end_date, payer_account, currency,  usage_accounts, attributes, tag_cols)
+        super().__init__(start_date, end_date, payer_account, currency, usage_accounts, attributes, tag_cols)
         self._processor_arch = choice(self.ARCHS)
         self._product_sku = self.fake.pystr(min_chars=12, max_chars=12).upper()
         self._instance_type = choice(self.INSTANCE_TYPES)

--- a/nise/generators/aws/rds_generator.py
+++ b/nise/generators/aws/rds_generator.py
@@ -68,9 +68,9 @@ class RDSGenerator(AWSGenerator):
 
     ARCHS = ("32-bit", "64-bit")
 
-    def __init__(self, start_date, end_date, payer_account, currency, usage_accounts, attributes=None, tag_cols=None):
+    def __init__(self, start_date, end_date, currency, payer_account, usage_accounts, attributes=None, tag_cols=None):
         """Initialize the RDS generator."""
-        super().__init__(start_date, end_date, payer_account, currency, usage_accounts, attributes, tag_cols)
+        super().__init__(start_date, end_date, currency, payer_account, usage_accounts, attributes, tag_cols)
         self._processor_arch = choice(self.ARCHS)
         self._product_sku = self.fake.pystr(min_chars=12, max_chars=12).upper()
         self._instance_type = choice(self.INSTANCE_TYPES)

--- a/nise/generators/aws/route53_generator.py
+++ b/nise/generators/aws/route53_generator.py
@@ -29,9 +29,9 @@ ROUTE_53_PRODUCTS = list(ROUTE_53_PRODUCTS_DICT.values())
 class Route53Generator(AWSGenerator):
     """Generator for Route53 data."""
 
-    def __init__(self, start_date, end_date, payer_account, usage_accounts, attributes=None, tag_cols=None):
+    def __init__(self, start_date, end_date, payer_account, currency, usage_accounts, attributes=None, tag_cols=None):
         """Initialize the Route53 generator."""
-        super().__init__(start_date, end_date, payer_account, usage_accounts, attributes, tag_cols)
+        super().__init__(start_date, end_date, payer_account, currency, usage_accounts, attributes, tag_cols)
         self._product_sku = self.fake.pystr(min_chars=12, max_chars=12).upper()
         self._product_family = None
         self._resource_id = self.fake.ean8()
@@ -76,7 +76,6 @@ class Route53Generator(AWSGenerator):
         row["lineItem/AvailabilityZone"] = ""
         row["lineItem/ResourceId"] = self._get_arn()
         row["lineItem/UsageAmount"] = "1"
-        row["lineItem/CurrencyCode"] = "USD"
         row["lineItem/UnblendedRate"] = rate
         row["lineItem/UnblendedCost"] = cost
         row["lineItem/BlendedRate"] = rate

--- a/nise/generators/aws/route53_generator.py
+++ b/nise/generators/aws/route53_generator.py
@@ -29,9 +29,9 @@ ROUTE_53_PRODUCTS = list(ROUTE_53_PRODUCTS_DICT.values())
 class Route53Generator(AWSGenerator):
     """Generator for Route53 data."""
 
-    def __init__(self, start_date, end_date, payer_account, currency, usage_accounts, attributes=None, tag_cols=None):
+    def __init__(self, start_date, end_date, currency, payer_account, usage_accounts, attributes=None, tag_cols=None):
         """Initialize the Route53 generator."""
-        super().__init__(start_date, end_date, payer_account, currency, usage_accounts, attributes, tag_cols)
+        super().__init__(start_date, end_date, currency, payer_account, usage_accounts, attributes, tag_cols)
         self._product_sku = self.fake.pystr(min_chars=12, max_chars=12).upper()
         self._product_family = None
         self._resource_id = self.fake.ean8()

--- a/nise/generators/aws/s3_generator.py
+++ b/nise/generators/aws/s3_generator.py
@@ -25,7 +25,7 @@ class S3Generator(AWSGenerator):
 
     def __init__(self, start_date, end_date, payer_account, currency, usage_accounts, attributes=None, tag_cols=None):
         """Initialize the S3 generator."""
-        super().__init__(start_date, end_date, payer_account, currency,  usage_accounts, attributes, tag_cols)
+        super().__init__(start_date, end_date, payer_account, currency, usage_accounts, attributes, tag_cols)
         self._amount = uniform(0.2, 6000.99)
         self._rate = round(uniform(0.02, 0.06), 3)
         self._product_sku = self.fake.pystr(min_chars=12, max_chars=12).upper()

--- a/nise/generators/aws/s3_generator.py
+++ b/nise/generators/aws/s3_generator.py
@@ -23,9 +23,9 @@ from nise.generators.aws.aws_generator import AWSGenerator
 class S3Generator(AWSGenerator):
     """Generator for S3 data."""
 
-    def __init__(self, start_date, end_date, payer_account, currency, usage_accounts, attributes=None, tag_cols=None):
+    def __init__(self, start_date, end_date, currency, payer_account, usage_accounts, attributes=None, tag_cols=None):
         """Initialize the S3 generator."""
-        super().__init__(start_date, end_date, payer_account, currency, usage_accounts, attributes, tag_cols)
+        super().__init__(start_date, end_date, currency, payer_account, usage_accounts, attributes, tag_cols)
         self._amount = uniform(0.2, 6000.99)
         self._rate = round(uniform(0.02, 0.06), 3)
         self._product_sku = self.fake.pystr(min_chars=12, max_chars=12).upper()

--- a/nise/generators/aws/s3_generator.py
+++ b/nise/generators/aws/s3_generator.py
@@ -23,9 +23,9 @@ from nise.generators.aws.aws_generator import AWSGenerator
 class S3Generator(AWSGenerator):
     """Generator for S3 data."""
 
-    def __init__(self, start_date, end_date, payer_account, usage_accounts, attributes=None, tag_cols=None):
+    def __init__(self, start_date, end_date, payer_account, currency, usage_accounts, attributes=None, tag_cols=None):
         """Initialize the S3 generator."""
-        super().__init__(start_date, end_date, payer_account, usage_accounts, attributes, tag_cols)
+        super().__init__(start_date, end_date, payer_account, currency,  usage_accounts, attributes, tag_cols)
         self._amount = uniform(0.2, 6000.99)
         self._rate = round(uniform(0.02, 0.06), 3)
         self._product_sku = self.fake.pystr(min_chars=12, max_chars=12).upper()
@@ -62,7 +62,6 @@ class S3Generator(AWSGenerator):
         row["lineItem/Operation"] = "GetObject"
         row["lineItem/ResourceId"] = amazon_resource_name
         row["lineItem/UsageAmount"] = str(amount)
-        row["lineItem/CurrencyCode"] = "USD"
         row["lineItem/UnblendedRate"] = str(rate)
         row["lineItem/UnblendedCost"] = str(cost)
         row["lineItem/BlendedRate"] = str(rate)

--- a/nise/generators/aws/vpc_generator.py
+++ b/nise/generators/aws/vpc_generator.py
@@ -40,7 +40,6 @@ class VPCGenerator(AWSGenerator):
             if self.attributes.get("rate"):
                 self._rate = self.attributes.get("rate")
 
-
     def _update_data(self, row, start, end, **kwargs):
         """Update data with generator specific data."""
         default_cost = 0.05

--- a/nise/generators/aws/vpc_generator.py
+++ b/nise/generators/aws/vpc_generator.py
@@ -21,9 +21,9 @@ from nise.generators.aws.aws_generator import AWSGenerator
 class VPCGenerator(AWSGenerator):
     """Generator for VPC data."""
 
-    def __init__(self, start_date, end_date, payer_account, usage_accounts, attributes=None, tag_cols=None):
+    def __init__(self, start_date, end_date, payer_account, currency, usage_accounts, attributes=None, tag_cols=None):
         """Initialize the VPC generator."""
-        super().__init__(start_date, end_date, payer_account, usage_accounts, attributes, tag_cols)
+        super().__init__(start_date, end_date, payer_account, currency, usage_accounts, attributes, tag_cols)
         self._resource_id = "vpn-{}".format(self.fake.ean8())
         self._product_sku = self.fake.pystr(min_chars=12, max_chars=12).upper()
         self._rate = None
@@ -39,6 +39,7 @@ class VPCGenerator(AWSGenerator):
                 self._cost = self.attributes.get("cost")
             if self.attributes.get("rate"):
                 self._rate = self.attributes.get("rate")
+
 
     def _update_data(self, row, start, end, **kwargs):
         """Update data with generator specific data."""
@@ -57,7 +58,6 @@ class VPCGenerator(AWSGenerator):
         row["lineItem/AvailabilityZone"] = avail_zone
         row["lineItem/ResourceId"] = self._resource_id
         row["lineItem/UsageAmount"] = "1"
-        row["lineItem/CurrencyCode"] = "USD"
         row["lineItem/UnblendedRate"] = rate
         row["lineItem/UnblendedCost"] = cost
         row["lineItem/BlendedRate"] = rate

--- a/nise/generators/aws/vpc_generator.py
+++ b/nise/generators/aws/vpc_generator.py
@@ -21,9 +21,9 @@ from nise.generators.aws.aws_generator import AWSGenerator
 class VPCGenerator(AWSGenerator):
     """Generator for VPC data."""
 
-    def __init__(self, start_date, end_date, payer_account, currency, usage_accounts, attributes=None, tag_cols=None):
+    def __init__(self, start_date, end_date, currency, payer_account, usage_accounts, attributes=None, tag_cols=None):
         """Initialize the VPC generator."""
-        super().__init__(start_date, end_date, payer_account, currency, usage_accounts, attributes, tag_cols)
+        super().__init__(start_date, end_date, currency, payer_account, usage_accounts, attributes, tag_cols)
         self._resource_id = "vpn-{}".format(self.fake.ean8())
         self._product_sku = self.fake.pystr(min_chars=12, max_chars=12).upper()
         self._rate = None

--- a/nise/generators/azure/azure_generator.py
+++ b/nise/generators/azure/azure_generator.py
@@ -147,7 +147,7 @@ class AzureGenerator(AbstractGenerator):
 
     INVOICE_SECTION_NAMES = ("IT Services",)
 
-    def __init__(self, start_date, end_date, account_info, attributes=None):  # noqa: C901
+    def __init__(self, start_date, end_date, currency, account_info, attributes=None):  # noqa: C901
         """Initialize the generator."""
         self.azure_columns = AZURE_COLUMNS
         self.subscription_guid = account_info.get("subscription_guid")
@@ -167,7 +167,7 @@ class AzureGenerator(AbstractGenerator):
         self._consumed = None
         self._resource_type = None
         self._meter_cache = {}
-        self._billing_currency = account_info.get("currency_code")
+        self._billing_currency = currency
         # Version 2 fields
         self._invoice_section_id = None
         self._invoice_section_name = None

--- a/nise/generators/azure/bandwidth_generator.py
+++ b/nise/generators/azure/bandwidth_generator.py
@@ -54,7 +54,7 @@ class BandwidthGenerator(AzureGenerator):
         },
     )
 
-    def __init__(self, start_date, end_date, account_info, attributes=None):
+    def __init__(self, start_date, end_date, currency, account_info, attributes=None):
         """Initialize the data transfer generator."""
         self._service_name = "Bandwidth"
-        super().__init__(start_date, end_date, account_info, attributes)
+        super().__init__(start_date, end_date, currency, account_info, attributes)

--- a/nise/generators/azure/sql_database_generator.py
+++ b/nise/generators/azure/sql_database_generator.py
@@ -35,7 +35,7 @@ class SQLGenerator(AzureGenerator):
     )
     ADDITIONAL_INFO = ({"ConsumptionMeter": "22222222-3333-4444-5555-666666666666"},)
 
-    def __init__(self, start_date, end_date, account_info, attributes=None):
+    def __init__(self, start_date, end_date, currency, account_info, attributes=None):
         """Initialize the data transfer generator."""
         self._service_name = "SQL Database"
-        super().__init__(start_date, end_date, account_info, attributes)
+        super().__init__(start_date, end_date, currency, account_info, attributes)

--- a/nise/generators/azure/storage_generator.py
+++ b/nise/generators/azure/storage_generator.py
@@ -62,7 +62,7 @@ class StorageGenerator(AzureGenerator):
     )
     ADDITIONAL_INFO = [None]
 
-    def __init__(self, start_date, end_date, account_info, attributes=None):
+    def __init__(self, start_date, end_date, currency, account_info, attributes=None):
         """Initialize the data transfer generator."""
         self._service_name = "Storage"
-        super().__init__(start_date, end_date, account_info, attributes)
+        super().__init__(start_date, end_date, currency, account_info, attributes)

--- a/nise/generators/azure/virtual_machine_generator.py
+++ b/nise/generators/azure/virtual_machine_generator.py
@@ -52,7 +52,7 @@ class VMGenerator(AzureGenerator):
         },
     )
 
-    def __init__(self, start_date, end_date, account_info, attributes=None):
+    def __init__(self, start_date, end_date, currency, account_info, attributes=None):
         """Initialize the data transfer generator."""
         self._service_name = "Virtual Machines"
-        super().__init__(start_date, end_date, account_info, attributes)
+        super().__init__(start_date, end_date, currency, account_info, attributes)

--- a/nise/generators/azure/virtual_network_generator.py
+++ b/nise/generators/azure/virtual_network_generator.py
@@ -35,7 +35,7 @@ class VNGenerator(AzureGenerator):
     )
     ADDITIONAL_INFO = ({"ConsumptionMeter": "f114cb19-ea64-40b5-bcd7-aee474b62853"},)
 
-    def __init__(self, start_date, end_date, account_info, attributes=None):
+    def __init__(self, start_date, end_date, currency, account_info, attributes=None):
         """Initialize the data transfer generator."""
         self._service_name = "Virtual Network"
-        super().__init__(start_date, end_date, account_info, attributes)
+        super().__init__(start_date, end_date, currency, account_info, attributes)

--- a/nise/generators/gcp/cloud_storage_generator.py
+++ b/nise/generators/gcp/cloud_storage_generator.py
@@ -78,7 +78,6 @@ class CloudStorageGenerator(GCPGenerator):
         row["usage.amount_in_pricing_units"] = self._gen_pricing_unit_amount(pricing_unit, row["usage.amount"])
         cost = self._gen_cost(row["usage.amount_in_pricing_units"])
         row["cost"] = cost
-        row["currency"] = self._currency
         credit, credit_total = self._gen_credit(self.credit_total, self._credit_amount)
         self.credit_total = credit_total
         row["credits"] = credit
@@ -90,6 +89,7 @@ class CloudStorageGenerator(GCPGenerator):
                 if key in self.column_labels:
                     row[key] = self.attributes[key]
 
+        row["currency"] = self._currency
         row["labels"] = self.determine_labels(self.LABELS)
         row["system_labels"] = choice(self.SYSTEM_LABELS)
 
@@ -152,6 +152,7 @@ class JSONLCloudStorageGenerator(CloudStorageGenerator):
                     outer_key, inner_key = key.split(".")
                     row[outer_key][inner_key] = self.attributes[key]
 
+        row["currency"] = self._currency
         row["labels"] = self.determine_labels(self.LABELS)
         row["system_labels"] = choice(self.SYSTEM_LABELS)
 

--- a/nise/generators/gcp/cloud_storage_generator.py
+++ b/nise/generators/gcp/cloud_storage_generator.py
@@ -45,7 +45,7 @@ class CloudStorageGenerator(GCPGenerator):
         """Initialize the cloud storage generator."""
         super().__init__(start_date, end_date, currency, project, attributes)
         self.credit_total = 0
-        self._currency = currency 
+        self._currency = currency
         if self.attributes:
             if self.attributes.get("labels"):
                 self._labels = self.attributes.get("labels")

--- a/nise/generators/gcp/cloud_storage_generator.py
+++ b/nise/generators/gcp/cloud_storage_generator.py
@@ -41,10 +41,11 @@ class CloudStorageGenerator(GCPGenerator):
 
     SYSTEM_LABELS = (("[]"),)
 
-    def __init__(self, start_date, end_date, project, attributes=None):
+    def __init__(self, start_date, end_date, currency, project, attributes=None):
         """Initialize the cloud storage generator."""
-        super().__init__(start_date, end_date, project, attributes)
+        super().__init__(start_date, end_date, currency, project, attributes)
         self.credit_total = 0
+        self._currency = currency 
         if self.attributes:
             if self.attributes.get("labels"):
                 self._labels = self.attributes.get("labels")
@@ -72,12 +73,12 @@ class CloudStorageGenerator(GCPGenerator):
         row["usage.unit"] = usage_unit
         row["usage.pricing_unit"] = pricing_unit
         row["cost_type"] = "regular"
-        row["currency"] = "USD"
         row["currency_conversion_rate"] = 1
         row["usage.amount"] = self._gen_usage_unit_amount(usage_unit)
         row["usage.amount_in_pricing_units"] = self._gen_pricing_unit_amount(pricing_unit, row["usage.amount"])
         cost = self._gen_cost(row["usage.amount_in_pricing_units"])
         row["cost"] = cost
+        row["currency"] = self._currency
         credit, credit_total = self._gen_credit(self.credit_total, self._credit_amount)
         self.credit_total = credit_total
         row["credits"] = credit
@@ -136,7 +137,6 @@ class JSONLCloudStorageGenerator(CloudStorageGenerator):
         self.credit_total = credit_total
         row["credits"] = credit
         row["cost_type"] = "regular"
-        row["currency"] = "USD"
         row["currency_conversion_rate"] = 1
         invoice = {}
         year = datetime.strptime(row.get("usage_start_time"), "%Y-%m-%dT%H:%M:%S").year

--- a/nise/generators/gcp/cloud_storage_generator.py
+++ b/nise/generators/gcp/cloud_storage_generator.py
@@ -105,8 +105,8 @@ class JSONLCloudStorageGenerator(CloudStorageGenerator):
 
     SYSTEM_LABELS = (([]),)
 
-    def __init__(self, start_date, end_date, project, attributes=None):
-        super().__init__(start_date, end_date, project, attributes)
+    def __init__(self, start_date, end_date, currency, project, attributes=None):
+        super().__init__(start_date, end_date, currency, project, attributes)
         self.column_labels = GCP_REPORT_COLUMNS_JSONL
         self.return_list = True
 

--- a/nise/generators/gcp/compute_engine_generator.py
+++ b/nise/generators/gcp/compute_engine_generator.py
@@ -16,6 +16,7 @@
 #
 """Module for gcp compute engine data generation."""
 from datetime import datetime
+from locale import currency
 from random import choice
 
 from nise.generators.gcp.gcp_generator import GCP_REPORT_COLUMNS_JSONL
@@ -47,9 +48,9 @@ class ComputeEngineGenerator(GCPGenerator):
 
     LABELS = (([{"key": "vm_key_proj2", "value": "vm_label_proj2"}]), ([]))
 
-    def __init__(self, start_date, end_date, project, attributes=None):  # noqa: C901
+    def __init__(self, start_date, end_date, currency, project, attributes=None):  # noqa: C901
         """Initialize the cloud storage generator."""
-        super().__init__(start_date, end_date, project, attributes)
+        super().__init__(start_date, end_date, currency, project, attributes)
         self.credit_total = 0
         if self.attributes:
             if self.attributes.get("labels"):
@@ -83,7 +84,7 @@ class ComputeEngineGenerator(GCPGenerator):
         row["usage.unit"] = usage_unit
         row["usage.pricing_unit"] = pricing_unit
         row["cost_type"] = "regular"
-        row["currency"] = "USD"
+        row["currency"] = self._currency
         row["currency_conversion_rate"] = 1
         row["usage.amount"] = self._gen_usage_unit_amount(usage_unit)
         row["usage.amount_in_pricing_units"] = self._gen_pricing_unit_amount(pricing_unit, row["usage.amount"])
@@ -115,10 +116,11 @@ class JSONLComputeEngineGenerator(ComputeEngineGenerator):
 
     LABELS = (([{"key": "vm_key_proj2", "value": "vm_label_proj2"}]), ([]))
 
-    def __init__(self, start_date, end_date, project, attributes=None):
-        super().__init__(start_date, end_date, project, attributes)
+    def __init__(self, start_date, end_date, project, currency, attributes=None):
+        super().__init__(start_date, end_date, project, currency, attributes)
         self.column_labels = GCP_REPORT_COLUMNS_JSONL
         self.return_list = True
+        self._currency = currency
 
     def _update_data(self, row):  # noqa: C901
         """Update a data row with compute values."""
@@ -147,7 +149,7 @@ class JSONLComputeEngineGenerator(ComputeEngineGenerator):
         self.credit_total = credit_total
         row["credits"] = credit
         row["cost_type"] = "regular"
-        row["currency"] = "USD"
+        row["currency"] = self._currency
         row["currency_conversion_rate"] = 1
         invoice = {}
         year = datetime.strptime(row.get("usage_start_time"), "%Y-%m-%dT%H:%M:%S").year

--- a/nise/generators/gcp/compute_engine_generator.py
+++ b/nise/generators/gcp/compute_engine_generator.py
@@ -16,7 +16,6 @@
 #
 """Module for gcp compute engine data generation."""
 from datetime import datetime
-from locale import currency
 from random import choice
 
 from nise.generators.gcp.gcp_generator import GCP_REPORT_COLUMNS_JSONL

--- a/nise/generators/gcp/compute_engine_generator.py
+++ b/nise/generators/gcp/compute_engine_generator.py
@@ -83,7 +83,6 @@ class ComputeEngineGenerator(GCPGenerator):
         row["usage.unit"] = usage_unit
         row["usage.pricing_unit"] = pricing_unit
         row["cost_type"] = "regular"
-        row["currency"] = self._currency
         row["currency_conversion_rate"] = 1
         row["usage.amount"] = self._gen_usage_unit_amount(usage_unit)
         row["usage.amount_in_pricing_units"] = self._gen_pricing_unit_amount(pricing_unit, row["usage.amount"])
@@ -100,6 +99,7 @@ class ComputeEngineGenerator(GCPGenerator):
                 if key in self.column_labels:
                     row[key] = self.attributes[key]
 
+        row["currency"] = self._currency
         row["labels"] = self.determine_labels(self.LABELS)
         row["system_labels"] = self.determine_system_labels(sku[3])
 
@@ -115,8 +115,8 @@ class JSONLComputeEngineGenerator(ComputeEngineGenerator):
 
     LABELS = (([{"key": "vm_key_proj2", "value": "vm_label_proj2"}]), ([]))
 
-    def __init__(self, start_date, end_date, project, currency, attributes=None):
-        super().__init__(start_date, end_date, project, currency, attributes)
+    def __init__(self, start_date, end_date, currency, project, attributes=None):
+        super().__init__(start_date, end_date, currency, project, attributes)
         self.column_labels = GCP_REPORT_COLUMNS_JSONL
         self.return_list = True
         self._currency = currency
@@ -148,7 +148,6 @@ class JSONLComputeEngineGenerator(ComputeEngineGenerator):
         self.credit_total = credit_total
         row["credits"] = credit
         row["cost_type"] = "regular"
-        row["currency"] = self._currency
         row["currency_conversion_rate"] = 1
         invoice = {}
         year = datetime.strptime(row.get("usage_start_time"), "%Y-%m-%dT%H:%M:%S").year
@@ -164,6 +163,7 @@ class JSONLComputeEngineGenerator(ComputeEngineGenerator):
                     outer_key, inner_key = key.split(".")
                     row[outer_key][inner_key] = self.attributes[key]
 
+        row["currency"] = self._currency
         row["labels"] = self.determine_labels(self.LABELS)
         row["system_labels"] = self.determine_system_labels(sku_choice[3])
 

--- a/nise/generators/gcp/gcp_database_generator.py
+++ b/nise/generators/gcp/gcp_database_generator.py
@@ -41,10 +41,11 @@ class GCPDatabaseGenerator(GCPGenerator):
 
     LABELS = (([{"key": "vm_key_proj2", "value": "vm_label_proj2"}]), ([]))
 
-    def __init__(self, start_date, end_date, project, attributes=None):
+    def __init__(self, start_date, end_date, currency, project, attributes=None):
         """Initialize the cloud storage generator."""
-        super().__init__(start_date, end_date, project, attributes)
+        super().__init__(start_date, end_date, currency, project, attributes)
         self.credit_total = 0
+        self._currency = currency
         if self.attributes:
             if self.attributes.get("labels"):
                 self._labels = self.attributes.get("labels")
@@ -77,7 +78,7 @@ class GCPDatabaseGenerator(GCPGenerator):
         row["usage.unit"] = usage_unit
         row["usage.pricing_unit"] = pricing_unit
         row["cost_type"] = "regular"
-        row["currency"] = "USD"
+        row["currency"] = self.currency
         row["currency_conversion_rate"] = 1
         row["usage.amount"] = self._gen_usage_unit_amount(usage_unit)
         row["usage.amount_in_pricing_units"] = self._gen_pricing_unit_amount(pricing_unit, row["usage.amount"])
@@ -135,7 +136,6 @@ class JSONLGCPDatabaseGenerator(GCPDatabaseGenerator):
         usage["unit"] = usage_unit
         usage["pricing_unit"] = pricing_unit
         row["cost_type"] = "regular"
-        row["currency"] = "USD"
         row["currency_conversion_rate"] = 1
         usage["amount"] = self._gen_usage_unit_amount(usage_unit)
         usage["amount_in_pricing_units"] = self._gen_pricing_unit_amount(pricing_unit, usage["amount"])

--- a/nise/generators/gcp/gcp_database_generator.py
+++ b/nise/generators/gcp/gcp_database_generator.py
@@ -78,7 +78,6 @@ class GCPDatabaseGenerator(GCPGenerator):
         row["usage.unit"] = usage_unit
         row["usage.pricing_unit"] = pricing_unit
         row["cost_type"] = "regular"
-        row["currency"] = self.currency
         row["currency_conversion_rate"] = 1
         row["usage.amount"] = self._gen_usage_unit_amount(usage_unit)
         row["usage.amount_in_pricing_units"] = self._gen_pricing_unit_amount(pricing_unit, row["usage.amount"])
@@ -95,6 +94,7 @@ class GCPDatabaseGenerator(GCPGenerator):
                 if key in self.column_labels:
                     row[key] = self.attributes[key]
 
+        row["currency"] = self._currency
         row["labels"] = self.determine_labels(self.LABELS)
 
         return row
@@ -159,6 +159,7 @@ class JSONLGCPDatabaseGenerator(GCPDatabaseGenerator):
                     outer_key, inner_key = key.split(".")
                     row[outer_key][inner_key] = self.attributes[key]
 
+        row["currency"] = self._currency
         row["labels"] = self.determine_labels(self.LABELS)
 
         return row

--- a/nise/generators/gcp/gcp_database_generator.py
+++ b/nise/generators/gcp/gcp_database_generator.py
@@ -109,7 +109,7 @@ class JSONLGCPDatabaseGenerator(GCPDatabaseGenerator):
 
     LABELS = (([{"key": "vm_key_proj2", "value": "vm_label_proj2"}]), ([]))
 
-    def __init__(self, start_date, end_date, project, attributes=None):
+    def __init__(self, start_date, end_date, currency, project, attributes=None):
         super().__init__(start_date, end_date, project, attributes)
         self.column_labels = GCP_REPORT_COLUMNS_JSONL
         self.return_list = True

--- a/nise/generators/gcp/gcp_database_generator.py
+++ b/nise/generators/gcp/gcp_database_generator.py
@@ -110,7 +110,7 @@ class JSONLGCPDatabaseGenerator(GCPDatabaseGenerator):
     LABELS = (([{"key": "vm_key_proj2", "value": "vm_label_proj2"}]), ([]))
 
     def __init__(self, start_date, end_date, currency, project, attributes=None):
-        super().__init__(start_date, end_date, project, attributes)
+        super().__init__(start_date, end_date, currency, project, attributes)
         self.column_labels = GCP_REPORT_COLUMNS_JSONL
         self.return_list = True
 

--- a/nise/generators/gcp/gcp_generator.py
+++ b/nise/generators/gcp/gcp_generator.py
@@ -83,7 +83,7 @@ GCP_INSTANCE_TYPES = ("e2-medium", "n1-standard-4", "m2-megamem-416", "a2-highgp
 class GCPGenerator(AbstractGenerator):
     """Abstract class for GCP generators."""
 
-    def __init__(self, start_date, end_date, project, attributes=None):
+    def __init__(self, start_date, end_date, currency, project, attributes=None):
         """
         Initialize the generator.
 
@@ -99,6 +99,7 @@ class GCPGenerator(AbstractGenerator):
         self.attributes = attributes
         self.column_labels = GCP_REPORT_COLUMNS
         self.return_list = False
+        self.currency = currency
         # class vars to be set by the child classes based off attributes.
         self._labels = None
         self._usage_amount = None
@@ -108,6 +109,7 @@ class GCPGenerator(AbstractGenerator):
         self._instance_type = choice(GCP_INSTANCE_TYPES)
         self._service = None
         self._credit_amount = None
+        self._currency = currency
 
     @staticmethod
     def _create_days_list(start_date, end_date):

--- a/nise/generators/gcp/gcp_network_generator.py
+++ b/nise/generators/gcp/gcp_network_generator.py
@@ -47,10 +47,11 @@ class GCPNetworkGenerator(GCPGenerator):
 
     LABELS = (([{"key": "vm_key_proj2", "value": "vm_label_proj2"}]), ([]))
 
-    def __init__(self, start_date, end_date, project, attributes=None):
+    def __init__(self, start_date, end_date, currency, project, attributes=None):
         """Initialize the cloud storage generator."""
-        super().__init__(start_date, end_date, project, attributes)
+        super().__init__(start_date, end_date, currency, project, attributes)
         self.credit_total = 0
+        self._currency = currency
         if self.attributes:
             if self.attributes.get("labels"):
                 self._labels = self.attributes.get("labels")
@@ -83,7 +84,7 @@ class GCPNetworkGenerator(GCPGenerator):
         row["usage.unit"] = usage_unit
         row["usage.pricing_unit"] = pricing_unit
         row["cost_type"] = "regular"
-        row["currency"] = "USD"
+        row["currency"] = self._currency
         row["currency_conversion_rate"] = 1
         row["usage.amount"] = self._gen_usage_unit_amount(usage_unit)
         row["usage.amount_in_pricing_units"] = self._gen_pricing_unit_amount(pricing_unit, row["usage.amount"])
@@ -140,7 +141,6 @@ class JSONLGCPNetworkGenerator(GCPNetworkGenerator):
         usage["unit"] = usage_unit
         usage["pricing_unit"] = pricing_unit
         row["cost_type"] = "regular"
-        row["currency"] = "USD"
         row["currency_conversion_rate"] = 1
         usage["amount"] = self._gen_usage_unit_amount(usage_unit)
         usage["amount_in_pricing_units"] = self._gen_pricing_unit_amount(pricing_unit, usage["amount"])

--- a/nise/generators/gcp/gcp_network_generator.py
+++ b/nise/generators/gcp/gcp_network_generator.py
@@ -115,8 +115,8 @@ class JSONLGCPNetworkGenerator(GCPNetworkGenerator):
 
     LABELS = (([{"key": "vm_key_proj2", "value": "vm_label_proj2"}]), ([]))
 
-    def __init__(self, start_date, end_date, project, attributes=None):
-        super().__init__(start_date, end_date, project, attributes)
+    def __init__(self, start_date, end_date, currency, project, attributes=None):
+        super().__init__(start_date, end_date, currency, project, attributes)
         self.column_labels = GCP_REPORT_COLUMNS_JSONL
         self.return_list = True
 

--- a/nise/generators/gcp/gcp_network_generator.py
+++ b/nise/generators/gcp/gcp_network_generator.py
@@ -164,6 +164,7 @@ class JSONLGCPNetworkGenerator(GCPNetworkGenerator):
                     outer_key, inner_key = key.split(".")
                     row[outer_key][inner_key] = self.attributes[key]
 
+        row["currency"] = self._currency
         row["labels"] = self.determine_labels(self.LABELS)
 
         return row

--- a/nise/generators/ocp/ocp_generator.py
+++ b/nise/generators/ocp/ocp_generator.py
@@ -465,12 +465,12 @@ class OCPGenerator(AbstractGenerator):
         cpu_usage = self._get_usage_for_date(kwargs.get("cpu_usage"), start)
         cpu = round(uniform(0.02, cpu_limit), 5)
         if cpu_usage:
-            cpu = min(cpu_limit, cpu_request, cpu_usage)
+            cpu = min(cpu_limit, cpu_usage)
 
         mem_usage_gig = self._get_usage_for_date(kwargs.get("mem_usage_gig"), start)
         mem = round(uniform(1, mem_limit_gig), 2)
         if mem_usage_gig:
-            mem = min(mem_limit_gig, mem_request_gig, mem_usage_gig)
+            mem = min(mem_limit_gig, mem_usage_gig)
 
         pod["pod_usage_cpu_core_seconds"] = pod_seconds * cpu
         pod["pod_request_cpu_core_seconds"] = pod_seconds * cpu_request

--- a/nise/report.py
+++ b/nise/report.py
@@ -476,6 +476,10 @@ def aws_create_report(options):  # noqa: C901
     data = []
     start_date = options.get("start_date")
     end_date = options.get("end_date")
+    if options.get("currency"):
+        currency_code = options.get("currency")
+    else:
+        currency_code = 'USD'
     aws_finalize_report = options.get("aws_finalize_report")
     static_report_data = options.get("static_report_data")
 
@@ -524,7 +528,7 @@ def aws_create_report(options):  # noqa: C901
                 gen_start_date, gen_end_date = _create_generator_dates_from_yaml(attributes, month)
 
             gen = generator_cls(
-                gen_start_date, gen_end_date, payer_account, usage_accounts, attributes, options.get("aws_tags")
+                gen_start_date, gen_end_date, payer_account, currency_code, usage_accounts, attributes, options.get("aws_tags")
             )
             num_instances = 1 if attributes else randint(2, 60)
             for _ in range(num_instances):

--- a/nise/report.py
+++ b/nise/report.py
@@ -967,8 +967,8 @@ def gcp_create_report(options):  # noqa: C901
         monthly_files = _gcp_bigquery_process(
             start_date,
             end_date,
-            currency,
             projects,
+            currency,
             generators,
             options,
             gcp_bucket_name,

--- a/nise/report.py
+++ b/nise/report.py
@@ -470,16 +470,18 @@ def write_aws_file(
 
     return full_file_name
 
+def default_currency(currency):
+    if currency:
+        return currency
+    else:
+        return 'USD'
 
 def aws_create_report(options):  # noqa: C901
     """Create a cost usage report file."""
     data = []
     start_date = options.get("start_date")
     end_date = options.get("end_date")
-    if options.get("currency"):
-        currency_code = options.get("currency")
-    else:
-        currency_code = "USD"
+    currency_code = default_currency(options.get("currency"))
     aws_finalize_report = options.get("aws_finalize_report")
     static_report_data = options.get("static_report_data")
 
@@ -602,10 +604,7 @@ def azure_create_report(options):  # noqa: C901
     data = []
     start_date = options.get("start_date")
     end_date = options.get("end_date")
-    if options.get("currency"):
-        currency = options.get("currency")
-    else:
-        currency = "USD"
+    currency = default_currency(options.get("currency"))
     static_report_data = options.get("static_report_data")
     if static_report_data:
         generators = _get_generators(static_report_data.get("generators"))
@@ -886,10 +885,7 @@ def gcp_create_report(options):  # noqa: C901
 
     start_date = options.get("start_date")
     end_date = options.get("end_date")
-    if options.get("currency"):
-        currency = options.get("currency")
-    else:
-        currency = "USD"
+    currency = default_currency(options.get("currency"))
 
     static_report_data = options.get("static_report_data")
 

--- a/nise/report.py
+++ b/nise/report.py
@@ -320,6 +320,7 @@ def _generate_accounts(static_report_data=None):
     if static_report_data:
         payer_account = static_report_data.get("payer")
         usage_accounts = tuple(static_report_data.get("user"))
+        currency_code = static_report_data.get("currency_code")
     else:
         fake = Faker()
         payer_account = fake.ean(length=13)
@@ -330,7 +331,8 @@ def _generate_accounts(static_report_data=None):
             fake.ean(length=13),
             fake.ean(length=13),
         )
-    return payer_account, usage_accounts
+        currency_code = "USD"
+    return payer_account, usage_accounts, currency_code
 
 
 def _generate_azure_account_info(static_report_data=None):
@@ -507,8 +509,8 @@ def aws_create_report(options):  # noqa: C901
 
     months = _create_month_list(start_date, end_date)
 
-    payer_account, usage_accounts = _generate_accounts(accounts_list)
-    currency_code = default_currency(options.get("currency"), accounts_list["currency_code"])
+    payer_account, usage_accounts, currency_code = _generate_accounts(accounts_list)
+    currency_code = default_currency(options.get("currency"), currency_code)
 
     aws_bucket_name = options.get("aws_bucket_name")
     aws_report_name = options.get("aws_report_name")
@@ -1004,6 +1006,8 @@ def gcp_create_report(options):  # noqa: C901
                         start_date = attributes.get("start_date")
                         end_date = attributes.get("end_date")
                         currency = default_currency(options.get("currency"), attributes.get("currency"))
+                    else:
+                        currency = default_currency(options.get("currency"), None)
                     if gen_end_date > end_date:
                         gen_end_date = end_date
 

--- a/nise/report.py
+++ b/nise/report.py
@@ -470,11 +470,13 @@ def write_aws_file(
 
     return full_file_name
 
+
 def default_currency(currency):
     if currency:
         return currency
     else:
-        return 'USD'
+        return "USD"
+
 
 def aws_create_report(options):  # noqa: C901
     """Create a cost usage report file."""

--- a/nise/report.py
+++ b/nise/report.py
@@ -479,7 +479,7 @@ def aws_create_report(options):  # noqa: C901
     if options.get("currency"):
         currency_code = options.get("currency")
     else:
-        currency_code = 'USD'
+        currency_code = "USD"
     aws_finalize_report = options.get("aws_finalize_report")
     static_report_data = options.get("static_report_data")
 
@@ -528,7 +528,13 @@ def aws_create_report(options):  # noqa: C901
                 gen_start_date, gen_end_date = _create_generator_dates_from_yaml(attributes, month)
 
             gen = generator_cls(
-                gen_start_date, gen_end_date, payer_account, currency_code, usage_accounts, attributes, options.get("aws_tags")
+                gen_start_date,
+                gen_end_date,
+                payer_account,
+                currency_code,
+                usage_accounts,
+                attributes,
+                options.get("aws_tags"),
             )
             num_instances = 1 if attributes else randint(2, 60)
             for _ in range(num_instances):
@@ -599,7 +605,7 @@ def azure_create_report(options):  # noqa: C901
     if options.get("currency"):
         currency = options.get("currency")
     else:
-        currency = 'USD'
+        currency = "USD"
     static_report_data = options.get("static_report_data")
     if static_report_data:
         generators = _get_generators(static_report_data.get("generators"))
@@ -883,7 +889,7 @@ def gcp_create_report(options):  # noqa: C901
     if options.get("currency"):
         currency = options.get("currency")
     else:
-        currency = 'USD'   
+        currency = "USD"
 
     static_report_data = options.get("static_report_data")
 
@@ -906,7 +912,7 @@ def gcp_create_report(options):  # noqa: C901
                         key = pair.split(":")[0]
                         value = pair.split(":")[1]
                         labels.append({"key": key, "value": value})
-                
+
                 project["labels"] = labels
                 location = {}
                 location["location"] = static_dict.get("location.location", "")
@@ -959,7 +965,15 @@ def gcp_create_report(options):  # noqa: C901
 
     if gcp_dataset_name:
         monthly_files = _gcp_bigquery_process(
-            start_date, end_date, currency, projects, generators, options, gcp_bucket_name, gcp_dataset_name, gcp_table_name
+            start_date,
+            end_date,
+            currency,
+            projects,
+            generators,
+            options,
+            gcp_bucket_name,
+            gcp_dataset_name,
+            gcp_table_name,
         )
     else:
         months = _create_month_list(start_date, end_date)

--- a/nise/report.py
+++ b/nise/report.py
@@ -596,6 +596,7 @@ def azure_create_report(options):  # noqa: C901
     data = []
     start_date = options.get("start_date")
     end_date = options.get("end_date")
+    currency = options.get("currency")
     static_report_data = options.get("static_report_data")
     if static_report_data:
         generators = _get_generators(static_report_data.get("generators"))
@@ -649,7 +650,7 @@ def azure_create_report(options):  # noqa: C901
                 meter_cache.update(attributes.get("meter_cache"))  # needed so that meter_cache can be defined in yaml
             attributes["meter_cache"] = meter_cache
             attributes["version_two"] = version_two
-            gen = generator_cls(gen_start_date, gen_end_date, account_info, attributes)
+            gen = generator_cls(gen_start_date, gen_end_date, currency, account_info, attributes)
             azure_columns = gen.azure_columns
             data += gen.generate_data()
             meter_cache = gen.get_meter_cache()

--- a/nise/report.py
+++ b/nise/report.py
@@ -1018,7 +1018,7 @@ def _gcp_bigquery_process(
                 end_date = attributes.get("end_date")
 
             generator_cls = generator.get("generator")
-            gen = generator_cls(start_date, end_date, project, attributes=attributes)
+            gen = generator_cls(start_date, end_date, currency, project, attributes=attributes)
             for hour in gen.generate_data():
                 data += [hour]
             count += 1

--- a/nise/report.py
+++ b/nise/report.py
@@ -270,6 +270,7 @@ def _create_month_list(start_date, end_date):
     """Create a list of months given the date range args."""
     months = []
     current = start_date.replace(day=1)
+    end_month_first_day = end_date.replace(day=1)
     while current <= end_date:
         month = {
             "name": calendar.month_name[current.month],
@@ -285,7 +286,8 @@ def _create_month_list(start_date, end_date):
         if current.month == start_date.month:
             # First month start with start_date
             month["start"] = start_date
-        if current.month < end_date.month:
+        if current < end_month_first_day:
+            # can not compare months in this case - January < December
             month["end"] = (month.get("end") + relativedelta(days=1)).replace(hour=0, minute=0)
         if current.month == end_date.month:
             # Last month ends with end_date

--- a/nise/report.py
+++ b/nise/report.py
@@ -483,6 +483,8 @@ def default_currency(currency, static_currency):
         return static_currency
     else:
         return "USD"
+
+
 def aws_create_marketplace_report(options):  # noqa: C901
     """Create a marketplace usage report file."""
     static_report_data = options.get("static_report_data")
@@ -565,8 +567,8 @@ def aws_create_report(options):  # noqa: C901
             gen = generator_cls(
                 gen_start_date,
                 gen_end_date,
-                payer_account,
                 currency_code,
+                payer_account,
                 usage_accounts,
                 attributes,
                 options.get("aws_tags"),
@@ -899,7 +901,6 @@ def write_gcp_file(start_date, end_date, data, options):
         file_name = report_prefix + ".csv"
     local_file_path = "{}/{}".format(os.getcwd(), file_name)
     output_file_name = f"{etag}/{file_name}"
-    # data['currency'] = default_currency(options['currency'], data['currency'])
     _write_csv(local_file_path, data, GCP_REPORT_COLUMNS)
     return local_file_path, output_file_name
 

--- a/tests/test_aws_generator.py
+++ b/tests/test_aws_generator.py
@@ -47,7 +47,7 @@ class AbstractGeneratorTestCase(TestCase):
         self.now = datetime.now().replace(microsecond=0, second=0, minute=0)
         self.one_hour = timedelta(minutes=60)
         self.payer_account = self.fake.ean(length=13)
-        self.currency = 'USD'
+        self.currency = "USD"
         self.usage_accounts = (
             self.payer_account,
             self.fake.ean(length=13),
@@ -149,7 +149,9 @@ class AbstractGeneratorTestCase(TestCase):
 
         attributes = {}
         attributes["region"] = "us-west-1a"
-        generator = TestGenerator(two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts, attributes)
+        generator = TestGenerator(
+            two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts, attributes
+        )
         location = generator._get_location()
         self.assertIn("us-west-1", location)
 
@@ -189,7 +191,7 @@ class AWSGeneratorTestCase(TestCase):
         self.amount = 1
         self.rate = 0.1
         self.saving = 0.1
-        self.currency = 'USD'
+        self.currency = "USD"
         self.attributes = {
             "product_sku": self.product_sku,
             "tags": self.tags,
@@ -209,7 +211,9 @@ class AWSGeneratorTestCase(TestCase):
         key = "resourceTags/user:new-key"
         tag_cols = {key}
         two_hours_ago = (self.now - self.one_hour) - self.one_hour
-        generator = TestGenerator(two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts, tag_cols=tag_cols)
+        generator = TestGenerator(
+            two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts, tag_cols=tag_cols
+        )
         self.assertIn(key, generator.AWS_COLUMNS)
         self.assertNotIn("key-that-has-not-been-added", generator.AWS_COLUMNS)
 
@@ -219,7 +223,9 @@ class AWSGeneratorTestCase(TestCase):
         key = "resourceTags/user:new-key"
         tag_cols = {key}
         two_hours_ago = (self.now - self.one_hour) - self.one_hour
-        generator = TestGenerator(two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts, tag_cols=tag_cols)
+        generator = TestGenerator(
+            two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts, tag_cols=tag_cols
+        )
         self.assertIn(key, generator.AWS_COLUMNS)
         self.assertNotIn("key-that-has-not-been-added", generator.AWS_COLUMNS)
 
@@ -230,7 +236,12 @@ class TestRDSGenerator(AWSGeneratorTestCase):
     def test_init_no_attributes(self):
         """Test the init wihout attributes."""
         generator = RDSGenerator(
-            self.two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts, attributes={"empty": "dictionary"}
+            self.two_hours_ago,
+            self.now,
+            self.payer_account,
+            self.currency,
+            self.usage_accounts,
+            attributes={"empty": "dictionary"},
         )
         self.assertIsNotNone(generator._product_sku)
         self.assertIsNotNone(generator._resource_id)
@@ -415,7 +426,9 @@ class TestS3Generator(AWSGeneratorTestCase):
     def test_init_with_attributes(self):
         """Test the unique init options for Data Transfer."""
 
-        generator = S3Generator(self.two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts, self.attributes)
+        generator = S3Generator(
+            self.two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts, self.attributes
+        )
         self.assertEqual(generator._product_sku, self.product_sku)
         self.assertEqual(generator._tags, self.tags)
         self.assertEqual(generator._amount, self.amount)
@@ -423,7 +436,9 @@ class TestS3Generator(AWSGeneratorTestCase):
 
     def test_update_data(self):
         """Test S3 specific update data method."""
-        generator = S3Generator(self.two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts, self.attributes)
+        generator = S3Generator(
+            self.two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts, self.attributes
+        )
         start_row = {}
         row = generator._update_data(start_row, self.two_hours_ago, self.now)
 

--- a/tests/test_aws_generator.py
+++ b/tests/test_aws_generator.py
@@ -47,6 +47,7 @@ class AbstractGeneratorTestCase(TestCase):
         self.now = datetime.now().replace(microsecond=0, second=0, minute=0)
         self.one_hour = timedelta(minutes=60)
         self.payer_account = self.fake.ean(length=13)
+        self.currency = 'USD'
         self.usage_accounts = (
             self.payer_account,
             self.fake.ean(length=13),
@@ -58,33 +59,33 @@ class AbstractGeneratorTestCase(TestCase):
     def test_set_hours_invalid_start(self):
         """Test that the start date must be a date object."""
         with self.assertRaises(ValueError):
-            TestGenerator("invalid", self.now, self.payer_account, self.usage_accounts)
+            TestGenerator("invalid", self.now, self.payer_account, self.currency, self.usage_accounts)
 
     def test_set_hours_invalid_end(self):
         """Test that the end date must be a date object."""
         with self.assertRaises(ValueError):
-            TestGenerator(self.now, "invalid", self.payer_account, self.usage_accounts)
+            TestGenerator(self.now, "invalid", self.payer_account, self.currency, self.usage_accounts)
 
     def test_set_hours_none_start(self):
         """Test that the start date is not None."""
         with self.assertRaises(ValueError):
-            TestGenerator(None, self.now, self.payer_account, self.usage_accounts)
+            TestGenerator(None, self.now, self.payer_account, self.currency, self.usage_accounts)
 
     def test_set_hours_none_end(self):
         """Test that the end date is not None."""
         with self.assertRaises(ValueError):
-            TestGenerator(self.now, None, self.payer_account, self.usage_accounts)
+            TestGenerator(self.now, None, self.payer_account, self.currency, self.usage_accounts)
 
     def test_set_hours_compared_dates(self):
         """Test that the start date must be less than the end date."""
         hour_ago = self.now - self.one_hour
         with self.assertRaises(ValueError):
-            TestGenerator(self.now, hour_ago, self.payer_account, self.usage_accounts)
+            TestGenerator(self.now, hour_ago, self.payer_account, self.currency, self.usage_accounts)
 
     def test_set_hours(self):
         """Test that a valid list of hours are returned."""
         two_hours_ago = (self.now - self.one_hour) - self.one_hour
-        generator = TestGenerator(two_hours_ago, self.now, self.payer_account, self.usage_accounts)
+        generator = TestGenerator(two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts)
         expected = [
             {"start": two_hours_ago, "end": two_hours_ago + self.one_hour},
             {"start": two_hours_ago + self.one_hour, "end": two_hours_ago + self.one_hour + self.one_hour},
@@ -104,7 +105,7 @@ class AbstractGeneratorTestCase(TestCase):
     def test_init_data_row(self):
         """Test the init data row method."""
         two_hours_ago = (self.now - self.one_hour) - self.one_hour
-        generator = TestGenerator(two_hours_ago, self.now, self.payer_account, self.usage_accounts)
+        generator = TestGenerator(two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts)
         a_row = generator._init_data_row(two_hours_ago, self.now)
         self.assertIsInstance(a_row, dict)
         for col in generator.AWS_COLUMNS:
@@ -113,35 +114,35 @@ class AbstractGeneratorTestCase(TestCase):
     def test_init_data_row_start_none(self):
         """Test the init data row method none start date."""
         two_hours_ago = (self.now - self.one_hour) - self.one_hour
-        generator = TestGenerator(two_hours_ago, self.now, self.payer_account, self.usage_accounts)
+        generator = TestGenerator(two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts)
         with self.assertRaises(ValueError):
             generator._init_data_row(None, self.now)
 
     def test_init_data_row_end_none(self):
         """Test the init data row method none end date."""
         two_hours_ago = (self.now - self.one_hour) - self.one_hour
-        generator = TestGenerator(two_hours_ago, self.now, self.payer_account, self.usage_accounts)
+        generator = TestGenerator(two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts)
         with self.assertRaises(ValueError):
             generator._init_data_row(two_hours_ago, None)
 
     def test_init_data_row_start_invalid(self):
         """Test the init data row method invalid start date."""
         two_hours_ago = (self.now - self.one_hour) - self.one_hour
-        generator = TestGenerator(two_hours_ago, self.now, self.payer_account, self.usage_accounts)
+        generator = TestGenerator(two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts)
         with self.assertRaises(ValueError):
             generator._init_data_row("invalid", self.now)
 
     def test_init_data_row_end_invalid(self):
         """Test the init data row method invalid end date."""
         two_hours_ago = (self.now - self.one_hour) - self.one_hour
-        generator = TestGenerator(two_hours_ago, self.now, self.payer_account, self.usage_accounts)
+        generator = TestGenerator(two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts)
         with self.assertRaises(ValueError):
             generator._init_data_row(two_hours_ago, "invalid")
 
     def test_get_location(self):
         """Test the _get_location method."""
         two_hours_ago = (self.now - self.one_hour) - self.one_hour
-        generator = TestGenerator(two_hours_ago, self.now, self.payer_account, self.usage_accounts)
+        generator = TestGenerator(two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts)
         location = generator._get_location()
 
         self.assertIsInstance(location, tuple)
@@ -188,6 +189,7 @@ class AWSGeneratorTestCase(TestCase):
         self.amount = 1
         self.rate = 0.1
         self.saving = 0.1
+        self.currency = 'USD'
         self.attributes = {
             "product_sku": self.product_sku,
             "tags": self.tags,
@@ -207,7 +209,7 @@ class AWSGeneratorTestCase(TestCase):
         key = "resourceTags/user:new-key"
         tag_cols = {key}
         two_hours_ago = (self.now - self.one_hour) - self.one_hour
-        generator = TestGenerator(two_hours_ago, self.now, self.payer_account, self.usage_accounts, tag_cols=tag_cols)
+        generator = TestGenerator(two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts, tag_cols=tag_cols)
         self.assertIn(key, generator.AWS_COLUMNS)
         self.assertNotIn("key-that-has-not-been-added", generator.AWS_COLUMNS)
 
@@ -217,7 +219,7 @@ class AWSGeneratorTestCase(TestCase):
         key = "resourceTags/user:new-key"
         tag_cols = {key}
         two_hours_ago = (self.now - self.one_hour) - self.one_hour
-        generator = TestGenerator(two_hours_ago, self.now, self.payer_account, self.usage_accounts, tag_cols=tag_cols)
+        generator = TestGenerator(two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts, tag_cols=tag_cols)
         self.assertIn(key, generator.AWS_COLUMNS)
         self.assertNotIn("key-that-has-not-been-added", generator.AWS_COLUMNS)
 
@@ -228,7 +230,7 @@ class TestRDSGenerator(AWSGeneratorTestCase):
     def test_init_no_attributes(self):
         """Test the init wihout attributes."""
         generator = RDSGenerator(
-            self.two_hours_ago, self.now, self.payer_account, self.usage_accounts, attributes={"empty": "dictionary"}
+            self.two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts, attributes={"empty": "dictionary"}
         )
         self.assertIsNotNone(generator._product_sku)
         self.assertIsNotNone(generator._resource_id)
@@ -247,7 +249,7 @@ class TestRDSGenerator(AWSGeneratorTestCase):
     def test_update_data(self):
         """Test RDS specific update data method."""
         generator = RDSGenerator(
-            self.two_hours_ago, self.now, self.payer_account, self.usage_accounts, self.attributes
+            self.two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts, self.attributes
         )
         start_row = {}
         row = generator._update_data(start_row, self.two_hours_ago, self.now)
@@ -283,7 +285,7 @@ class TestDataTransferGenerator(AWSGeneratorTestCase):
     def test_update_data(self):
         """Test Data Transfer specific update data method."""
         generator = DataTransferGenerator(
-            self.two_hours_ago, self.now, self.payer_account, self.usage_accounts, self.attributes
+            self.two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts, self.attributes
         )
         start_row = {}
         row = generator._update_data(start_row, self.two_hours_ago, self.now)
@@ -309,7 +311,7 @@ class TestEBSGenerator(AWSGeneratorTestCase):
     def test_update_data(self):
         """Test EBS specific update data method."""
         generator = EBSGenerator(
-            self.two_hours_ago, self.now, self.payer_account, self.usage_accounts, self.attributes
+            self.two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts, self.attributes
         )
         start_row = {}
         row = generator._update_data(start_row, self.two_hours_ago, self.now)
@@ -355,7 +357,7 @@ class TestEC2Generator(AWSGeneratorTestCase):
     def test_update_data(self):
         """Test EBS specific update data method."""
         generator = EC2Generator(
-            self.two_hours_ago, self.now, self.payer_account, self.usage_accounts, self.attributes
+            self.two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts, self.attributes
         )
         start_row = {}
         row = generator._update_data(start_row, self.two_hours_ago, self.now)
@@ -389,7 +391,7 @@ class TestRoute53Generator(AWSGeneratorTestCase):
     def test_update_data(self):
         """Test Route53 specific update data method."""
         generator = Route53Generator(
-            self.two_hours_ago, self.now, self.payer_account, self.usage_accounts, self.attributes
+            self.two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts, self.attributes
         )
         start_row = {}
         row = generator._update_data(start_row, self.two_hours_ago, self.now)
@@ -421,7 +423,7 @@ class TestS3Generator(AWSGeneratorTestCase):
 
     def test_update_data(self):
         """Test S3 specific update data method."""
-        generator = S3Generator(self.two_hours_ago, self.now, self.payer_account, self.usage_accounts, self.attributes)
+        generator = S3Generator(self.two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts, self.attributes)
         start_row = {}
         row = generator._update_data(start_row, self.two_hours_ago, self.now)
 
@@ -443,7 +445,7 @@ class TestVPCGenerator(AWSGeneratorTestCase):
         """Test the unique init options for Data Transfer."""
 
         generator = VPCGenerator(
-            self.two_hours_ago, self.now, self.payer_account, self.usage_accounts, self.attributes
+            self.two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts, self.attributes
         )
         self.assertEqual(generator._product_sku, self.product_sku)
         self.assertEqual(generator._tags, self.tags)
@@ -452,7 +454,7 @@ class TestVPCGenerator(AWSGeneratorTestCase):
     def test_update_data(self):
         """Test VPC specific update data method."""
         generator = VPCGenerator(
-            self.two_hours_ago, self.now, self.payer_account, self.usage_accounts, self.attributes
+            self.two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts, self.attributes
         )
         start_row = {}
         row = generator._update_data(start_row, self.two_hours_ago, self.now)

--- a/tests/test_aws_generator.py
+++ b/tests/test_aws_generator.py
@@ -59,33 +59,33 @@ class AbstractGeneratorTestCase(TestCase):
     def test_set_hours_invalid_start(self):
         """Test that the start date must be a date object."""
         with self.assertRaises(ValueError):
-            TestGenerator("invalid", self.now, self.payer_account, self.currency, self.usage_accounts)
+            TestGenerator("invalid", self.now, self.currency, self.payer_account, self.usage_accounts)
 
     def test_set_hours_invalid_end(self):
         """Test that the end date must be a date object."""
         with self.assertRaises(ValueError):
-            TestGenerator(self.now, "invalid", self.payer_account, self.currency, self.usage_accounts)
+            TestGenerator(self.now, "invalid", self.currency, self.payer_account, self.usage_accounts)
 
     def test_set_hours_none_start(self):
         """Test that the start date is not None."""
         with self.assertRaises(ValueError):
-            TestGenerator(None, self.now, self.payer_account, self.currency, self.usage_accounts)
+            TestGenerator(None, self.now, self.currency, self.payer_account, self.usage_accounts)
 
     def test_set_hours_none_end(self):
         """Test that the end date is not None."""
         with self.assertRaises(ValueError):
-            TestGenerator(self.now, None, self.payer_account, self.currency, self.usage_accounts)
+            TestGenerator(self.now, None, self.currency, self.payer_account, self.usage_accounts)
 
     def test_set_hours_compared_dates(self):
         """Test that the start date must be less than the end date."""
         hour_ago = self.now - self.one_hour
         with self.assertRaises(ValueError):
-            TestGenerator(self.now, hour_ago, self.payer_account, self.currency, self.usage_accounts)
+            TestGenerator(self.now, hour_ago, self.currency, self.payer_account, self.usage_accounts)
 
     def test_set_hours(self):
         """Test that a valid list of hours are returned."""
         two_hours_ago = (self.now - self.one_hour) - self.one_hour
-        generator = TestGenerator(two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts)
+        generator = TestGenerator(two_hours_ago, self.now, self.currency, self.payer_account, self.usage_accounts)
         expected = [
             {"start": two_hours_ago, "end": two_hours_ago + self.one_hour},
             {"start": two_hours_ago + self.one_hour, "end": two_hours_ago + self.one_hour + self.one_hour},
@@ -105,7 +105,7 @@ class AbstractGeneratorTestCase(TestCase):
     def test_init_data_row(self):
         """Test the init data row method."""
         two_hours_ago = (self.now - self.one_hour) - self.one_hour
-        generator = TestGenerator(two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts)
+        generator = TestGenerator(two_hours_ago, self.now, self.currency, self.payer_account, self.usage_accounts)
         a_row = generator._init_data_row(two_hours_ago, self.now)
         self.assertIsInstance(a_row, dict)
         for col in generator.AWS_COLUMNS:
@@ -114,35 +114,35 @@ class AbstractGeneratorTestCase(TestCase):
     def test_init_data_row_start_none(self):
         """Test the init data row method none start date."""
         two_hours_ago = (self.now - self.one_hour) - self.one_hour
-        generator = TestGenerator(two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts)
+        generator = TestGenerator(two_hours_ago, self.now, self.currency, self.payer_account, self.usage_accounts)
         with self.assertRaises(ValueError):
             generator._init_data_row(None, self.now)
 
     def test_init_data_row_end_none(self):
         """Test the init data row method none end date."""
         two_hours_ago = (self.now - self.one_hour) - self.one_hour
-        generator = TestGenerator(two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts)
+        generator = TestGenerator(two_hours_ago, self.now, self.currency, self.payer_account, self.usage_accounts)
         with self.assertRaises(ValueError):
             generator._init_data_row(two_hours_ago, None)
 
     def test_init_data_row_start_invalid(self):
         """Test the init data row method invalid start date."""
         two_hours_ago = (self.now - self.one_hour) - self.one_hour
-        generator = TestGenerator(two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts)
+        generator = TestGenerator(two_hours_ago, self.now, self.currency, self.payer_account, self.usage_accounts)
         with self.assertRaises(ValueError):
             generator._init_data_row("invalid", self.now)
 
     def test_init_data_row_end_invalid(self):
         """Test the init data row method invalid end date."""
         two_hours_ago = (self.now - self.one_hour) - self.one_hour
-        generator = TestGenerator(two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts)
+        generator = TestGenerator(two_hours_ago, self.now, self.currency, self.payer_account, self.usage_accounts)
         with self.assertRaises(ValueError):
             generator._init_data_row(two_hours_ago, "invalid")
 
     def test_get_location(self):
         """Test the _get_location method."""
         two_hours_ago = (self.now - self.one_hour) - self.one_hour
-        generator = TestGenerator(two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts)
+        generator = TestGenerator(two_hours_ago, self.now, self.currency, self.payer_account, self.usage_accounts)
         location = generator._get_location()
 
         self.assertIsInstance(location, tuple)
@@ -150,7 +150,7 @@ class AbstractGeneratorTestCase(TestCase):
         attributes = {}
         attributes["region"] = "us-west-1a"
         generator = TestGenerator(
-            two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts, attributes
+            two_hours_ago, self.now, self.currency, self.payer_account, self.usage_accounts, attributes
         )
         location = generator._get_location()
         self.assertIn("us-west-1", location)
@@ -212,7 +212,7 @@ class AWSGeneratorTestCase(TestCase):
         tag_cols = {key}
         two_hours_ago = (self.now - self.one_hour) - self.one_hour
         generator = TestGenerator(
-            two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts, tag_cols=tag_cols
+            two_hours_ago, self.now, self.currency, self.payer_account, self.usage_accounts, tag_cols=tag_cols
         )
         self.assertIn(key, generator.AWS_COLUMNS)
         self.assertNotIn("key-that-has-not-been-added", generator.AWS_COLUMNS)
@@ -224,7 +224,7 @@ class AWSGeneratorTestCase(TestCase):
         tag_cols = {key}
         two_hours_ago = (self.now - self.one_hour) - self.one_hour
         generator = TestGenerator(
-            two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts, tag_cols=tag_cols
+            two_hours_ago, self.now, self.currency, self.payer_account, self.usage_accounts, tag_cols=tag_cols
         )
         self.assertIn(key, generator.AWS_COLUMNS)
         self.assertNotIn("key-that-has-not-been-added", generator.AWS_COLUMNS)
@@ -250,7 +250,7 @@ class TestRDSGenerator(AWSGeneratorTestCase):
     def test_init_with_attributes(self):
         """Test the unique init options for RDS."""
         generator = RDSGenerator(
-            self.two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts, self.attributes
+            self.two_hours_ago, self.now, self.currency, self.payer_account, self.usage_accounts, self.attributes
         )
         self.assertEqual(generator._product_sku, self.product_sku)
         self.assertEqual(generator._resource_id, "i-" + self.resource_id)
@@ -260,7 +260,7 @@ class TestRDSGenerator(AWSGeneratorTestCase):
     def test_update_data(self):
         """Test RDS specific update data method."""
         generator = RDSGenerator(
-            self.two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts, self.attributes
+            self.two_hours_ago, self.now, self.currency, self.payer_account, self.usage_accounts, self.attributes
         )
         start_row = {}
         row = generator._update_data(start_row, self.two_hours_ago, self.now)
@@ -272,7 +272,7 @@ class TestRDSGenerator(AWSGeneratorTestCase):
     def test_generate_data(self):
         """Test that the RDS generate_data method works."""
         generator = RDSGenerator(
-            self.two_hours_ago, self.now, self.payer_account, self.usage_accounts, self.attributes
+            self.two_hours_ago, self.now, self.currency, self.payer_account, self.usage_accounts, self.attributes
         )
         data = generator.generate_data()
         self.assertNotEqual(data, [])
@@ -285,7 +285,7 @@ class TestDataTransferGenerator(AWSGeneratorTestCase):
         """Test the unique init options for Data Transfer."""
 
         generator = DataTransferGenerator(
-            self.two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts, self.attributes
+            self.two_hours_ago, self.now, self.currency, self.payer_account, self.usage_accounts, self.attributes
         )
         self.assertEqual(generator._product_code, self.product_code)
         self.assertEqual(generator._tags, self.tags)
@@ -296,7 +296,7 @@ class TestDataTransferGenerator(AWSGeneratorTestCase):
     def test_update_data(self):
         """Test Data Transfer specific update data method."""
         generator = DataTransferGenerator(
-            self.two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts, self.attributes
+            self.two_hours_ago, self.now, self.currency, self.payer_account, self.usage_accounts, self.attributes
         )
         start_row = {}
         row = generator._update_data(start_row, self.two_hours_ago, self.now)
@@ -311,7 +311,7 @@ class TestEBSGenerator(AWSGeneratorTestCase):
     def test_init_with_attributes(self):
         """Test the unique init options for Data Transfer."""
         generator = EBSGenerator(
-            self.two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts, self.attributes
+            self.two_hours_ago, self.now, self.currency, self.payer_account, self.usage_accounts, self.attributes
         )
         self.assertEqual(generator._product_sku, self.product_sku)
         self.assertEqual(generator._tags, self.tags)
@@ -322,7 +322,7 @@ class TestEBSGenerator(AWSGeneratorTestCase):
     def test_update_data(self):
         """Test EBS specific update data method."""
         generator = EBSGenerator(
-            self.two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts, self.attributes
+            self.two_hours_ago, self.now, self.currency, self.payer_account, self.usage_accounts, self.attributes
         )
         start_row = {}
         row = generator._update_data(start_row, self.two_hours_ago, self.now)
@@ -333,9 +333,7 @@ class TestEBSGenerator(AWSGeneratorTestCase):
 
     def test_generate_data(self):
         """Test that the EBS generate_data method works."""
-        generator = EBSGenerator(
-            self.two_hours_ago, self.now, self.payer_account, self.usage_accounts, self.attributes
-        )
+        generator = EBSGenerator(self.two_hours_ago, self.now, self.currency, self.usage_accounts, self.attributes)
         data = generator.generate_data()
         self.assertNotEqual(data, [])
 
@@ -358,7 +356,7 @@ class TestEC2Generator(AWSGeneratorTestCase):
         self.attributes["instance_type"] = self.instance_type
 
         generator = EC2Generator(
-            self.two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts, self.attributes
+            self.two_hours_ago, self.now, self.currency, self.payer_account, self.usage_accounts, self.attributes
         )
         self.assertEqual(generator._product_sku, self.product_sku)
         self.assertEqual(generator._tags, self.tags)
@@ -368,7 +366,7 @@ class TestEC2Generator(AWSGeneratorTestCase):
     def test_update_data(self):
         """Test EBS specific update data method."""
         generator = EC2Generator(
-            self.two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts, self.attributes
+            self.two_hours_ago, self.now, self.currency, self.payer_account, self.usage_accounts, self.attributes
         )
         start_row = {}
         row = generator._update_data(start_row, self.two_hours_ago, self.now)
@@ -380,7 +378,7 @@ class TestEC2Generator(AWSGeneratorTestCase):
     def test_generate_data(self):
         """Test that the EBS generate_data method works."""
         generator = EC2Generator(
-            self.two_hours_ago, self.now, self.payer_account, self.usage_accounts, self.attributes
+            self.two_hours_ago, self.now, self.currency, self.payer_account, self.usage_accounts, self.attributes
         )
         data = generator.generate_data()
         self.assertNotEqual(data, [])
@@ -393,7 +391,7 @@ class TestRoute53Generator(AWSGeneratorTestCase):
         """Test the unique init options for Data Transfer."""
 
         generator = Route53Generator(
-            self.two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts, self.attributes
+            self.two_hours_ago, self.now, self.currency, self.payer_account, self.usage_accounts, self.attributes
         )
         self.assertEqual(generator._product_sku, self.product_sku)
         self.assertEqual(generator._tags, self.tags)
@@ -402,7 +400,7 @@ class TestRoute53Generator(AWSGeneratorTestCase):
     def test_update_data(self):
         """Test Route53 specific update data method."""
         generator = Route53Generator(
-            self.two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts, self.attributes
+            self.two_hours_ago, self.now, self.currency, self.payer_account, self.usage_accounts, self.attributes
         )
         start_row = {}
         row = generator._update_data(start_row, self.two_hours_ago, self.now)
@@ -414,7 +412,7 @@ class TestRoute53Generator(AWSGeneratorTestCase):
     def test_generate_data(self):
         """Test that the Route53 generate_data method works."""
         generator = Route53Generator(
-            self.two_hours_ago, self.now, self.payer_account, self.usage_accounts, self.attributes
+            self.two_hours_ago, self.now, self.currency, self.payer_account, self.usage_accounts, self.attributes
         )
         data = generator.generate_data()
         self.assertNotEqual(data, [])
@@ -427,7 +425,7 @@ class TestS3Generator(AWSGeneratorTestCase):
         """Test the unique init options for Data Transfer."""
 
         generator = S3Generator(
-            self.two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts, self.attributes
+            self.two_hours_ago, self.now, self.currency, self.payer_account, self.usage_accounts, self.attributes
         )
         self.assertEqual(generator._product_sku, self.product_sku)
         self.assertEqual(generator._tags, self.tags)
@@ -437,7 +435,7 @@ class TestS3Generator(AWSGeneratorTestCase):
     def test_update_data(self):
         """Test S3 specific update data method."""
         generator = S3Generator(
-            self.two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts, self.attributes
+            self.two_hours_ago, self.now, self.currency, self.payer_account, self.usage_accounts, self.attributes
         )
         start_row = {}
         row = generator._update_data(start_row, self.two_hours_ago, self.now)
@@ -448,7 +446,9 @@ class TestS3Generator(AWSGeneratorTestCase):
 
     def test_generate_data(self):
         """Test that the S3 generate_data method works."""
-        generator = S3Generator(self.two_hours_ago, self.now, self.payer_account, self.usage_accounts, self.attributes)
+        generator = S3Generator(
+            self.two_hours_ago, self.now, self.currency, self.payer_account, self.usage_accounts, self.attributes
+        )
         data = generator.generate_data()
         self.assertNotEqual(data, [])
 
@@ -460,7 +460,7 @@ class TestVPCGenerator(AWSGeneratorTestCase):
         """Test the unique init options for Data Transfer."""
 
         generator = VPCGenerator(
-            self.two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts, self.attributes
+            self.two_hours_ago, self.now, self.currency, self.payer_account, self.usage_accounts, self.attributes
         )
         self.assertEqual(generator._product_sku, self.product_sku)
         self.assertEqual(generator._tags, self.tags)
@@ -469,7 +469,7 @@ class TestVPCGenerator(AWSGeneratorTestCase):
     def test_update_data(self):
         """Test VPC specific update data method."""
         generator = VPCGenerator(
-            self.two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts, self.attributes
+            self.two_hours_ago, self.now, self.currency, self.payer_account, self.usage_accounts, self.attributes
         )
         start_row = {}
         row = generator._update_data(start_row, self.two_hours_ago, self.now)
@@ -481,7 +481,7 @@ class TestVPCGenerator(AWSGeneratorTestCase):
     def test_generate_data(self):
         """Test that the VPC generate_data method works."""
         generator = VPCGenerator(
-            self.two_hours_ago, self.now, self.payer_account, self.usage_accounts, self.attributes
+            self.two_hours_ago, self.now, self.currency, self.payer_account, self.usage_accounts, self.attributes
         )
         data = generator.generate_data()
         self.assertNotEqual(data, [])

--- a/tests/test_aws_generator.py
+++ b/tests/test_aws_generator.py
@@ -47,8 +47,8 @@ class AbstractGeneratorTestCase(TestCase):
         self.fake = Faker()
         self.now = datetime.now().replace(microsecond=0, second=0, minute=0)
         self.one_hour = timedelta(minutes=60)
-        self.payer_account = self.fake.ean(length=13)
         self.currency = "USD"
+        self.payer_account = self.fake.ean(length=13)
         self.usage_accounts = (
             self.payer_account,
             self.fake.ean(length=13),
@@ -239,8 +239,8 @@ class TestRDSGenerator(AWSGeneratorTestCase):
         generator = RDSGenerator(
             self.two_hours_ago,
             self.now,
-            self.payer_account,
             self.currency,
+            self.payer_account,
             self.usage_accounts,
             attributes={"empty": "dictionary"},
         )
@@ -495,7 +495,7 @@ class TestMarketplaceGenerator(AWSGeneratorTestCase):
         """Test the unique init options for Data Transfer."""
 
         generator = MarketplaceGenerator(
-            self.two_hours_ago, self.now, self.payer_account, self.usage_accounts, self.attributes
+            self.two_hours_ago, self.now, self.currency, self.payer_account, self.usage_accounts, self.attributes
         )
         self.assertEqual(generator._product_sku, self.product_sku)
         self.assertEqual(generator._tags, self.tags)
@@ -506,7 +506,7 @@ class TestMarketplaceGenerator(AWSGeneratorTestCase):
     def test_update_data(self):
         """Test Marketplace specific update data method."""
         generator = MarketplaceGenerator(
-            self.two_hours_ago, self.now, self.payer_account, self.usage_accounts, self.attributes
+            self.two_hours_ago, self.now, self.currency, self.payer_account, self.usage_accounts, self.attributes
         )
         start_row = {}
         row = generator._update_data(start_row, self.two_hours_ago, self.now)
@@ -517,14 +517,14 @@ class TestMarketplaceGenerator(AWSGeneratorTestCase):
     def test_generate_data(self):
         """Test that the MarketplaceGenerator generate_data method works."""
         generator = MarketplaceGenerator(
-            self.two_hours_ago, self.now, self.payer_account, self.usage_accounts, self.attributes
+            self.two_hours_ago, self.now, self.currency, self.payer_account, self.usage_accounts, self.attributes
         )
         data = generator.generate_data()
         self.assertNotEqual(data, [])
 
     def test_add_common_pricing_info(self):
         generator = MarketplaceGenerator(
-            self.two_hours_ago, self.now, self.payer_account, self.usage_accounts, self.attributes
+            self.two_hours_ago, self.now, self.currency, self.payer_account, self.usage_accounts, self.attributes
         )
 
         row = {}

--- a/tests/test_aws_generator.py
+++ b/tests/test_aws_generator.py
@@ -149,7 +149,7 @@ class AbstractGeneratorTestCase(TestCase):
 
         attributes = {}
         attributes["region"] = "us-west-1a"
-        generator = TestGenerator(two_hours_ago, self.now, self.payer_account, self.usage_accounts, attributes)
+        generator = TestGenerator(two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts, attributes)
         location = generator._get_location()
         self.assertIn("us-west-1", location)
 
@@ -239,7 +239,7 @@ class TestRDSGenerator(AWSGeneratorTestCase):
     def test_init_with_attributes(self):
         """Test the unique init options for RDS."""
         generator = RDSGenerator(
-            self.two_hours_ago, self.now, self.payer_account, self.usage_accounts, self.attributes
+            self.two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts, self.attributes
         )
         self.assertEqual(generator._product_sku, self.product_sku)
         self.assertEqual(generator._resource_id, "i-" + self.resource_id)
@@ -274,7 +274,7 @@ class TestDataTransferGenerator(AWSGeneratorTestCase):
         """Test the unique init options for Data Transfer."""
 
         generator = DataTransferGenerator(
-            self.two_hours_ago, self.now, self.payer_account, self.usage_accounts, self.attributes
+            self.two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts, self.attributes
         )
         self.assertEqual(generator._product_code, self.product_code)
         self.assertEqual(generator._tags, self.tags)
@@ -300,7 +300,7 @@ class TestEBSGenerator(AWSGeneratorTestCase):
     def test_init_with_attributes(self):
         """Test the unique init options for Data Transfer."""
         generator = EBSGenerator(
-            self.two_hours_ago, self.now, self.payer_account, self.usage_accounts, self.attributes
+            self.two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts, self.attributes
         )
         self.assertEqual(generator._product_sku, self.product_sku)
         self.assertEqual(generator._tags, self.tags)
@@ -347,7 +347,7 @@ class TestEC2Generator(AWSGeneratorTestCase):
         self.attributes["instance_type"] = self.instance_type
 
         generator = EC2Generator(
-            self.two_hours_ago, self.now, self.payer_account, self.usage_accounts, self.attributes
+            self.two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts, self.attributes
         )
         self.assertEqual(generator._product_sku, self.product_sku)
         self.assertEqual(generator._tags, self.tags)
@@ -382,7 +382,7 @@ class TestRoute53Generator(AWSGeneratorTestCase):
         """Test the unique init options for Data Transfer."""
 
         generator = Route53Generator(
-            self.two_hours_ago, self.now, self.payer_account, self.usage_accounts, self.attributes
+            self.two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts, self.attributes
         )
         self.assertEqual(generator._product_sku, self.product_sku)
         self.assertEqual(generator._tags, self.tags)
@@ -415,7 +415,7 @@ class TestS3Generator(AWSGeneratorTestCase):
     def test_init_with_attributes(self):
         """Test the unique init options for Data Transfer."""
 
-        generator = S3Generator(self.two_hours_ago, self.now, self.payer_account, self.usage_accounts, self.attributes)
+        generator = S3Generator(self.two_hours_ago, self.now, self.payer_account, self.currency, self.usage_accounts, self.attributes)
         self.assertEqual(generator._product_sku, self.product_sku)
         self.assertEqual(generator._tags, self.tags)
         self.assertEqual(generator._amount, self.amount)

--- a/tests/test_azure_generator.py
+++ b/tests/test_azure_generator.py
@@ -58,39 +58,40 @@ class AbstractGeneratorTestCase(TestCase):
         self.account_info = _generate_azure_account_info()
         self.payer_account = self.account_info.get("subscription_guid")
         self.version_two_attribute = {"version_two": True}
+        self.currency = 'USD'
 
     def test_set_hours_invalid_start(self):
         """Test that the start date must be a date object."""
         with self.assertRaises(ValueError):
-            TestGenerator("invalid", self.now, self.account_info)
+            TestGenerator("invalid", self.now, self.currency, self.account_info)
 
     def test_set_hours_invalid_end(self):
         """Test that the end date must be a date object."""
         with self.assertRaises(ValueError):
-            TestGenerator(self.now, "invalid", self.account_info)
+            TestGenerator(self.now, "invalid", self.currency, self.account_info)
 
     def test_set_hours_none_start(self):
         """Test that the start date is not None."""
         with self.assertRaises(ValueError):
-            TestGenerator(None, self.now, self.account_info)
+            TestGenerator(None, self.now, self.currency, self.account_info)
 
     def test_set_hours_none_end(self):
         """Test that the end date is not None."""
         with self.assertRaises(ValueError):
-            TestGenerator(self.now, None, self.account_info)
+            TestGenerator(self.now, None, self.currency, self.account_info)
 
     def test_set_hours_compared_dates(self):
         """Test that the start date must be less than the end date."""
         hour_ago = self.now - self.one_hour
         with self.assertRaises(ValueError):
-            TestGenerator(self.now, hour_ago, self.account_info)
+            TestGenerator(self.now, hour_ago, self.currency, self.account_info)
 
     def test_set_hours(self):
         """Test that a valid list of hours are returned."""
         two_hours_ago = (self.now - self.one_hour) - self.one_hour
         generators = [
-            TestGenerator(two_hours_ago, self.now, self.account_info),
-            TestGenerator(two_hours_ago, self.now, self.account_info, self.version_two_attribute),
+            TestGenerator(two_hours_ago, self.now, self.currency, self.account_info),
+            TestGenerator(two_hours_ago, self.now, self.currency, self.account_info, self.version_two_attribute),
         ]
         expected = [
             {"start": two_hours_ago, "end": two_hours_ago + self.one_hour},
@@ -103,8 +104,8 @@ class AbstractGeneratorTestCase(TestCase):
         """Test the init data row method."""
         two_hours_ago = (self.now - self.one_hour) - self.one_hour
         generators = [
-            TestGenerator(two_hours_ago, self.now, self.account_info),
-            TestGenerator(two_hours_ago, self.now, self.account_info, self.version_two_attribute),
+            TestGenerator(two_hours_ago, self.now, self.currency, self.account_info),
+            TestGenerator(two_hours_ago, self.now, self.currency, self.account_info, self.version_two_attribute),
         ]
         for generator in generators:
             columns = generator.azure_columns
@@ -118,8 +119,8 @@ class AbstractGeneratorTestCase(TestCase):
         """Test the init data row method none start date."""
         two_hours_ago = (self.now - self.one_hour) - self.one_hour
         generators = [
-            TestGenerator(two_hours_ago, self.now, self.account_info),
-            TestGenerator(two_hours_ago, self.now, self.account_info, self.version_two_attribute),
+            TestGenerator(two_hours_ago, self.now, self.currency, self.account_info),
+            TestGenerator(two_hours_ago, self.now, self.currency, self.account_info, self.version_two_attribute),
         ]
         for generator in generators:
             with self.assertRaises(ValueError):
@@ -129,8 +130,8 @@ class AbstractGeneratorTestCase(TestCase):
         """Test the init data row method none end date."""
         two_hours_ago = (self.now - self.one_hour) - self.one_hour
         generators = [
-            TestGenerator(two_hours_ago, self.now, self.account_info),
-            TestGenerator(two_hours_ago, self.now, self.account_info, self.version_two_attribute),
+            TestGenerator(two_hours_ago, self.now, self.currency, self.account_info),
+            TestGenerator(two_hours_ago, self.now, self.currency, self.account_info, self.version_two_attribute),
         ]
         for generator in generators:
             with self.assertRaises(ValueError):
@@ -140,8 +141,8 @@ class AbstractGeneratorTestCase(TestCase):
         """Test the init data row method invalid start date."""
         two_hours_ago = (self.now - self.one_hour) - self.one_hour
         generators = [
-            TestGenerator(two_hours_ago, self.now, self.account_info),
-            TestGenerator(two_hours_ago, self.now, self.account_info, self.version_two_attribute),
+            TestGenerator(two_hours_ago, self.now, self.currency, self.account_info),
+            TestGenerator(two_hours_ago, self.now, self.currency, self.account_info, self.version_two_attribute),
         ]
         for generator in generators:
             with self.assertRaises(ValueError):
@@ -151,8 +152,8 @@ class AbstractGeneratorTestCase(TestCase):
         """Test the init data row method invalid end date."""
         two_hours_ago = (self.now - self.one_hour) - self.one_hour
         generators = [
-            TestGenerator(two_hours_ago, self.now, self.account_info),
-            TestGenerator(two_hours_ago, self.now, self.account_info, self.version_two_attribute),
+            TestGenerator(two_hours_ago, self.now, self.currency, self.account_info),
+            TestGenerator(two_hours_ago, self.now, self.currency, self.account_info, self.version_two_attribute),
         ]
         for generator in generators:
             with self.assertRaises(ValueError):
@@ -161,13 +162,13 @@ class AbstractGeneratorTestCase(TestCase):
     def test_get_location(self):
         """Test the _get_location method."""
         two_hours_ago = (self.now - self.one_hour) - self.one_hour
-        generator = TestGenerator(two_hours_ago, self.now, self.account_info)
+        generator = TestGenerator(two_hours_ago, self.now, self.currency, self.account_info)
         location = generator._get_location()
         self.assertIsInstance(location, tuple)
 
         attributes = {}
         attributes["resource_location"] = "US East"
-        generator = TestGenerator(two_hours_ago, self.now, self.account_info, attributes)
+        generator = TestGenerator(two_hours_ago, self.now, self.currency, self.account_info, attributes)
         location = generator._get_location()
         self.assertIn("US East", location)
 
@@ -191,6 +192,7 @@ class AzureGeneratorTestCase(TestCase):
         self.usage_quantity = 1
         self.resource_rate = 0.1
         self.pre_tax_cost = 20
+        self.currency = 'USD'
         self.attributes = {
             "tags": self.tags,
             "instance_id": self.instance_id,
@@ -217,7 +219,7 @@ class TestBandwidthGenerator(AzureGeneratorTestCase):
     def test_init_no_attributes(self):
         """Test the init wihout attributes."""
         generator = BandwidthGenerator(
-            self.two_hours_ago, self.now, self.account_info, attributes={"empty": "dictionary"}
+            self.two_hours_ago, self.now, self.currency, self.account_info, attributes={"empty": "dictionary"}
         )
         self.assertEqual(generator._service_name, "Bandwidth")
         self.assertIsNone(generator._service_tier)
@@ -225,8 +227,8 @@ class TestBandwidthGenerator(AzureGeneratorTestCase):
     def test_init_with_attributes(self):
         """Test the unique init options for Bandwidth."""
         default_generators = [
-            BandwidthGenerator(self.two_hours_ago, self.now, self.account_info, self.attributes),
-            BandwidthGenerator(self.two_hours_ago, self.now, self.account_info, self.attributes_v2),
+            BandwidthGenerator(self.two_hours_ago, self.now, self.currency, self.account_info, self.attributes),
+            BandwidthGenerator(self.two_hours_ago, self.now, self.currency, self.account_info, self.attributes_v2),
         ]
         for generator in default_generators:
             self.assertEqual(generator._service_name, "Bandwidth")
@@ -254,7 +256,7 @@ class TestStorageGenerator(AzureGeneratorTestCase):
     def test_init_no_attributes(self):
         """Test the init wihout attributes."""
         generator = StorageGenerator(
-            self.two_hours_ago, self.now, self.account_info, attributes={"empty": "dictionary"}
+            self.two_hours_ago, self.now, self.currency, self.account_info, attributes={"empty": "dictionary"}
         )
         self.assertEqual(generator._service_name, "Storage")
         self.assertIsNone(generator._service_tier)
@@ -262,8 +264,8 @@ class TestStorageGenerator(AzureGeneratorTestCase):
     def test_init_with_attributes(self):
         """Test the unique init options for Storage."""
         default_generators = [
-            StorageGenerator(self.two_hours_ago, self.now, self.account_info, self.attributes),
-            StorageGenerator(self.two_hours_ago, self.now, self.account_info, self.attributes_v2),
+            StorageGenerator(self.two_hours_ago, self.now, self.currency, self.account_info, self.attributes),
+            StorageGenerator(self.two_hours_ago, self.now, self.currency, self.account_info, self.attributes_v2),
         ]
         for generator in default_generators:
             self.assertEqual(generator._service_name, "Storage")
@@ -276,8 +278,8 @@ class TestStorageGenerator(AzureGeneratorTestCase):
     def test_update_data(self):
         """Test that row is updated."""
         default_generators = [
-            StorageGenerator(self.two_hours_ago, self.now, self.account_info, self.attributes),
-            StorageGenerator(self.two_hours_ago, self.now, self.account_info, self.attributes_v2),
+            StorageGenerator(self.two_hours_ago, self.now, self.currency, self.account_info, self.attributes),
+            StorageGenerator(self.two_hours_ago, self.now, self.currency, self.account_info, self.attributes_v2),
         ]
         for generator in default_generators:
             start_row = {}
@@ -296,15 +298,15 @@ class TestSQLGenerator(AzureGeneratorTestCase):
 
     def test_init_no_attributes(self):
         """Test the init wihout attributes."""
-        generator = SQLGenerator(self.two_hours_ago, self.now, self.account_info, attributes={"empty": "dictionary"})
+        generator = SQLGenerator(self.two_hours_ago, self.now, self.currency, self.account_info, attributes={"empty": "dictionary"})
         self.assertEqual(generator._service_name, "SQL Database")
         self.assertIsNone(generator._service_tier)
 
     def test_init_with_attributes(self):
         """Test the unique init options for SQL db."""
         default_generators = [
-            SQLGenerator(self.two_hours_ago, self.now, self.account_info, self.attributes),
-            SQLGenerator(self.two_hours_ago, self.now, self.account_info, self.attributes_v2),
+            SQLGenerator(self.two_hours_ago, self.now, self.currency, self.account_info, self.attributes),
+            SQLGenerator(self.two_hours_ago, self.now, self.currency, self.account_info, self.attributes_v2),
         ]
         for generator in default_generators:
             self.assertEqual(generator._service_name, "SQL Database")
@@ -317,8 +319,8 @@ class TestSQLGenerator(AzureGeneratorTestCase):
     def test_update_data(self):
         """Test that row is updated."""
         default_generators = [
-            SQLGenerator(self.two_hours_ago, self.now, self.account_info, self.attributes),
-            SQLGenerator(self.two_hours_ago, self.now, self.account_info, self.attributes_v2),
+            SQLGenerator(self.two_hours_ago, self.now, self.currency, self.account_info, self.attributes),
+            SQLGenerator(self.two_hours_ago, self.now, self.currency, self.account_info, self.attributes_v2),
         ]
         for generator in default_generators:
             start_row = {}
@@ -337,15 +339,15 @@ class TestVMGenerator(AzureGeneratorTestCase):
 
     def test_init_no_attributes(self):
         """Test the init wihout attributes."""
-        generator = VMGenerator(self.two_hours_ago, self.now, self.account_info, attributes={"empty": "dictionary"})
+        generator = VMGenerator(self.two_hours_ago, self.now, self.currency, self.account_info, attributes={"empty": "dictionary"})
         self.assertEqual(generator._service_name, "Virtual Machines")
         self.assertIsNone(generator._service_tier)
 
     def test_init_with_attributes(self):
         """Test the unique init options for VM."""
         default_generators = [
-            VMGenerator(self.two_hours_ago, self.now, self.account_info, self.attributes),
-            VMGenerator(self.two_hours_ago, self.now, self.account_info, self.attributes_v2),
+            VMGenerator(self.two_hours_ago, self.now, self.currency, self.account_info, self.attributes),
+            VMGenerator(self.two_hours_ago, self.now, self.currency, self.account_info, self.attributes_v2),
         ]
         for generator in default_generators:
             self.assertEqual(generator._service_name, "Virtual Machines")
@@ -358,8 +360,8 @@ class TestVMGenerator(AzureGeneratorTestCase):
     def test_update_data(self):
         """Test that row is updated."""
         default_generators = [
-            VMGenerator(self.two_hours_ago, self.now, self.account_info, self.attributes),
-            VMGenerator(self.two_hours_ago, self.now, self.account_info, self.attributes_v2),
+            VMGenerator(self.two_hours_ago, self.now, self.currency, self.account_info, self.attributes),
+            VMGenerator(self.two_hours_ago, self.now, self.currency, self.account_info, self.attributes_v2),
         ]
         for generator in default_generators:
             start_row = {}
@@ -378,15 +380,15 @@ class TestVNGenerator(AzureGeneratorTestCase):
 
     def test_init_no_attributes(self):
         """Test the init wihout attributes."""
-        generator = VNGenerator(self.two_hours_ago, self.now, self.account_info, attributes={"empty": "dictionary"})
+        generator = VNGenerator(self.two_hours_ago, self.now, self.currency, self.account_info, attributes={"empty": "dictionary"})
         self.assertEqual(generator._service_name, "Virtual Network")
         self.assertIsNone(generator._service_tier)
 
     def test_init_with_attributes(self):
         """Test the unique init options for VM."""
         default_generators = [
-            VNGenerator(self.two_hours_ago, self.now, self.account_info, self.attributes),
-            VNGenerator(self.two_hours_ago, self.now, self.account_info, self.attributes_v2),
+            VNGenerator(self.two_hours_ago, self.now, self.currency, self.account_info, self.attributes),
+            VNGenerator(self.two_hours_ago, self.now, self.currency, self.account_info, self.attributes_v2),
         ]
         for generator in default_generators:
             self.assertEqual(generator._service_name, "Virtual Network")
@@ -398,7 +400,7 @@ class TestVNGenerator(AzureGeneratorTestCase):
 
     def test_update_data(self):
         """Test that row is updated."""
-        generator = VNGenerator(self.two_hours_ago, self.now, self.account_info)
+        generator = VNGenerator(self.two_hours_ago, self.now, self.currency, self.account_info)
         start_row = {}
         row = generator._update_data(start_row, self.two_hours_ago, self.now)
         self.assertEqual(row["ConsumedService"], "Microsoft.Network")
@@ -407,8 +409,8 @@ class TestVNGenerator(AzureGeneratorTestCase):
     def test_update_data_with_attributes(self):
         """Test that row is updated."""
         default_generators = [
-            VNGenerator(self.two_hours_ago, self.now, self.account_info, self.attributes),
-            VNGenerator(self.two_hours_ago, self.now, self.account_info, self.attributes_v2),
+            VNGenerator(self.two_hours_ago, self.now, self.currency, self.account_info, self.attributes),
+            VNGenerator(self.two_hours_ago, self.now, self.currency, self.account_info, self.attributes_v2),
         ]
         for generator in default_generators:
             start_row = {}

--- a/tests/test_azure_generator.py
+++ b/tests/test_azure_generator.py
@@ -58,7 +58,7 @@ class AbstractGeneratorTestCase(TestCase):
         self.account_info = _generate_azure_account_info()
         self.payer_account = self.account_info.get("subscription_guid")
         self.version_two_attribute = {"version_two": True}
-        self.currency = 'USD'
+        self.currency = "USD"
 
     def test_set_hours_invalid_start(self):
         """Test that the start date must be a date object."""
@@ -192,7 +192,7 @@ class AzureGeneratorTestCase(TestCase):
         self.usage_quantity = 1
         self.resource_rate = 0.1
         self.pre_tax_cost = 20
-        self.currency = 'USD'
+        self.currency = "USD"
         self.attributes = {
             "tags": self.tags,
             "instance_id": self.instance_id,
@@ -298,7 +298,9 @@ class TestSQLGenerator(AzureGeneratorTestCase):
 
     def test_init_no_attributes(self):
         """Test the init wihout attributes."""
-        generator = SQLGenerator(self.two_hours_ago, self.now, self.currency, self.account_info, attributes={"empty": "dictionary"})
+        generator = SQLGenerator(
+            self.two_hours_ago, self.now, self.currency, self.account_info, attributes={"empty": "dictionary"}
+        )
         self.assertEqual(generator._service_name, "SQL Database")
         self.assertIsNone(generator._service_tier)
 
@@ -339,7 +341,9 @@ class TestVMGenerator(AzureGeneratorTestCase):
 
     def test_init_no_attributes(self):
         """Test the init wihout attributes."""
-        generator = VMGenerator(self.two_hours_ago, self.now, self.currency, self.account_info, attributes={"empty": "dictionary"})
+        generator = VMGenerator(
+            self.two_hours_ago, self.now, self.currency, self.account_info, attributes={"empty": "dictionary"}
+        )
         self.assertEqual(generator._service_name, "Virtual Machines")
         self.assertIsNone(generator._service_tier)
 
@@ -380,7 +384,9 @@ class TestVNGenerator(AzureGeneratorTestCase):
 
     def test_init_no_attributes(self):
         """Test the init wihout attributes."""
-        generator = VNGenerator(self.two_hours_ago, self.now, self.currency, self.account_info, attributes={"empty": "dictionary"})
+        generator = VNGenerator(
+            self.two_hours_ago, self.now, self.currency, self.account_info, attributes={"empty": "dictionary"}
+        )
         self.assertEqual(generator._service_name, "Virtual Network")
         self.assertIsNone(generator._service_tier)
 

--- a/tests/test_gcp_generator.py
+++ b/tests/test_gcp_generator.py
@@ -48,7 +48,7 @@ class TestGCPGenerator(TestCase):
         }
         self.now = datetime.now().replace(microsecond=0, second=0, minute=0)
         self.yesterday = self.now - timedelta(days=1)
-        self.currency = 'USD'
+        self.currency = None
 
     def test_cloud_storage_init_with_attributes(self):
         """Test the init with attribute for Cloud Storage."""
@@ -69,7 +69,7 @@ class TestGCPGenerator(TestCase):
 
     def test_jsonl_cloud_storage_init_with_attributes(self):
         """Test the init with attribute for JSONL Cloud Storage."""
-        generator = JSONLCloudStorageGenerator(self.yesterday, self.now, self.project, attributes=self.attributes)
+        generator = JSONLCloudStorageGenerator(self.yesterday, self.now, self.project, self.currency, attributes=self.attributes)
         generated_data = generator.generate_data()
         list_data = list(generated_data)
         self.assertEqual(list_data[0]["cost"], self.attributes["cost"])
@@ -78,7 +78,7 @@ class TestGCPGenerator(TestCase):
     def test_jsonl_cloud_storage_init_with_usage_attributes(self):
         """Test the init with usage attribute for JSONL Cloud Storage."""
         generator = JSONLCloudStorageGenerator(
-            self.yesterday, self.now, self.project, attributes=self.usage_attributes
+            self.yesterday, self.now, self.currency, self.project, attributes=self.usage_attributes
         )
         generated_data = generator.generate_data()
         list_data = list(generated_data)
@@ -88,7 +88,7 @@ class TestGCPGenerator(TestCase):
     def test_compute_engine_init_with_attributes(self):
         """Test the init with attribute for Compute Engine."""
 
-        generator = ComputeEngineGenerator(self.yesterday, self.now, self.project, attributes=self.attributes)
+        generator = ComputeEngineGenerator(self.yesterday, self.now, self.currency, self.project, attributes=self.attributes)
         generated_data = generator.generate_data()
         list_data = list(generated_data)
         self.assertEqual(list_data[0]["cost"], self.attributes["cost"])
@@ -96,7 +96,7 @@ class TestGCPGenerator(TestCase):
 
     def test_compute_engine_init_with_usage_attributes(self):
         """Test the init with usage attributes for Compute Engine."""
-        generator = ComputeEngineGenerator(self.yesterday, self.now, self.project, attributes=self.usage_attributes)
+        generator = ComputeEngineGenerator(self.yesterday, self.now, self.currency, self.project, attributes=self.usage_attributes)
         generated_data = generator.generate_data()
         list_data = list(generated_data)
         self.assertEqual(list_data[0]["cost"], self.usage_attributes["usage.amount"] * self.usage_attributes["price"])
@@ -104,7 +104,7 @@ class TestGCPGenerator(TestCase):
 
     def test_jsonl_compute_engine_init_with_attributes(self):
         """Test the init with attribute for JSONL Compute Engine."""
-        generator = JSONLComputeEngineGenerator(self.yesterday, self.now, self.project, attributes=self.attributes)
+        generator = JSONLComputeEngineGenerator(self.yesterday, self.now, self.currency, self.project, attributes=self.attributes)
         generated_data = generator.generate_data()
         list_data = list(generated_data)
         self.assertEqual(list_data[0]["cost"], self.attributes["cost"])
@@ -113,7 +113,7 @@ class TestGCPGenerator(TestCase):
     def test_jsonl_compute_engine_init_with_usage_attributes(self):
         """Test the init with attribute for JSONL Compute Engine."""
         generator = JSONLComputeEngineGenerator(
-            self.yesterday, self.now, self.project, attributes=self.usage_attributes
+            self.yesterday, self.now, self.currency, self.project, attributes=self.usage_attributes
         )
         generated_data = generator.generate_data()
         list_data = list(generated_data)
@@ -122,7 +122,7 @@ class TestGCPGenerator(TestCase):
 
     def test_network_generator_init_with_attributes(self):
         """Test the init with attribute for GCP Network Generator."""
-        generator = GCPNetworkGenerator(self.yesterday, self.now, self.project, attributes=self.attributes)
+        generator = GCPNetworkGenerator(self.yesterday, self.now, self.currency, self.project, attributes=self.attributes)
         generated_data = generator.generate_data()
         list_data = list(generated_data)
         self.assertEqual(list_data[0]["cost"], self.attributes["cost"])
@@ -130,7 +130,7 @@ class TestGCPGenerator(TestCase):
 
     def test_network_generator_init_with_usage_attributes(self):
         """Test the init with usage attributes for GCP Network Generator."""
-        generator = GCPNetworkGenerator(self.yesterday, self.now, self.project, attributes=self.usage_attributes)
+        generator = GCPNetworkGenerator(self.yesterday, self.now, self.currency, self.project, attributes=self.usage_attributes)
         generated_data = generator.generate_data()
         list_data = list(generated_data)
         self.assertEqual(list_data[0]["cost"], self.usage_attributes["usage.amount"] * self.usage_attributes["price"])
@@ -154,7 +154,7 @@ class TestGCPGenerator(TestCase):
 
     def test_database_generator_init_with_attributes(self):
         """Test the init with attribute for GCP Database Generator."""
-        generator = GCPDatabaseGenerator(self.yesterday, self.now, self.project, attributes=self.attributes)
+        generator = GCPDatabaseGenerator(self.yesterday, self.now, self.currency, self.project, attributes=self.attributes)
         generated_data = generator.generate_data()
         list_data = list(generated_data)
         self.assertEqual(list_data[0]["cost"], self.attributes["cost"])
@@ -162,7 +162,7 @@ class TestGCPGenerator(TestCase):
 
     def test_database_generator_init_with_usage_attributes(self):
         """Test the init with usage attributes for GCP Database Generator."""
-        generator = GCPDatabaseGenerator(self.yesterday, self.now, self.project, attributes=self.usage_attributes)
+        generator = GCPDatabaseGenerator(self.yesterday, self.now, self.currency, self.project, attributes=self.usage_attributes)
         generated_data = generator.generate_data()
         list_data = list(generated_data)
         self.assertEqual(list_data[0]["cost"], self.usage_attributes["usage.amount"] * self.usage_attributes["price"])
@@ -187,25 +187,25 @@ class TestGCPGenerator(TestCase):
     def test_set_hours_invalid_start(self):
         """Test that the start date must be a date object."""
         with self.assertRaises(ValueError):
-            generator = CloudStorageGenerator("invalid", self.now, self.project)
+            generator = CloudStorageGenerator("invalid", self.now, None, self.project)
             generator.generate_data()
 
     def test_set_hours_invalid_end(self):
         """Test that the end date must be a date object."""
         with self.assertRaises(ValueError):
-            generator = CloudStorageGenerator(self.now, "invalid", self.project)
+            generator = CloudStorageGenerator(self.now, "invalid", None, self.project)
             generator.generate_data()
 
     def test_set_hours_none_start(self):
         """Test that the start date is not None."""
         with self.assertRaises(ValueError):
-            generator = CloudStorageGenerator(None, self.now, self.project)
+            generator = CloudStorageGenerator(None, self.now, self.currency, self.project)
             generator.generate_data()
 
     def test_set_hours_none_end(self):
         """Test that the end date is not None."""
         with self.assertRaises(ValueError):
-            generator = CloudStorageGenerator(self.now, None, self.project)
+            generator = CloudStorageGenerator(self.now, None, None, self.project)
             generator.generate_data()
 
     def test_gcp_generators_with_credit_attributes(self):
@@ -223,7 +223,7 @@ class TestGCPGenerator(TestCase):
         }
         generators_list = [CloudStorageGenerator, ComputeEngineGenerator, GCPDatabaseGenerator, GCPNetworkGenerator]
         for generator in generators_list:
-            gen_handler = generator(self.yesterday, self.now, self.project, attributes=attributes)
+            gen_handler = generator(self.yesterday, self.now, self.currency, self.project, attributes=attributes)
             generated_data = gen_handler.generate_data()
             list_data = list(generated_data)
             credit_rows = []
@@ -250,7 +250,7 @@ class TestGCPGenerator(TestCase):
         }
         generators_list = [JSONLCloudStorageGenerator, JSONLComputeEngineGenerator, JSONLGCPDatabaseGenerator]
         for generator in generators_list:
-            gen_handler = generator(self.yesterday, self.now, self.project, attributes=attributes)
+            gen_handler = generator(self.yesterday, self.now, self.currency, self.project, attributes=attributes)
             generated_data = gen_handler.generate_data()
             list_data = list(generated_data)
             credit_rows = []

--- a/tests/test_gcp_generator.py
+++ b/tests/test_gcp_generator.py
@@ -53,7 +53,9 @@ class TestGCPGenerator(TestCase):
     def test_cloud_storage_init_with_attributes(self):
         """Test the init with attribute for Cloud Storage."""
 
-        generator = CloudStorageGenerator(self.yesterday, self.now, self.currency, self.project, attributes=self.attributes)
+        generator = CloudStorageGenerator(
+            self.yesterday, self.now, self.currency, self.project, attributes=self.attributes
+        )
         generated_data = generator.generate_data()
         list_data = list(generated_data)
         self.assertEqual(list_data[0]["cost"], self.attributes["cost"])
@@ -61,7 +63,9 @@ class TestGCPGenerator(TestCase):
 
     def test_cloud_storage_init_with_usage_attributes(self):
         """Test the init with usage attribute for Cloud Storage."""
-        generator = CloudStorageGenerator(self.yesterday, self.now, self.currency, self.project, attributes=self.usage_attributes)
+        generator = CloudStorageGenerator(
+            self.yesterday, self.now, self.currency, self.project, attributes=self.usage_attributes
+        )
         generated_data = generator.generate_data()
         list_data = list(generated_data)
         self.assertEqual(list_data[0]["cost"], self.usage_attributes["usage.amount"] * self.usage_attributes["price"])
@@ -69,7 +73,9 @@ class TestGCPGenerator(TestCase):
 
     def test_jsonl_cloud_storage_init_with_attributes(self):
         """Test the init with attribute for JSONL Cloud Storage."""
-        generator = JSONLCloudStorageGenerator(self.yesterday, self.now, self.project, self.currency, attributes=self.attributes)
+        generator = JSONLCloudStorageGenerator(
+            self.yesterday, self.now, self.project, self.currency, attributes=self.attributes
+        )
         generated_data = generator.generate_data()
         list_data = list(generated_data)
         self.assertEqual(list_data[0]["cost"], self.attributes["cost"])
@@ -88,7 +94,9 @@ class TestGCPGenerator(TestCase):
     def test_compute_engine_init_with_attributes(self):
         """Test the init with attribute for Compute Engine."""
 
-        generator = ComputeEngineGenerator(self.yesterday, self.now, self.currency, self.project, attributes=self.attributes)
+        generator = ComputeEngineGenerator(
+            self.yesterday, self.now, self.currency, self.project, attributes=self.attributes
+        )
         generated_data = generator.generate_data()
         list_data = list(generated_data)
         self.assertEqual(list_data[0]["cost"], self.attributes["cost"])
@@ -96,7 +104,9 @@ class TestGCPGenerator(TestCase):
 
     def test_compute_engine_init_with_usage_attributes(self):
         """Test the init with usage attributes for Compute Engine."""
-        generator = ComputeEngineGenerator(self.yesterday, self.now, self.currency, self.project, attributes=self.usage_attributes)
+        generator = ComputeEngineGenerator(
+            self.yesterday, self.now, self.currency, self.project, attributes=self.usage_attributes
+        )
         generated_data = generator.generate_data()
         list_data = list(generated_data)
         self.assertEqual(list_data[0]["cost"], self.usage_attributes["usage.amount"] * self.usage_attributes["price"])
@@ -104,7 +114,9 @@ class TestGCPGenerator(TestCase):
 
     def test_jsonl_compute_engine_init_with_attributes(self):
         """Test the init with attribute for JSONL Compute Engine."""
-        generator = JSONLComputeEngineGenerator(self.yesterday, self.now, self.currency, self.project, attributes=self.attributes)
+        generator = JSONLComputeEngineGenerator(
+            self.yesterday, self.now, self.currency, self.project, attributes=self.attributes
+        )
         generated_data = generator.generate_data()
         list_data = list(generated_data)
         self.assertEqual(list_data[0]["cost"], self.attributes["cost"])
@@ -122,7 +134,9 @@ class TestGCPGenerator(TestCase):
 
     def test_network_generator_init_with_attributes(self):
         """Test the init with attribute for GCP Network Generator."""
-        generator = GCPNetworkGenerator(self.yesterday, self.now, self.currency, self.project, attributes=self.attributes)
+        generator = GCPNetworkGenerator(
+            self.yesterday, self.now, self.currency, self.project, attributes=self.attributes
+        )
         generated_data = generator.generate_data()
         list_data = list(generated_data)
         self.assertEqual(list_data[0]["cost"], self.attributes["cost"])
@@ -130,7 +144,9 @@ class TestGCPGenerator(TestCase):
 
     def test_network_generator_init_with_usage_attributes(self):
         """Test the init with usage attributes for GCP Network Generator."""
-        generator = GCPNetworkGenerator(self.yesterday, self.now, self.currency, self.project, attributes=self.usage_attributes)
+        generator = GCPNetworkGenerator(
+            self.yesterday, self.now, self.currency, self.project, attributes=self.usage_attributes
+        )
         generated_data = generator.generate_data()
         list_data = list(generated_data)
         self.assertEqual(list_data[0]["cost"], self.usage_attributes["usage.amount"] * self.usage_attributes["price"])
@@ -154,7 +170,9 @@ class TestGCPGenerator(TestCase):
 
     def test_database_generator_init_with_attributes(self):
         """Test the init with attribute for GCP Database Generator."""
-        generator = GCPDatabaseGenerator(self.yesterday, self.now, self.currency, self.project, attributes=self.attributes)
+        generator = GCPDatabaseGenerator(
+            self.yesterday, self.now, self.currency, self.project, attributes=self.attributes
+        )
         generated_data = generator.generate_data()
         list_data = list(generated_data)
         self.assertEqual(list_data[0]["cost"], self.attributes["cost"])
@@ -162,7 +180,9 @@ class TestGCPGenerator(TestCase):
 
     def test_database_generator_init_with_usage_attributes(self):
         """Test the init with usage attributes for GCP Database Generator."""
-        generator = GCPDatabaseGenerator(self.yesterday, self.now, self.currency, self.project, attributes=self.usage_attributes)
+        generator = GCPDatabaseGenerator(
+            self.yesterday, self.now, self.currency, self.project, attributes=self.usage_attributes
+        )
         generated_data = generator.generate_data()
         list_data = list(generated_data)
         self.assertEqual(list_data[0]["cost"], self.usage_attributes["usage.amount"] * self.usage_attributes["price"])
@@ -170,7 +190,9 @@ class TestGCPGenerator(TestCase):
 
     def test_jsonl_database_generator_init_with_attributes(self):
         """Test the init with attribute for JSONL GCP Database Generator."""
-        generator = JSONLGCPDatabaseGenerator(self.yesterday, self.now, self.currency, self.project, attributes=self.attributes)
+        generator = JSONLGCPDatabaseGenerator(
+            self.yesterday, self.now, self.currency, self.project, attributes=self.attributes
+        )
         generated_data = generator.generate_data()
         list_data = list(generated_data)
         self.assertEqual(list_data[0]["cost"], self.attributes["cost"])
@@ -178,7 +200,9 @@ class TestGCPGenerator(TestCase):
 
     def test_jsonl_database_generator_init_with_usage_attributes(self):
         """Test the init with attribute for JSONL GCP Database Generator."""
-        generator = JSONLGCPDatabaseGenerator(self.yesterday, self.now, self.currency, self.project, attributes=self.usage_attributes)
+        generator = JSONLGCPDatabaseGenerator(
+            self.yesterday, self.now, self.currency, self.project, attributes=self.usage_attributes
+        )
         generated_data = generator.generate_data()
         list_data = list(generated_data)
         self.assertEqual(list_data[0]["cost"], self.usage_attributes["usage.amount"] * self.usage_attributes["price"])

--- a/tests/test_gcp_generator.py
+++ b/tests/test_gcp_generator.py
@@ -48,11 +48,12 @@ class TestGCPGenerator(TestCase):
         }
         self.now = datetime.now().replace(microsecond=0, second=0, minute=0)
         self.yesterday = self.now - timedelta(days=1)
+        self.currency = 'USD'
 
     def test_cloud_storage_init_with_attributes(self):
         """Test the init with attribute for Cloud Storage."""
 
-        generator = CloudStorageGenerator(self.yesterday, self.now, self.project, attributes=self.attributes)
+        generator = CloudStorageGenerator(self.yesterday, self.now, self.currency, self.project, attributes=self.attributes)
         generated_data = generator.generate_data()
         list_data = list(generated_data)
         self.assertEqual(list_data[0]["cost"], self.attributes["cost"])
@@ -60,7 +61,7 @@ class TestGCPGenerator(TestCase):
 
     def test_cloud_storage_init_with_usage_attributes(self):
         """Test the init with usage attribute for Cloud Storage."""
-        generator = CloudStorageGenerator(self.yesterday, self.now, self.project, attributes=self.usage_attributes)
+        generator = CloudStorageGenerator(self.yesterday, self.now, self.currency, self.project, attributes=self.usage_attributes)
         generated_data = generator.generate_data()
         list_data = list(generated_data)
         self.assertEqual(list_data[0]["cost"], self.usage_attributes["usage.amount"] * self.usage_attributes["price"])

--- a/tests/test_gcp_generator.py
+++ b/tests/test_gcp_generator.py
@@ -154,7 +154,9 @@ class TestGCPGenerator(TestCase):
 
     def test_jsonl_network_generator_init_with_attributes(self):
         """Test the init with attribute for JSONL GCP Network Generator."""
-        generator = JSONLGCPNetworkGenerator(self.yesterday, self.now, self.project, attributes=self.attributes)
+        generator = JSONLGCPNetworkGenerator(
+            self.yesterday, self.now, self.currency, self.project, attributes=self.attributes
+        )
         generated_data = generator.generate_data()
         list_data = list(generated_data)
         self.assertEqual(list_data[0]["cost"], self.attributes["cost"])
@@ -162,7 +164,9 @@ class TestGCPGenerator(TestCase):
 
     def test_jsonl_network_generator_init_with_usage_attributes(self):
         """Test the init with attribute for JSONL GCP Network Generator."""
-        generator = JSONLGCPNetworkGenerator(self.yesterday, self.now, self.project, attributes=self.usage_attributes)
+        generator = JSONLGCPNetworkGenerator(
+            self.yesterday, self.now, self.currency, self.project, attributes=self.usage_attributes
+        )
         generated_data = generator.generate_data()
         list_data = list(generated_data)
         self.assertEqual(list_data[0]["cost"], self.usage_attributes["usage.amount"] * self.usage_attributes["price"])

--- a/tests/test_gcp_generator.py
+++ b/tests/test_gcp_generator.py
@@ -74,7 +74,7 @@ class TestGCPGenerator(TestCase):
     def test_jsonl_cloud_storage_init_with_attributes(self):
         """Test the init with attribute for JSONL Cloud Storage."""
         generator = JSONLCloudStorageGenerator(
-            self.yesterday, self.now, self.project, self.currency, attributes=self.attributes
+            self.yesterday, self.now, self.currency, self.project, attributes=self.attributes
         )
         generated_data = generator.generate_data()
         list_data = list(generated_data)

--- a/tests/test_gcp_generator.py
+++ b/tests/test_gcp_generator.py
@@ -48,7 +48,7 @@ class TestGCPGenerator(TestCase):
         }
         self.now = datetime.now().replace(microsecond=0, second=0, minute=0)
         self.yesterday = self.now - timedelta(days=1)
-        self.currency = None
+        self.currency = "USD"
 
     def test_cloud_storage_init_with_attributes(self):
         """Test the init with attribute for Cloud Storage."""
@@ -59,7 +59,6 @@ class TestGCPGenerator(TestCase):
         generated_data = generator.generate_data()
         list_data = list(generated_data)
         self.assertEqual(list_data[0]["cost"], self.attributes["cost"])
-        self.assertEqual(list_data[0]["currency"], self.attributes["currency"])
 
     def test_cloud_storage_init_with_usage_attributes(self):
         """Test the init with usage attribute for Cloud Storage."""
@@ -69,7 +68,6 @@ class TestGCPGenerator(TestCase):
         generated_data = generator.generate_data()
         list_data = list(generated_data)
         self.assertEqual(list_data[0]["cost"], self.usage_attributes["usage.amount"] * self.usage_attributes["price"])
-        self.assertEqual(list_data[0]["currency"], self.usage_attributes["currency"])
 
     def test_jsonl_cloud_storage_init_with_attributes(self):
         """Test the init with attribute for JSONL Cloud Storage."""
@@ -79,7 +77,6 @@ class TestGCPGenerator(TestCase):
         generated_data = generator.generate_data()
         list_data = list(generated_data)
         self.assertEqual(list_data[0]["cost"], self.attributes["cost"])
-        self.assertEqual(list_data[0]["currency"], self.attributes["currency"])
 
     def test_jsonl_cloud_storage_init_with_usage_attributes(self):
         """Test the init with usage attribute for JSONL Cloud Storage."""
@@ -89,7 +86,6 @@ class TestGCPGenerator(TestCase):
         generated_data = generator.generate_data()
         list_data = list(generated_data)
         self.assertEqual(list_data[0]["cost"], self.usage_attributes["usage.amount"] * self.usage_attributes["price"])
-        self.assertEqual(list_data[0]["currency"], self.usage_attributes["currency"])
 
     def test_compute_engine_init_with_attributes(self):
         """Test the init with attribute for Compute Engine."""
@@ -100,7 +96,6 @@ class TestGCPGenerator(TestCase):
         generated_data = generator.generate_data()
         list_data = list(generated_data)
         self.assertEqual(list_data[0]["cost"], self.attributes["cost"])
-        self.assertEqual(list_data[0]["currency"], self.attributes["currency"])
 
     def test_compute_engine_init_with_usage_attributes(self):
         """Test the init with usage attributes for Compute Engine."""
@@ -109,8 +104,8 @@ class TestGCPGenerator(TestCase):
         )
         generated_data = generator.generate_data()
         list_data = list(generated_data)
+        print("CHECKING DATA: ", list_data)
         self.assertEqual(list_data[0]["cost"], self.usage_attributes["usage.amount"] * self.usage_attributes["price"])
-        self.assertEqual(list_data[0]["currency"], self.usage_attributes["currency"])
 
     def test_jsonl_compute_engine_init_with_attributes(self):
         """Test the init with attribute for JSONL Compute Engine."""
@@ -120,7 +115,6 @@ class TestGCPGenerator(TestCase):
         generated_data = generator.generate_data()
         list_data = list(generated_data)
         self.assertEqual(list_data[0]["cost"], self.attributes["cost"])
-        self.assertEqual(list_data[0]["currency"], self.attributes["currency"])
 
     def test_jsonl_compute_engine_init_with_usage_attributes(self):
         """Test the init with attribute for JSONL Compute Engine."""
@@ -130,7 +124,6 @@ class TestGCPGenerator(TestCase):
         generated_data = generator.generate_data()
         list_data = list(generated_data)
         self.assertEqual(list_data[0]["cost"], self.usage_attributes["usage.amount"] * self.usage_attributes["price"])
-        self.assertEqual(list_data[0]["currency"], self.usage_attributes["currency"])
 
     def test_network_generator_init_with_attributes(self):
         """Test the init with attribute for GCP Network Generator."""
@@ -140,7 +133,6 @@ class TestGCPGenerator(TestCase):
         generated_data = generator.generate_data()
         list_data = list(generated_data)
         self.assertEqual(list_data[0]["cost"], self.attributes["cost"])
-        self.assertEqual(list_data[0]["currency"], self.attributes["currency"])
 
     def test_network_generator_init_with_usage_attributes(self):
         """Test the init with usage attributes for GCP Network Generator."""
@@ -150,7 +142,6 @@ class TestGCPGenerator(TestCase):
         generated_data = generator.generate_data()
         list_data = list(generated_data)
         self.assertEqual(list_data[0]["cost"], self.usage_attributes["usage.amount"] * self.usage_attributes["price"])
-        self.assertEqual(list_data[0]["currency"], self.usage_attributes["currency"])
 
     def test_jsonl_network_generator_init_with_attributes(self):
         """Test the init with attribute for JSONL GCP Network Generator."""
@@ -160,7 +151,6 @@ class TestGCPGenerator(TestCase):
         generated_data = generator.generate_data()
         list_data = list(generated_data)
         self.assertEqual(list_data[0]["cost"], self.attributes["cost"])
-        self.assertEqual(list_data[0]["currency"], self.attributes["currency"])
 
     def test_jsonl_network_generator_init_with_usage_attributes(self):
         """Test the init with attribute for JSONL GCP Network Generator."""
@@ -170,7 +160,6 @@ class TestGCPGenerator(TestCase):
         generated_data = generator.generate_data()
         list_data = list(generated_data)
         self.assertEqual(list_data[0]["cost"], self.usage_attributes["usage.amount"] * self.usage_attributes["price"])
-        self.assertEqual(list_data[0]["currency"], self.usage_attributes["currency"])
 
     def test_database_generator_init_with_attributes(self):
         """Test the init with attribute for GCP Database Generator."""
@@ -180,7 +169,6 @@ class TestGCPGenerator(TestCase):
         generated_data = generator.generate_data()
         list_data = list(generated_data)
         self.assertEqual(list_data[0]["cost"], self.attributes["cost"])
-        self.assertEqual(list_data[0]["currency"], self.attributes["currency"])
 
     def test_database_generator_init_with_usage_attributes(self):
         """Test the init with usage attributes for GCP Database Generator."""
@@ -190,7 +178,6 @@ class TestGCPGenerator(TestCase):
         generated_data = generator.generate_data()
         list_data = list(generated_data)
         self.assertEqual(list_data[0]["cost"], self.usage_attributes["usage.amount"] * self.usage_attributes["price"])
-        self.assertEqual(list_data[0]["currency"], self.usage_attributes["currency"])
 
     def test_jsonl_database_generator_init_with_attributes(self):
         """Test the init with attribute for JSONL GCP Database Generator."""
@@ -200,7 +187,6 @@ class TestGCPGenerator(TestCase):
         generated_data = generator.generate_data()
         list_data = list(generated_data)
         self.assertEqual(list_data[0]["cost"], self.attributes["cost"])
-        self.assertEqual(list_data[0]["currency"], self.attributes["currency"])
 
     def test_jsonl_database_generator_init_with_usage_attributes(self):
         """Test the init with attribute for JSONL GCP Database Generator."""
@@ -210,7 +196,6 @@ class TestGCPGenerator(TestCase):
         generated_data = generator.generate_data()
         list_data = list(generated_data)
         self.assertEqual(list_data[0]["cost"], self.usage_attributes["usage.amount"] * self.usage_attributes["price"])
-        self.assertEqual(list_data[0]["currency"], self.usage_attributes["currency"])
 
     def test_set_hours_invalid_start(self):
         """Test that the start date must be a date object."""

--- a/tests/test_gcp_generator.py
+++ b/tests/test_gcp_generator.py
@@ -170,7 +170,7 @@ class TestGCPGenerator(TestCase):
 
     def test_jsonl_database_generator_init_with_attributes(self):
         """Test the init with attribute for JSONL GCP Database Generator."""
-        generator = JSONLGCPDatabaseGenerator(self.yesterday, self.now, self.project, attributes=self.attributes)
+        generator = JSONLGCPDatabaseGenerator(self.yesterday, self.now, self.currency, self.project, attributes=self.attributes)
         generated_data = generator.generate_data()
         list_data = list(generated_data)
         self.assertEqual(list_data[0]["cost"], self.attributes["cost"])
@@ -178,7 +178,7 @@ class TestGCPGenerator(TestCase):
 
     def test_jsonl_database_generator_init_with_usage_attributes(self):
         """Test the init with attribute for JSONL GCP Database Generator."""
-        generator = JSONLGCPDatabaseGenerator(self.yesterday, self.now, self.project, attributes=self.usage_attributes)
+        generator = JSONLGCPDatabaseGenerator(self.yesterday, self.now, self.currency, self.project, attributes=self.usage_attributes)
         generated_data = generator.generate_data()
         list_data = list(generated_data)
         self.assertEqual(list_data[0]["cost"], self.usage_attributes["usage.amount"] * self.usage_attributes["price"])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -28,7 +28,8 @@ from nise.__main__ import _validate_provider_inputs
 from nise.__main__ import create_parser
 from nise.__main__ import main
 from nise.__main__ import run
-from nise.__main__ import valid_date, valid_currency
+from nise.__main__ import valid_currency
+from nise.__main__ import valid_date
 from nise.util import load_yaml
 
 
@@ -92,8 +93,8 @@ class CommandLineTestCase(TestCase):
         Test where user passes an invalid currency.
         """
         with self.assertRaises(SystemExit):
-            self.parser.parse_args([ "-c", "JPY", "report", "ocp", "--start-date", str(date.today())])
-    
+            self.parser.parse_args(["-c", "JPY", "report", "ocp", "--start-date", str(date.today())])
+
     def test_valid_currency(self):
         """
         Test where user passes an valid currency.
@@ -101,7 +102,6 @@ class CommandLineTestCase(TestCase):
         test_currency = "jpy"
         out_currency = valid_currency(test_currency)
         self.assertEqual(test_currency.upper(), out_currency)
-        
 
     def test_valid_s3_no_input(self):
         """

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -28,7 +28,7 @@ from nise.__main__ import _validate_provider_inputs
 from nise.__main__ import create_parser
 from nise.__main__ import main
 from nise.__main__ import run
-from nise.__main__ import valid_date
+from nise.__main__ import valid_date, valid_currency
 from nise.util import load_yaml
 
 
@@ -86,6 +86,22 @@ class CommandLineTestCase(TestCase):
         """
         with self.assertRaises(SystemExit):
             self.parser.parse_args(["report", "ocp", "--start-date", "foo"])
+
+    def test_invalid_currency(self):
+        """
+        Test where user passes an invalid currency.
+        """
+        with self.assertRaises(SystemExit):
+            self.parser.parse_args([ "-c", "JPY", "report", "ocp", "--start-date", str(date.today())])
+    
+    def test_valid_currency(self):
+        """
+        Test where user passes an valid currency.
+        """
+        test_currency = "jpy"
+        out_currency = valid_currency(test_currency)
+        self.assertEqual(test_currency.upper(), out_currency)
+        
 
     def test_valid_s3_no_input(self):
         """

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -164,12 +164,12 @@ class MiscReportTestCase(TestCase):
                     {
                         "name": "November",
                         "start": datetime.datetime(year=2018, month=11, day=15),
-                        "end": datetime.datetime(year=2018, month=11, day=30, hour=23, minute=59),
+                        "end": datetime.datetime(year=2018, month=12, day=1, hour=0, minute=0),
                     },
                     {
                         "name": "December",
                         "start": datetime.datetime(year=2018, month=12, day=1),
-                        "end": datetime.datetime(year=2018, month=12, day=31, hour=23, minute=59),
+                        "end": datetime.datetime(year=2019, month=1, day=1, hour=0, minute=0),
                     },
                     {
                         "name": "January",

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -19,7 +19,6 @@ import calendar
 import csv
 import datetime
 import json
-from locale import currency
 import os
 import re
 import shutil
@@ -1156,12 +1155,10 @@ class GCPReportTestCase(TestCase):
         yesterday = now - one_day
         dataset_name = "test_name"
         etag = "test_tag"
-        currency = 'USD'
         gcp_create_report(
             {
                 "start_date": yesterday,
                 "end_date": now,
-                "currency": currency,
                 "write_monthly": True,
                 "gcp_dataset_name": dataset_name,
                 "gcp_etag": etag,
@@ -1235,7 +1232,6 @@ class GCPReportTestCase(TestCase):
         report_prefix = "test_report"
         dataset_name = "test_name"
         cost = fake.pyint(min_value=10, max_value=1000)
-        currency = 'USD'
         static_gcp_data = {
             "generators": [
                 {
@@ -1270,7 +1266,6 @@ class GCPReportTestCase(TestCase):
             {
                 "start_date": yesterday,
                 "end_date": now,
-                "currency": currency,
                 "gcp_report_prefix": report_prefix,
                 "write_monthly": True,
                 "gcp_dataset_name": dataset_name,
@@ -1296,7 +1291,7 @@ class GCPReportTestCase(TestCase):
                     "ComputeEngineGenerator": {
                         "start_date": str(yesterday.date()),
                         "end_date": str(now.date()),
-                        "cost": cost
+                        "cost": cost,
                     }
                 },
                 {

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -30,6 +30,7 @@ from unittest.mock import patch
 
 import faker
 from dateutil.relativedelta import relativedelta
+from nise.__main__ import valid_currency
 from nise.generators.ocp.ocp_generator import OCP_REPORT_TYPE_TO_COLS
 from nise.report import _convert_bytes
 from nise.report import _create_generator_dates_from_yaml
@@ -48,6 +49,7 @@ from nise.report import gcp_route_file
 from nise.report import ocp_create_report
 from nise.report import ocp_route_file
 from nise.report import post_payload_to_ingest_service
+from nise.report import default_currency
 
 
 fake = faker.Faker()
@@ -286,7 +288,11 @@ class MiscReportTestCase(TestCase):
         post_payload_to_ingest_service(insights_upload, temp_file.name)
         self.assertEqual(mock_post.call_args[1].get("auth"), auth)
         self.assertNotIn("headers", mock_post.call_args[1])
-
+    
+    def test_defaulting_currency(self):
+        currency = None
+        updated_currency = default_currency(currency)
+        self.assertEqual(updated_currency, 'USD')
 
 class AWSReportTestCase(TestCase):
     """

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -30,7 +30,6 @@ from unittest.mock import patch
 
 import faker
 from dateutil.relativedelta import relativedelta
-from nise.__main__ import valid_currency
 from nise.generators.ocp.ocp_generator import OCP_REPORT_TYPE_TO_COLS
 from nise.report import _convert_bytes
 from nise.report import _create_generator_dates_from_yaml

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -44,12 +44,12 @@ from nise.report import _write_jsonl
 from nise.report import _write_manifest
 from nise.report import aws_create_report
 from nise.report import azure_create_report
+from nise.report import default_currency
 from nise.report import gcp_create_report
 from nise.report import gcp_route_file
 from nise.report import ocp_create_report
 from nise.report import ocp_route_file
 from nise.report import post_payload_to_ingest_service
-from nise.report import default_currency
 
 
 fake = faker.Faker()
@@ -288,11 +288,12 @@ class MiscReportTestCase(TestCase):
         post_payload_to_ingest_service(insights_upload, temp_file.name)
         self.assertEqual(mock_post.call_args[1].get("auth"), auth)
         self.assertNotIn("headers", mock_post.call_args[1])
-    
+
     def test_defaulting_currency(self):
         currency = None
         updated_currency = default_currency(currency)
-        self.assertEqual(updated_currency, 'USD')
+        self.assertEqual(updated_currency, "USD")
+
 
 class AWSReportTestCase(TestCase):
     """

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1137,6 +1137,7 @@ class GCPReportTestCase(TestCase):
             {
                 "start_date": yesterday,
                 "end_date": now,
+                "currency": "USD",
                 "gcp_report_prefix": report_prefix,
                 "write_monthly": True,
                 "gcp_dataset_name": dataset_name,
@@ -1159,6 +1160,7 @@ class GCPReportTestCase(TestCase):
             {
                 "start_date": yesterday,
                 "end_date": now,
+                "currency": "USD",
                 "write_monthly": True,
                 "gcp_dataset_name": dataset_name,
                 "gcp_etag": etag,

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -289,9 +289,25 @@ class MiscReportTestCase(TestCase):
         self.assertNotIn("headers", mock_post.call_args[1])
 
     def test_defaulting_currency(self):
+        """Test that if no currency is provide in options or static it defaults to USD."""
         currency = None
-        updated_currency = default_currency(currency)
+        static_currency = None
+        updated_currency = default_currency(currency, static_currency)
         self.assertEqual(updated_currency, "USD")
+
+    def test_defaulting_to_static_currency(self):
+        """Test that if no currency is provide in options it defaults to static."""
+        currency = None
+        static_currency = "NOK"
+        updated_currency = default_currency(currency, static_currency)
+        self.assertEqual(updated_currency, "NOK")
+
+    def test_currency_option(self):
+        """Test that if currency is provide in options it sets to that."""
+        currency = "AUD"
+        static_currency = "NOK"
+        updated_currency = default_currency(currency, static_currency)
+        self.assertEqual(updated_currency, "AUD")
 
 
 class AWSReportTestCase(TestCase):

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -19,6 +19,7 @@ import calendar
 import csv
 import datetime
 import json
+from locale import currency
 import os
 import re
 import shutil
@@ -1155,10 +1156,12 @@ class GCPReportTestCase(TestCase):
         yesterday = now - one_day
         dataset_name = "test_name"
         etag = "test_tag"
+        currency = 'USD'
         gcp_create_report(
             {
                 "start_date": yesterday,
                 "end_date": now,
+                "currency": currency,
                 "write_monthly": True,
                 "gcp_dataset_name": dataset_name,
                 "gcp_etag": etag,
@@ -1232,6 +1235,7 @@ class GCPReportTestCase(TestCase):
         report_prefix = "test_report"
         dataset_name = "test_name"
         cost = fake.pyint(min_value=10, max_value=1000)
+        currency = 'USD'
         static_gcp_data = {
             "generators": [
                 {
@@ -1266,6 +1270,7 @@ class GCPReportTestCase(TestCase):
             {
                 "start_date": yesterday,
                 "end_date": now,
+                "currency": currency,
                 "gcp_report_prefix": report_prefix,
                 "write_monthly": True,
                 "gcp_dataset_name": dataset_name,
@@ -1291,7 +1296,7 @@ class GCPReportTestCase(TestCase):
                     "ComputeEngineGenerator": {
                         "start_date": str(yesterday.date()),
                         "end_date": str(now.date()),
-                        "cost": cost,
+                        "cost": cost
                     }
                 },
                 {


### PR DESCRIPTION
Adding the ability to pass in currency argument -c where you can pass in a currency code to get reports in foreign currencies to test MVP currency.

Testing instructions:
1. checkout and pull branch
2. Create reports for AWS, Azure, and GCP
```
AWS report:
nise report -c jpy aws --static-report-file ./example_aws_static_data.yml --aws-s3-report-name <directory_name> --aws-s3-bucket-name ./

Azure Report:
nise report -c nok azure --static-report-file ./example_azure_static_data.yml --azure-report-name <directory_name> --azure-container-name ./

GCP Report:
nise report -c jpy gcp -s 2021-01-01 -e 2021-01-02  --gcp-report-prefix <report_name> --gcp-bucket-name ./  

```
3. check reports for currency to see if it matches in passed in value, valid currency options below
```
valid_currencies = [
        "aud",
        "cad",
        "chf",
        "cny",
        "dkk",
        "eur",
        "gbp",
        "hkd",
        "jpy",
        "nok",
        "nzd",
        "sek",
        "sgd",
        "usd",
        "zar",
    ]
```
4. If the currency code is not in support list
```
nise report: error: argument -c/--currency: nkd is an unsupported currency code.
```
5. If no code is given should default currency to USD