### PR TITLE
for AWS marketplace generator added ability to override product_name …

### DIFF
--- a/nise/generators/aws/marketplace_generator.py
+++ b/nise/generators/aws/marketplace_generator.py
@@ -37,7 +37,6 @@ class MarketplaceGenerator(AWSGenerator):
         """Initialize the generator."""
         super().__init__(start_date, end_date, currency, payer_account, usage_accounts, attributes, tag_cols)
 
-        self._legal_entity = choice(self.LEGAL_ENTITY_CHOICES)
         self._amount = uniform(0.2, 300.99)
         self._rate = round(uniform(0.02, 0.16), 3)
         self._resource_id = "i-{}".format(self.fake.ean8())
@@ -93,7 +92,7 @@ class MarketplaceGenerator(AWSGenerator):
         row["bill/BillingEntity"] = "AWS Marketplace"
 
         row["lineItem/UsageAccountId"] = choice(self.usage_accounts)
-        row["lineItem/LegalEntity"] = self._legal_entity
+        row["lineItem/LegalEntity"] = self._get_legal_entity()
         row["lineItem/LineItemType"] = "Usage"
         row["lineItem/UsageStartDate"] = start
         row["lineItem/UsageEndDate"] = end
@@ -110,7 +109,7 @@ class MarketplaceGenerator(AWSGenerator):
         row["lineItem/BlendedCost"] = cost
         row["lineItem/LineItemDescription"] = description
 
-        row["product/ProductName"] = choice(self.MARKETPLACE_PRODUCTS)
+        row["product/ProductName"] = self._get_product_name()
         row["product/region"] = aws_region
         row["product/sku"] = self._product_sku
 
@@ -130,3 +129,21 @@ class MarketplaceGenerator(AWSGenerator):
     def generate_data(self, report_type=None):
         """Responsibile for generating data."""
         return self._generate_hourly_data()
+
+    def _get_legal_entity(self):
+        """look for provided 'legal_entity', if not supplied use defaults."""
+        if self.attributes and self.attributes.get("legal_entity"):
+            legal_entity = self.attributes.get("legal_entity")
+        else:
+            legal_entity = choice(self.LEGAL_ENTITY_CHOICES)
+
+        return legal_entity
+
+    def _get_product_name(self):
+        """look for provided 'product_name', if not supplied use defaults."""
+        if self.attributes and self.attributes.get("product_name"):
+            product_name = self.attributes.get("product_name")
+        else:
+            product_name = choice(self.MARKETPLACE_PRODUCTS)
+
+        return product_name

--- a/tests/test_aws_generator.py
+++ b/tests/test_aws_generator.py
@@ -505,6 +505,7 @@ class TestMarketplaceGenerator(AWSGeneratorTestCase):
 
     def test_update_data(self):
         """Test Marketplace specific update data method."""
+        del self.attributes["product_name"]
         generator = MarketplaceGenerator(
             self.two_hours_ago, self.now, self.currency, self.payer_account, self.usage_accounts, self.attributes
         )
@@ -513,6 +514,21 @@ class TestMarketplaceGenerator(AWSGeneratorTestCase):
 
         self.assertEqual(row["bill/BillingEntity"], "AWS Marketplace")
         self.assertIn(row["product/ProductName"], generator.MARKETPLACE_PRODUCTS)
+
+    def test_update_data_with_overrides(self):
+        """Test Marketplace specific update data method with override to 'product_name' & 'legal_entity'"""
+        self.attributes["product_name"] = "TESTING_PN"
+        self.attributes["legal_entity"] = "TESTING_LE"
+
+        generator = MarketplaceGenerator(
+            self.two_hours_ago, self.now, self.currency, self.payer_account, self.usage_accounts, self.attributes
+        )
+        start_row = {}
+        row = generator._update_data(start_row, self.two_hours_ago, self.now)
+
+        self.assertEqual(row["bill/BillingEntity"], "AWS Marketplace")
+        self.assertIn(row["product/ProductName"], "TESTING_PN")
+        self.assertIn(row["lineItem/LegalEntity"], "TESTING_LE")
 
     def test_generate_data(self):
         """Test that the MarketplaceGenerator generate_data method works."""


### PR DESCRIPTION
Added the ability to override 'product_name' & 'legal_entity' to AWS marketplace generator

When running the following commands with not specifying 'product_name' & 'legal_entity' in static.yaml file, you should see the default values be utilized.

**default static file:**
```
---
  generators:
    - MarketplaceGenerator:
        start_date: 2022-01-01
        processor_arch: 32-bit
        resource_id: 55555555
        product_sku: VEAJHRNKTJZQ
        region: us-east-1a
        tags:
          resourceTags/aws:createdBy: AssumedRole:AROAYSLL3JVQ6DYUNKWQJ:1637692740557658269
        instance_type:
          inst_type: m5.large
          vcpu: 2
          memory: '8 GiB'
          storage: 'EBS Only'
          family: 'General Purpose'
          cost: 1.000
          rate: 0.500

  accounts:
    payer: 9999999999999
    user:
      - 9999999999999
    currency_code: USD
```

`nise report aws --static-report-file example_aws-marketplace_static_data.yml --aws-s3-report-name None --aws-s3-bucket-name ./local_providers/aws_local`

results (snip-snaps)

![default_legal_ent](https://user-images.githubusercontent.com/57504257/180076783-801d1cfa-302e-423f-88f3-a1414bb5d751.png)

![default_product_name](https://user-images.githubusercontent.com/57504257/180076818-0543a4ce-caa2-47f8-b1f4-780d44cc9a07.png)


**override defaults values for 'product_name' & 'legal_entity' static file:**
```
---
  generators:
    - MarketplaceGenerator:
        start_date: 2022-01-01
        processor_arch: 32-bit
        resource_id: 55555555
        product_sku: VEAJHRNKTJZQ
        product_name: 'TESTING'
        region: us-east-1a
        legal_entity: 'AWS DD'
        tags:
          resourceTags/aws:createdBy: AssumedRole:AROAYSLL3JVQ6DYUNKWQJ:1637692740557658269
        instance_type:
          inst_type: m5.large
          vcpu: 2
          memory: '8 GiB'
          storage: 'EBS Only'
          family: 'General Purpose'
          cost: 1.000
          rate: 0.500

  accounts:
    payer: 9999999999999
    user:
      - 9999999999999
    currency_code: USD
```

`nise report aws --static-report-file example_aws-marketplace_static_data.yml --aws-s3-report-name None --aws-s3-bucket-name ./local_providers/aws_local`

results (snip-snaps)

![override_legal_ent](https://user-images.githubusercontent.com/57504257/180077038-7344148f-04c5-45dc-8d4a-b3a9cf8c2618.png)

![override_product_name](https://user-images.githubusercontent.com/57504257/180077053-beab5529-b78f-4642-97d2-63d69e7446c3.png)

