### PR TITLE
[COST-2902] Nise update for QE testing consistency

### DIFF
--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.9.8"
+__version__ = "2.9.9"
 VERSION = __version__.split(".")

--- a/nise/generators/gcp/compute_engine_generator.py
+++ b/nise/generators/gcp/compute_engine_generator.py
@@ -62,7 +62,11 @@ class ComputeEngineGenerator(GCPGenerator):
                 self._pricing_amount = self.attributes.get("usage.amount_in_pricing_units")
             if self.attributes.get("price"):
                 self._price = self.attributes.get("price")
-            if self.attributes.get("usage.pricing_unit"):
+            if self.attributes.get("sku_id"):
+                for sku in self.SKU:
+                    if self.attributes.get("sku_id") == sku[0]:
+                        self._sku = sku
+            elif self.attributes.get("usage.pricing_unit"):
                 for sku in self.SKU:
                     if self.attributes.get("usage.pricing_unit") == sku[3]:
                         self._sku = sku


### PR DESCRIPTION
This change will allow specifying an `SKU_ID` in a compute generator yaml for GCP to specifically choose the SKU you want to generate data for. If you specify both an `SKU_ID` and a `usage.pricing_unit`, the SKU_ID will be used to determine the sku and the pricing unit will be ignored.

Example:
```
---
generators:
  - ComputeEngineGenerator:
      start_date: 2022-08-01
      end_date: 2022-09-08
      cost: 2557
      currency: USD
      labels: [{"environment": "ci", "project":"p1"}]
  - ComputeEngineGenerator:
      start_date: 2022-08-01
      end_date: 2022-09-08
      price: 2
      usage.amount_in_pricing_units: 1
      usage.pricing_unit: hour
      currency: USD
      instance_type: m2-megamem-416
      location.region: australia-southeast1-a
      labels: [{"environment": "clyde", "app":"winter", "version":"green", "kubernetes-io-cluster-test-ocp-gcp-cluster": "owned"}]
  - ComputeEngineGenerator:
      start_date: 2022-08-01
      end_date: 2022-09-08
      price: 2
      usage.amount_in_pricing_units: 1
      usage.pricing_unit: hour
      currency: USD
      labels: [{"usage": "hour"}]
  - ComputeEngineGenerator:
      start_date: 2022-08-01
      end_date: 2022-09-08
      price: 3
      usage.amount_in_pricing_units: 1
      sku_id: CF4E-A0C7-E3BF
      currency: USD
  - ComputeEngineGenerator:
      start_date: 2022-08-01
      end_date: 2022-09-08
      price: 3
      usage.amount_in_pricing_units: 1
      sku_id: 236F-83FC-852C
      currency: USD
``` 