### PR TITLE
GCP generator currency bug fix

### DIFF
--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.8.0"
+__version__ = "2.8.1"
 VERSION = __version__.split(".")

--- a/nise/generators/gcp/gcp_network_generator.py
+++ b/nise/generators/gcp/gcp_network_generator.py
@@ -84,7 +84,6 @@ class GCPNetworkGenerator(GCPGenerator):
         row["usage.unit"] = usage_unit
         row["usage.pricing_unit"] = pricing_unit
         row["cost_type"] = "regular"
-        row["currency"] = self._currency
         row["currency_conversion_rate"] = 1
         row["usage.amount"] = self._gen_usage_unit_amount(usage_unit)
         row["usage.amount_in_pricing_units"] = self._gen_pricing_unit_amount(pricing_unit, row["usage.amount"])
@@ -101,6 +100,7 @@ class GCPNetworkGenerator(GCPGenerator):
                 if key in self.column_labels:
                     row[key] = self.attributes[key]
 
+        row["currency"] = self._currency
         row["labels"] = self.determine_labels(self.LABELS)
 
         return row


### PR DESCRIPTION
There was a small bug where the network GCP generator was not overriding the default USD value and getting foreign currency code

**Testing Instructions**
1. Pull Branch
2. pipenv in to nise
3. Run `make install` to make sure your environment is up to date with the new code
4. Run the following command
```
nise report -c jpy gcp --static-report-file "Local file path"/nise/example_gcp_static_data.yml --gcp-report-prefix report-name --gcp-bucket-name ./
```
5.There should be a new directory under nise which contains a file `report-name.csv` Open this file and just insure the currency column only contains JPY for the entire file