### PR TITLE
Update marketplace generator to use same columns

### DIFF
--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.9.0"
+__version__ = "2.9.1"
 VERSION = __version__.split(".")

--- a/nise/generators/aws/aws_generator.py
+++ b/nise/generators/aws/aws_generator.py
@@ -61,8 +61,11 @@ PRODUCT_COLS = (
     "product/architecturalReview",
     "product/architectureSupport",
     "product/availability",
+    "product/availabilityZone",
     "product/bestPractices",
+    "product/capacitystatus",
     "product/caseSeverityresponseTimes",
+    "product/classicnetworkingsupport",
     "product/clockSpeed",
     "product/comments",
     "product/contentType",
@@ -78,6 +81,7 @@ PRODUCT_COLS = (
     "product/durability",
     "product/ebsOptimized",
     "product/ecu",
+    "product/edition",
     "product/endpointType",
     "product/engineCode",
     "product/enhancedNetworkingSupported",
@@ -85,17 +89,23 @@ PRODUCT_COLS = (
     "product/feeDescription",
     "product/fromLocation",
     "product/fromLocationType",
+    "product/fromRegionCode",
     "product/group",
     "product/groupDescription",
     "product/includedServices",
     "product/instanceFamily",
     "product/instanceType",
+    "product/instanceTypeFamily",
+    "product/intelAvx2Available",
+    "product/intelAvxAvailable",
+    "product/intelTurboAvailable",
     "product/isshadow",
     "product/iswebsocket",
     "product/launchSupport",
     "product/licenseModel",
     "product/location",
     "product/locationType",
+    "product/marketoption",
     "product/maxIopsBurstPerformance",
     "product/maxIopsvolume",
     "product/maxThroughputvolume",
@@ -106,11 +116,14 @@ PRODUCT_COLS = (
     "product/messageDeliveryOrder",
     "product/minVolumeSize",
     "product/networkPerformance",
+    "product/normalizationSizeFactor",
     "product/operatingSystem",
     "product/operation",
     "product/operationsSupport",
     "product/origin",
     "product/physicalProcessor",
+    "product/platousagetype",
+    "product/platovolumetype",
     "product/preInstalledSw",
     "product/proactiveGuidance",
     "product/processorArchitecture",
@@ -122,34 +135,43 @@ PRODUCT_COLS = (
     "product/queueType",
     "product/recipient",
     "product/region",
+    "product/regionCode",
     "product/requestDescription",
     "product/requestType",
     "product/resourceEndpoint",
     "product/routingTarget",
     "product/routingType",
     "product/servicecode",
+    "product/servicename",
     "product/sku",
     "product/softwareType",
     "product/storage",
     "product/storageClass",
     "product/storageMedia",
     "product/storageType",
+    "product/subscriptionType",
     "product/technicalSupport",
     "product/tenancy",
     "product/thirdpartySoftwareSupport",
     "product/toLocation",
     "product/toLocationType",
+    "product/toRegionCode",
     "product/training",
     "product/transferType",
     "product/usagetype",
     "product/vcpu",
     "product/version",
     "product/virtualInterfaceType",
+    "product/volumeApiName",
     "product/volumeType",
+    "product/vpcnetworkingsupport",
     "product/whoCanOpenCases",
 )
 PRICING_COLS = (
     "pricing/LeaseContractLength",
+    "pricing/RateCode",
+    "pricing/RateId",
+    "pricing/currency",
     "pricing/OfferingClass" "pricing/PurchaseOption",
     "pricing/publicOnDemandCost",
     "pricing/publicOnDemandRate",
@@ -157,13 +179,26 @@ PRICING_COLS = (
     "pricing/unit",
 )
 RESERVE_COLS = (
+    "reservation/AmortizedUpfrontCostForUsage",
+    "reservation/AmortizedUpfrontFeeForBillingPeriod",
     "reservation/AvailabilityZone",
+    "reservation/EffectiveCost",
+    "reservation/EndTime",
+    "reservation/ModificationStatus",
     "reservation/NormalizedUnitsPerReservation",
     "reservation/NumberOfReservations",
+    "reservation/RecurringFeeForUsage",
     "reservation/ReservationARN",
+    "reservation/StartTime",
+    "reservation/SubscriptionId",
     "reservation/TotalReservedNormalizedUnits",
     "reservation/TotalReservedUnits",
     "reservation/UnitsPerReservation",
+    "reservation/UnusedAmortizedUpfrontFeeForBillingPeriod",
+    "reservation/UnusedNormalizedUnitQuantity",
+    "reservation/UnusedQuantity",
+    "reservation/UnusedRecurringFee",
+    "reservation/UpfrontValue",
 )
 SAVINGS_COLS = (
     "savingsPlan/AmortizedUpfrontCommitmentForBillingPeriod",
@@ -206,7 +241,7 @@ class AWSGenerator(AbstractGenerator):
         + tuple(RESOURCE_TAG_COLS)
     )
 
-    def __init__(self, start_date, end_date, currency, payer_account, usage_accounts, attributes=None, tag_cols=None):
+    def __init__(self, start_date, end_date, currency, payer_account, usage_accounts, attributes={}, tag_cols=None):
         """Initialize the generator."""
         self.payer_account = payer_account
         self.currency = currency
@@ -290,6 +325,7 @@ class AWSGenerator(AbstractGenerator):
         row["lineItem/UsageStartDate"] = start
         row["lineItem/UsageEndDate"] = end
         row["lineItem/CurrencyCode"] = self.currency
+        row["lineItem/LegalEntity"] = "Amazon Web Services, Inc."
         return row
 
     def _add_tag_data(self, row):

--- a/nise/generators/aws/marketplace_generator.py
+++ b/nise/generators/aws/marketplace_generator.py
@@ -15,189 +15,33 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 """Module for marketplace data generation."""
-import datetime
+import string
 from random import choice
-from random import randint
 from random import uniform
 
-from nise.generators.aws.aws_constants import REGIONS
-from nise.generators.generator import AbstractGenerator
-
-IDENTITY_COLS = ("identity/LineItemId", "identity/TimeInterval")
-BILL_COLS = (
-    "bill/InvoiceId",
-    "bill/BillingEntity",
-    "bill/BillType",
-    "bill/PayerAccountId",
-    "bill/BillingPeriodStartDate",
-    "bill/BillingPeriodEndDate",
-)
-LINE_ITEM_COLS = (
-    "lineItem/UsageAccountId",
-    "lineItem/LineItemType",
-    "lineItem/UsageStartDate",
-    "lineItem/UsageEndDate",
-    "lineItem/ProductCode",
-    "lineItem/UsageType",
-    "lineItem/Operation",
-    "lineItem/AvailabilityZone",
-    "lineItem/ResourceId",
-    "lineItem/UsageAmount",
-    "lineItem/NormalizationFactor",
-    "lineItem/NormalizedUsageAmount",
-    "lineItem/CurrencyCode",
-    "lineItem/UnblendedRate",
-    "lineItem/UnblendedCost",
-    "lineItem/BlendedRate",
-    "lineItem/BlendedCost",
-    "lineItem/LineItemDescription",
-    "lineItem/TaxType",
-    "lineItem/LegalEntity",
-)
-PRODUCT_COLS = (
-    "product/ProductName",
-    "product/availability",
-    "product/availabilityZone",
-    "product/capacitystatus",
-    "product/classicnetworkingsupport",
-    "product/clockSpeed",
-    "product/currentGeneration",
-    "product/databaseEngine",
-    "product/dedicatedEbsThroughput",
-    "product/description",
-    "product/durability",
-    "product/ecu",
-    "product/edition",
-    "product/endpointType",
-    "product/engineCode",
-    "product/enhancedNetworkingSupported",
-    "product/fromLocation",
-    "product/fromLocationType",
-    "product/fromRegionCode",
-    "product/group",
-    "product/groupDescription",
-    "product/instanceFamily",
-    "product/instanceType",
-    "product/instanceTypeFamily",
-    "product/intelAvx2Available",
-    "product/intelAvxAvailable",
-    "product/intelTurboAvailable",
-    "product/licenseModel",
-    "product/location",
-    "product/locationType",
-    "product/marketoption",
-    "product/maxIopsBurstPerformance",
-    "product/maxIopsvolume",
-    "product/maxThroughputvolume",
-    "product/maxVolumeSize",
-    "product/memory",
-    "product/networkPerformance",
-    "product/normalizationSizeFactor",
-    "product/operatingSystem",
-    "product/operation",
-    "product/physicalProcessor",
-    "product/platousagetype",
-    "product/platovolumetype",
-    "product/preInstalledSw",
-    "product/processorArchitecture",
-    "product/processorFeatures",
-    "product/productFamily",
-    "product/provisioned",
-    "product/region",
-    "product/regionCode",
-    "product/routingTarget",
-    "product/routingType",
-    "product/servicecode",
-    "product/servicename",
-    "product/sku",
-    "product/storage",
-    "product/storageClass",
-    "product/storageMedia",
-    "product/subscriptionType",
-    "product/tenancy",
-    "product/toLocation",
-    "product/toLocationType",
-    "product/toRegionCode",
-    "product/transferType",
-    "product/usagetype",
-    "product/vcpu",
-    "product/version",
-    "product/volumeApiName",
-    "product/volumeType",
-    "product/vpcnetworkingsupport",
-)
-PRICING_COLS = (
-    "pricing/RateCode",
-    "pricing/RateId",
-    "pricing/currency",
-    "pricing/publicOnDemandCost",
-    "pricing/publicOnDemandRate",
-    "pricing/term",
-    "pricing/unit",
-)
-RESERVE_COLS = (
-    "reservation/AmortizedUpfrontCostForUsage",
-    "reservation/AmortizedUpfrontFeeForBillingPeriod",
-    "reservation/EffectiveCost",
-    "reservation/EndTime",
-    "reservation/ModificationStatus",
-    "reservation/NormalizedUnitsPerReservation",
-    "reservation/NumberOfReservations",
-    "reservation/RecurringFeeForUsage",
-    "reservation/StartTime",
-    "reservation/SubscriptionId",
-    "reservation/TotalReservedNormalizedUnits",
-    "reservation/TotalReservedUnits",
-    "reservation/UnitsPerReservation",
-    "reservation/UnusedAmortizedUpfrontFeeForBillingPeriod",
-    "reservation/UnusedNormalizedUnitQuantity",
-    "reservation/UnusedQuantity",
-    "reservation/UnusedRecurringFee",
-    "reservation/UpfrontValue",
-)
-SAVINGS_COLS = (
-    "savingsPlan/TotalCommitmentToDate",
-    "savingsPlan/SavingsPlanARN",
-    "savingsPlan/SavingsPlanRate",
-    "savingsPlan/UsedCommitment",
-    "savingsPlan/SavingsPlanEffectiveCost",
-    "savingsPlan/AmortizedUpfrontCommitmentForBillingPeriod",
-    "savingsPlan/RecurringCommitmentForBillingPeriod",
-)
-
-LEGAL_ENTITY_CHOICES = ("Red Hat", "Red Hat Inc.", "Amazon Web Services, Inc.")
+from nise.generators.aws.aws_generator import AWSGenerator
 
 
-class MarketplaceGenerator(AbstractGenerator):
+class MarketplaceGenerator(AWSGenerator):
     """Defines a generator for AWS Marketplace"""
 
-    RESOURCE_TAG_COLS = {"resourceTags/aws:createdBy", "resourceTags/user:insights_project"}
+    LEGAL_ENTITY_CHOICES = ("Red Hat", "Red Hat Inc.", "Amazon Web Services, Inc.")
 
-    AWS_COLUMNS = set(
-        IDENTITY_COLS
-        + BILL_COLS
-        + LINE_ITEM_COLS
-        + PRODUCT_COLS
-        + PRICING_COLS
-        + RESERVE_COLS
-        + SAVINGS_COLS
-        + tuple(RESOURCE_TAG_COLS)
+    MARKETPLACE_PRODUCTS = (
+        "Red Hat OpenShift Service on AWS",
+        "Red Hat Enterprise Linux 7",
+        "Red Hat Enterprise Linux 8",
     )
 
-    def __init__(self, start_date, end_date, currency, payer_account, usage_accounts, attributes=None, tag_cols=None):
-        super().__init__(start_date, end_date)
+    def __init__(self, start_date, end_date, currency, payer_account, usage_accounts, attributes={}, tag_cols=None):
         """Initialize the generator."""
-        self.payer_account = payer_account
-        self.usage_accounts = usage_accounts
-        self.attributes = attributes
-        self._tags = None
-        self.num_instances = 1 if attributes else randint(2, 60)
-        self._amount = uniform(0.2, 6000.99)
-        self._rate = round(uniform(0.02, 0.06), 3)
-        self._product_sku = self.fake.pystr(min_chars=12, max_chars=12).upper()
+        super().__init__(start_date, end_date, currency, payer_account, usage_accounts, attributes, tag_cols)
+
+        self._legal_entity = choice(self.LEGAL_ENTITY_CHOICES)
+        self._amount = uniform(0.2, 300.99)
+        self._rate = round(uniform(0.02, 0.16), 3)
         self._resource_id = "i-{}".format(self.fake.ean8())
-        self._currency = currency
-        self._legal_entity = None
+        self._product_sku = self.fake.pystr(min_chars=12, max_chars=12).upper()
 
         for attribute in self.attributes:
             setattr(self, f"_{attribute}", self.attributes.get(attribute))
@@ -206,121 +50,50 @@ class MarketplaceGenerator(AbstractGenerator):
             self.RESOURCE_TAG_COLS.update(tag_cols)
             self.AWS_COLUMNS.update(tag_cols)
 
-    @staticmethod
-    def timestamp(in_date):
-        """Provide timestamp for a date."""
-        if not (in_date and isinstance(in_date, datetime.datetime)):
-            raise ValueError("in_date must be a date object.")
-        return in_date.strftime("%Y-%m-%dT%H:%M:%SZ")
+    @property
+    def rate_code(self):
+        """Return a formatted rate code."""
+        if hasattr(self, "_rate_code"):
+            return self._rate_code
 
-    @staticmethod
-    def time_interval(start, end):
-        """Create a time interval string from input dates."""
-        start_str = MarketplaceGenerator.timestamp(start)
-        end_str = MarketplaceGenerator.timestamp(end)
-        return str(start_str) + "/" + str(end_str)
+        chars = string.ascii_uppercase + string.digits
 
-    def _pick_tag(self, tag_key, options):
-        """Generate tag from options."""
-        if self._tags:
-            tags = self._tags.get(tag_key)
-        elif self.attributes:
-            tags = None
-        else:
-            tags = choice(options)
-        return tags
+        return (
+            "".join([choice(chars) for _ in range(16)])
+            + "."
+            + "".join([choice(chars) for _ in range(10)])
+            + "."
+            + "".join([choice(chars) for _ in range(10)])
+        )
 
-    def _init_data_row(self, start, end, **kwargs):  # noqa: C901
-        """Create a row of data with placeholder for all headers."""
-        if not (start and end):
-            raise ValueError("start and end must be date objects.")
-        if not isinstance(start, datetime.datetime):
-            raise ValueError("start must be a date object.")
-        if not isinstance(end, datetime.datetime):
-            raise ValueError("end must be a date object.")
+    @property
+    def rate_id(self):
+        """Return a formatted rate code."""
+        if hasattr(self, "_rate_id"):
+            return self._rate_id
+        return "".join([choice(string.digits) for _ in range(10)])
 
-        bill_begin = start.replace(microsecond=0, second=0, minute=0, hour=0, day=1)
-        bill_end = AbstractGenerator.next_month(bill_begin)
-        row = {}
-        COL_MAP = {
-            "identity/LineItemId": self.fake.sha1(raw_output=False),
-            "identity/TimeInterval": MarketplaceGenerator.time_interval(start, end),
-            "bill/BillingEntity": "AWS",
-            "bill/BillType": "Anniversary",
-            "bill/PayerAccountId": self.payer_account,
-            "bill/BillingPeriodStartDate": MarketplaceGenerator.timestamp(bill_begin),
-            "bill/BillingPeriodEndDate": MarketplaceGenerator.timestamp(bill_end),
-        }
-        for column in self.AWS_COLUMNS:
-            row[column] = ""
-            if COL_MAP.get(column):
-                row[column] = COL_MAP.get(column)
-
-        return row
-
-    def _get_location(self):
-        """Pick instance location."""
-        options = None
-        if self.attributes and self.attributes.get("region"):
-            region = self.attributes.get("region")
-            options = [option for option in REGIONS if region in option]
-        if options:
-            location = choice(options)
-        else:
-            location = choice(REGIONS)
-        return location
-
-    def _add_common_usage_info(self, row, start, end, **kwargs):
-        """Add common usage information."""
-        row["lineItem/UsageAccountId"] = choice(self.usage_accounts)
-        row["lineItem/LineItemType"] = "Usage"
-        row["lineItem/UsageStartDate"] = start
-        row["lineItem/UsageEndDate"] = end
-        return row
-
-    def _add_tag_data(self, row):
-        """Add tag data to the row."""
-        if self._tags:
-            for tag in self._tags:
-                row[tag] = self._tags[tag]
-        else:
-            num_tags = self.fake.random_int(0, 5)
-            for _ in range(num_tags):
-                seen_tags = set()
-                tag_key = choice(list(self.RESOURCE_TAG_COLS))
-                if tag_key not in seen_tags:
-                    row[tag_key] = self.fake.word()
-                    seen_tags.update([tag_key])
-
-    def _generate_region_short_code(self, region):
-        """Generate the AWS short code for a region."""
-        split_region = region.split("-")
-        return split_region[0][0:2].upper() + split_region[1][0].upper() + split_region[2]
+    @property
+    def subscription_id(self):
+        """Return a formatted rate code."""
+        if hasattr(self, "_subscription_id"):
+            return self._subscription_id
+        return "".join([choice(string.digits) for _ in range(10)])
 
     def _update_data(self, row, start, end, **kwargs):
         """Update data with generator specific data."""
         self.AWS_COLUMNS.update(self.AWS_COLUMNS)
         row = self._add_common_usage_info(row, start, end)
 
-        rate = self._rate
-        amount = self._amount
-        cost = amount * rate
-        location, aws_region, avail_zone, _ = self._get_location()
+        cost = self._amount * self._rate
+        _, aws_region, avail_zone, _ = self._get_location()
         description = "AWS Marketplace hourly software usage|us-east-1|m5.xlarge"
         amazon_resource_name = f"arn:aws:ec2:{avail_zone}:{self.payer_account}:instance/i-{self._resource_id}"
 
-        row["identity/LineItemId"] = "diygn5vanaqsvysz3prxwrekztiipfu7zywyauupnpmpi4fmd5dq"
-        row["identity/TimeInterval"] = "2021-11-23T17:49:15Z/2021-12-01T00:00:00Z"
-
-        row["bill/InvoiceId"] = "2021-11-23T17:49:15Z/2021-12-01T00:00:00Z"
         row["bill/BillingEntity"] = "AWS Marketplace"
-        row["bill/BillType"] = "Anniversary"
-        row["bill/PayerAccountId"] = "589173575009"
-        row["bill/BillingPeriodStartDate"] = "2021-11-01T00:00:00Z"
-        row["bill/BillingPeriodEndDate"] = "2021-12-01T00:00:00Z"
 
         row["lineItem/UsageAccountId"] = choice(self.usage_accounts)
-        row["lineItem/LegalEntity"] = self._legal_entity if self._legal_entity else choice(LEGAL_ENTITY_CHOICES)
+        row["lineItem/LegalEntity"] = self._legal_entity
         row["lineItem/LineItemType"] = "Usage"
         row["lineItem/UsageStartDate"] = start
         row["lineItem/UsageEndDate"] = end
@@ -329,41 +102,30 @@ class MarketplaceGenerator(AbstractGenerator):
         row["lineItem/Operation"] = "Hourly"
         row["lineItem/AvailabilityZone"] = avail_zone
         row["lineItem/ResourceId"] = amazon_resource_name
-        row["lineItem/UsageAmount"] = "1"
-        row["lineItem/CurrencyCode"] = self._currency
-        row["lineItem/UnblendedRate"] = rate
+        row["lineItem/UsageAmount"] = self._amount
+        row["lineItem/CurrencyCode"] = self.currency
+        row["lineItem/UnblendedRate"] = self._rate
         row["lineItem/UnblendedCost"] = cost
-        row["lineItem/BlendedRate"] = rate
+        row["lineItem/BlendedRate"] = self._rate
         row["lineItem/BlendedCost"] = cost
         row["lineItem/LineItemDescription"] = description
 
-        row["product/ProductName"] = "Red Hat OpenShift Service on AWS"
+        row["product/ProductName"] = choice(self.MARKETPLACE_PRODUCTS)
         row["product/region"] = aws_region
         row["product/sku"] = self._product_sku
 
         row["pricing/publicOnDemandCost"] = cost
         row["pricing/unit"] = "Hrs"
-        row["pricing/RateCode"] = "VDHYUHU8G2Z5AZY3.4799GE89SK.6YS6EN2CT7"
-        row["pricing/RateId"] = "4981658079"
-        row["pricing/currency"] = "USD"
+        row["pricing/RateCode"] = self.rate_code
+        row["pricing/RateId"] = self.rate_id
+        row["pricing/currency"] = self.currency
         row["pricing/term"] = "OnDemand"
 
-        row["reservation/SubscriptionId"] = "7592738291"
-
-        row["resourceTags/aws:createdBy"] = "AssumedRole:AROAYSLL3JVQ6DYUNKWQJ:1637692740557658269"
+        row["reservation/SubscriptionId"] = self.subscription_id
 
         self._add_tag_data(row)
 
         return row
-
-    def _generate_hourly_data(self, **kwargs):
-        """Create hourly data."""
-        for hour in self.hours:
-            start = hour.get("start")
-            end = hour.get("end")
-            row = self._init_data_row(start, end)
-            row = self._update_data(row, start, end)
-            yield row
 
     def generate_data(self, report_type=None):
         """Responsibile for generating data."""

--- a/nise/report.py
+++ b/nise/report.py
@@ -531,13 +531,14 @@ def aws_create_report(options):  # noqa: C901
         accounts_list = static_report_data.get("accounts")
     else:
         generators = [
-            {"generator": DataTransferGenerator, "attributes": None},
-            {"generator": EBSGenerator, "attributes": None},
-            {"generator": EC2Generator, "attributes": None},
-            {"generator": S3Generator, "attributes": None},
-            {"generator": RDSGenerator, "attributes": None},
-            {"generator": Route53Generator, "attributes": None},
-            {"generator": VPCGenerator, "attributes": None},
+            {"generator": DataTransferGenerator, "attributes": {}},
+            {"generator": EBSGenerator, "attributes": {}},
+            {"generator": EC2Generator, "attributes": {}},
+            {"generator": S3Generator, "attributes": {}},
+            {"generator": RDSGenerator, "attributes": {}},
+            {"generator": Route53Generator, "attributes": {}},
+            {"generator": VPCGenerator, "attributes": {}},
+            {"generator": MarketplaceGenerator, "attributes": {}},
         ]
         accounts_list = None
 
@@ -766,7 +767,7 @@ def ocp_create_report(options):  # noqa: C901
     if static_report_data:
         generators = _get_generators(static_report_data.get("generators"))
     else:
-        generators = [{"generator": OCPGenerator, "attributes": None}]
+        generators = [{"generator": OCPGenerator, "attributes": {}}]
 
     months = _create_month_list(start_date, end_date)
     insights_upload = options.get("insights_upload")
@@ -981,10 +982,10 @@ def gcp_create_report(options):  # noqa: C901
                 currency = default_currency(options.get("currency"), get_gcp_static_currency(generators))
         else:
             generators = [
-                {"generator": JSONLCloudStorageGenerator, "attributes": None},
-                {"generator": JSONLComputeEngineGenerator, "attributes": None},
-                {"generator": JSONLGCPNetworkGenerator, "attributes": None},
-                {"generator": JSONLGCPDatabaseGenerator, "attributes": None},
+                {"generator": JSONLCloudStorageGenerator, "attributes": {}},
+                {"generator": JSONLComputeEngineGenerator, "attributes": {}},
+                {"generator": JSONLGCPNetworkGenerator, "attributes": {}},
+                {"generator": JSONLGCPDatabaseGenerator, "attributes": {}},
             ]
             account = fake.word()
             project_generator = JSONLProjectGenerator(account)
@@ -1008,10 +1009,10 @@ def gcp_create_report(options):  # noqa: C901
 
     else:
         generators = [
-            {"generator": CloudStorageGenerator, "attributes": None},
-            {"generator": ComputeEngineGenerator, "attributes": None},
-            {"generator": GCPNetworkGenerator, "attributes": None},
-            {"generator": GCPDatabaseGenerator, "attributes": None},
+            {"generator": CloudStorageGenerator, "attributes": {}},
+            {"generator": ComputeEngineGenerator, "attributes": {}},
+            {"generator": GCPNetworkGenerator, "attributes": {}},
+            {"generator": GCPDatabaseGenerator, "attributes": {}},
         ]
         account = fake.word()
 

--- a/tests/test_aws_generator.py
+++ b/tests/test_aws_generator.py
@@ -512,7 +512,7 @@ class TestMarketplaceGenerator(AWSGeneratorTestCase):
         row = generator._update_data(start_row, self.two_hours_ago, self.now)
 
         self.assertEqual(row["bill/BillingEntity"], "AWS Marketplace")
-        self.assertEqual(row["product/ProductName"], "Red Hat OpenShift Service on AWS")
+        self.assertIn(row["product/ProductName"], generator.MARKETPLACE_PRODUCTS)
 
     def test_generate_data(self):
         """Test that the MarketplaceGenerator generate_data method works."""
@@ -523,6 +523,12 @@ class TestMarketplaceGenerator(AWSGeneratorTestCase):
         self.assertNotEqual(data, [])
 
     def test_add_common_pricing_info(self):
+        self.attributes.update(
+            {
+                "rate_id": "4981658079",
+                "rate_code": "VDHYUHU8G2Z5AZY3.4799GE89SK.6YS6EN2CT7",
+            }
+        )
         generator = MarketplaceGenerator(
             self.two_hours_ago, self.now, self.currency, self.payer_account, self.usage_accounts, self.attributes
         )


### PR DESCRIPTION
## Summary
This brings the AWS MarketplaceGenerator to be a subclass of the AWSGenerator and provides the option of producing marketplace data in the same YAML as the rest of a run's AWS data. This will produce a single CSV, but all the data is there. 