### PR TITLE
fix for static file does not exist

### DIFF
--- a/nise/__main__.py
+++ b/nise/__main__.py
@@ -19,6 +19,7 @@ import argparse
 import calendar
 import datetime
 import os
+import sys
 import time
 from pprint import pformat
 
@@ -518,11 +519,17 @@ def _load_static_report_data(options):
     """Validate/load and set start_date if static file is provided."""
     if not options.get("static_report_file"):
         return
+
+    static_file = options.get("static_report_file")
+    if not os.path.exists(static_file):
+        LOG.error(f"static-report-file does not exist: {static_file}")
+        sys.exit()
+
     LOG.info("Loading static data...")
     aws_tags = set()
     start_dates = []
     end_dates = []
-    static_report_data = load_yaml(options.get("static_report_file"))
+    static_report_data = load_yaml(options.get(static_file))
     for generator_dict in static_report_data.get("generators"):
         for _, attributes in generator_dict.items():
             start_date = get_start_date(attributes, options)

--- a/nise/__main__.py
+++ b/nise/__main__.py
@@ -529,7 +529,7 @@ def _load_static_report_data(options):
     aws_tags = set()
     start_dates = []
     end_dates = []
-    static_report_data = load_yaml(options.get(static_file))
+    static_report_data = load_yaml(static_file)
     for generator_dict in static_report_data.get("generators"):
         for _, attributes in generator_dict.items():
             start_date = get_start_date(attributes, options)

--- a/nise/__main__.py
+++ b/nise/__main__.py
@@ -522,7 +522,7 @@ def _load_static_report_data(options):
 
     static_file = options.get("static_report_file")
     if not os.path.exists(static_file):
-        LOG.error(f"static-report-file does not exist: {static_file}")
+        LOG.error(f"file does not exist: '{static_file}'")
         sys.exit()
 
     LOG.info("Loading static data...")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -466,7 +466,7 @@ class MainDateTest(TestCase):
             "aws_gen_last": {"start_date": datetime(2020, 5, 31, 0, 0), "end_date": datetime(2020, 5, 31, 0, 0)},
             "aws_gen_last_first": {"start_date": datetime(2020, 5, 31, 0, 0), "end_date": datetime(2020, 6, 1, 0, 0)},
         }
-        options = {"provider": "aws", "static_report_file": "fake-file"}
+        options = {"provider": "aws", "static_report_file": "tests/aws_static_report.yml"}
         mock_load.return_value = static_report_data
         _load_static_report_data(options)
         for generator_dict in options.get("static_report_data").get("generators"):
@@ -517,7 +517,7 @@ class MainDateTest(TestCase):
                 "end_date": datetime(2020, 6, 1, 0, 0),
             },
         }
-        options = {"provider": "aws-marketplace", "static_report_file": "fake-file"}
+        options = {"provider": "aws-marketplace", "static_report_file": "tests/aws_static_report.yml"}
         mock_load.return_value = static_report_data
         _load_static_report_data(options)
         for generator_dict in options.get("static_report_data").get("generators"):
@@ -557,7 +557,7 @@ class MainDateTest(TestCase):
             "ocp_gen_last": {"start_date": datetime(2020, 5, 31, 0, 0), "end_date": datetime(2020, 5, 31, 0, 0)},
             "ocp_gen_last_first": {"start_date": datetime(2020, 5, 31, 0, 0), "end_date": datetime(2020, 6, 1, 0, 0)},
         }
-        options = {"provider": "ocp", "static_report_file": "fake-file"}
+        options = {"provider": "ocp", "static_report_file": "tests/ocp_static_report.yml"}
         mock_load.return_value = static_report_data
         _load_static_report_data(options)
         for generator_dict in options.get("static_report_data").get("generators"):
@@ -603,7 +603,7 @@ class MainDateTest(TestCase):
                 "end_date": datetime(2020, 6, 2, 0, 0),
             },
         }
-        options = {"provider": "azure", "static_report_file": "fake-file"}
+        options = {"provider": "azure", "static_report_file": "tests/azure_static_report.yml"}
         mock_load.return_value = static_report_data
         _load_static_report_data(options)
         for generator_dict in options.get("static_report_data").get("generators"):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -611,3 +611,12 @@ class MainDateTest(TestCase):
                 with self.subTest(key=key):
                     self.assertEqual(attributes.get("start_date"), str(expected.get(key).get("start_date")))
                     self.assertEqual(attributes.get("end_date"), str(expected.get(key).get("end_date")))
+
+    def test_static_report_file_does_not_exist(self):
+        """
+        Test to load static report data form non existent file.
+        """
+        options = {"static_report_file": "tests/bogus_file"}
+
+        with self.assertRaises(SystemExit):
+            _load_static_report_data(options)


### PR DESCRIPTION
fixes: [COST-2335](https://issues.redhat.com/browse/COST-2335)

Without fix:
```
(nise) bash-3.2$ nise report aws --static-report-file ./does_not_exists
Traceback (most recent call last):
  File "/Users/dougdonahue/.local/share/virtualenvs/nise-5t57SMBa/bin/nise", line 33, in <module>
    sys.exit(load_entry_point('koku-nise==2.6.0', 'console_scripts', 'nise')())
  File "/Users/dougdonahue/.local/share/virtualenvs/nise-5t57SMBa/lib/python3.8/site-packages/koku_nise-2.6.0-py3.8.egg/nise/_main_.py", line 655, in main
    run(provider_type, options)
  File "/Users/dougdonahue/.local/share/virtualenvs/nise-5t57SMBa/lib/python3.8/site-packages/koku_nise-2.6.0-py3.8.egg/nise/_main_.py", line 617, in run
    static_data_bool = _load_static_report_data(options)
  File "/Users/dougdonahue/.local/share/virtualenvs/nise-5t57SMBa/lib/python3.8/site-packages/koku_nise-2.6.0-py3.8.egg/nise/_main_.py", line 526, in _load_static_report_data
    for generator_dict in static_report_data.get("generators"):
AttributeError: 'str' object has no attribute 'get'
```

With fix:
```
(nise) bash-3.2$ nise report aws --static-report-file ./bogus-file
2022-02-16 03:28:11,458 [ERROR] file does not exist: './bogus-file'
```