### PR TITLE
[COST-3210/3211] AWS/Azure CCSP Data

### DIFF
--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "3.0.5"
+__version__ = "3.0.6"
 VERSION = __version__.split(".")

--- a/nise/generators/aws/marketplace_generator.py
+++ b/nise/generators/aws/marketplace_generator.py
@@ -160,7 +160,11 @@ class MarketplaceGenerator(AWSGenerator):
         """Return a dictionary of values based on the legal entity for CCSP vs Private offer testing."""
         if legal_entity == "Amazon Web Services, Inc.":
             return {
-                "description": "$0.1158 per On Demand Red Hat Enterprise Linux with HA t3.small Instance Hour",
+                "description": getattr(
+                    self,
+                    "_lineitem_lineitemdescription",
+                    "$0.1158 per On Demand Red Hat Enterprise Linux with HA t3.small Instance Hour",
+                ),
                 "billingentity": "AWS",
                 "productcode": "AmazonEC2",
                 "productfamily": "Compute Instance",
@@ -168,7 +172,9 @@ class MarketplaceGenerator(AWSGenerator):
             }
         else:
             return {
-                "description": "AWS Marketplace hourly software usage|us-east-1|m5.xlarge",
+                "description": getattr(
+                    self, "_lineitem_lineitemdescription", "AWS Marketplace hourly software usage|us-east-1|m5.xlarge"
+                ),
                 "billingentity": "AWS Marketplace",
                 "productcode": "5hnnev4d0v7mapf09j0v8of0o2",
             }

--- a/nise/generators/azure/__init__.py
+++ b/nise/generators/azure/__init__.py
@@ -19,6 +19,7 @@ from nise.generators.azure.azure_generator import AZURE_COLUMNS  # noqa: F401
 from nise.generators.azure.azure_generator import AZURE_COLUMNS_V2  # noqa: F401
 from nise.generators.azure.azure_generator import AzureGenerator  # noqa: F401
 from nise.generators.azure.bandwidth_generator import BandwidthGenerator  # noqa: F401
+from nise.generators.azure.ccsp_generator import CCSPGenerator  # noqa: F401
 from nise.generators.azure.sql_database_generator import SQLGenerator  # noqa: F401
 from nise.generators.azure.storage_generator import StorageGenerator  # noqa: F401
 from nise.generators.azure.virtual_machine_generator import VMGenerator  # noqa: F401

--- a/nise/generators/azure/azure_generator.py
+++ b/nise/generators/azure/azure_generator.py
@@ -224,10 +224,7 @@ class AzureGenerator(AbstractGenerator):
     def _get_resource_info(self, meter_id, service_meter, ex_resource, add_info, service_info):
         """Return resource information."""
         service_tier, meter_sub, meter_name, units_of_measure = self._get_cached_meter_values(meter_id, service_meter)
-        if meter_sub == "Red Hat Enterprise Linux":
-            service_info_2 = "Red Hat"
-        else:
-            service_info_2 = choice(service_info)
+        service_info_2 = choice(service_info)
         resource_group, resource_name = choice(ex_resource)
         additional_info = choice(add_info)
         if self._instance_id:

--- a/nise/generators/azure/azure_generator.py
+++ b/nise/generators/azure/azure_generator.py
@@ -224,10 +224,12 @@ class AzureGenerator(AbstractGenerator):
     def _get_resource_info(self, meter_id, service_meter, ex_resource, add_info, service_info):
         """Return resource information."""
         service_tier, meter_sub, meter_name, units_of_measure = self._get_cached_meter_values(meter_id, service_meter)
-
+        if meter_sub == "Red Hat Enterprise Linux":
+            service_info_2 = "Red Hat"
+        else:
+            service_info_2 = choice(service_info)
         resource_group, resource_name = choice(ex_resource)
         additional_info = choice(add_info)
-        service_info_2 = choice(service_info)
         if self._instance_id:
             self._consumed, second_part = accts_str = self._get_accts_str(self._service_name)
             self._resource_type = self._consumed + "/" + second_part
@@ -380,8 +382,13 @@ class AzureGenerator(AbstractGenerator):
         # NOTE: Commented out columns exist in the report, but we don't have enough
         # information to date to accurately simulate values.
         if self._service_name == "Virtual Machines":
-            service_family = choice(self.SERVICE_FAMILIES + ("Azure Marketplace Services",))
-            publisher_name = "Red Hat Enterprise Linux"
+            if row.get("MeterSubCategory", "") == "Red Hat Enterprise Linux":
+                publisher_name = "Microsoft"
+                service_family = "Compute"
+                row["MeterCategory"] = "Virtual Machine Licenses"
+            else:
+                publisher_name = "Red Hat Enterprise Linux"
+                service_family = choice(self.SERVICE_FAMILIES + ("Azure Marketplace Services",))
             publisher_type = "Marketplace"
         else:
             service_family = choice(self.SERVICE_FAMILIES)

--- a/nise/generators/azure/azure_generator.py
+++ b/nise/generators/azure/azure_generator.py
@@ -379,7 +379,7 @@ class AzureGenerator(AbstractGenerator):
         # NOTE: Commented out columns exist in the report, but we don't have enough
         # information to date to accurately simulate values.
         if self._service_name == "Virtual Machines":
-            if row.get("MeterSubCategory", "") == "Red Hat Enterprise Linux":
+            if getattr(self, "_CCSP", False):
                 publisher_name = "Microsoft"
                 service_family = "Compute"
                 row["MeterCategory"] = "Virtual Machine Licenses"

--- a/nise/generators/azure/ccsp_generator.py
+++ b/nise/generators/azure/ccsp_generator.py
@@ -1,0 +1,35 @@
+#
+# Copyright 2022 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""Module for azure bandwidth data generation."""
+from nise.generators.azure.virtual_machine_generator import VMGenerator
+
+
+class CCSPGenerator(VMGenerator):
+    """Generator for CCSP data."""
+
+    SERVICE_METER = (("Red Hat Enterprise Linux", "Red Hat Enterprise Linux", "1 vCPU VM License", "1 Hour"),)
+    SERVICE_INFO_2 = ("Red Hat",)
+    ADDITIONAL_INFO = (
+        {
+            "UsageType": "ComputeHR",
+            "ImageType": "Red Hat",
+            "ServiceType": "Standard_B1ls",
+            "VMName": None,
+            "VMProperties": None,
+            "VCPUs": 1,
+        },
+    )

--- a/nise/generators/azure/ccsp_generator.py
+++ b/nise/generators/azure/ccsp_generator.py
@@ -21,8 +21,6 @@ from nise.generators.azure.virtual_machine_generator import VMGenerator
 class CCSPGenerator(VMGenerator):
     """Generator for CCSP data."""
 
-    SERVICE_METER = (("Red Hat Enterprise Linux", "Red Hat Enterprise Linux", "1 vCPU VM License", "1 Hour"),)
-    SERVICE_INFO_2 = ("Red Hat",)
     ADDITIONAL_INFO = (
         {
             "UsageType": "ComputeHR",
@@ -33,3 +31,17 @@ class CCSPGenerator(VMGenerator):
             "VCPUs": 1,
         },
     )
+
+    def __init__(self, start_date, end_date, currency, account_info, attributes=None):
+        """Initialize the data transfer generator."""
+        self.SERVICE_METER = (
+            (
+                "Red Hat Enterprise Linux",
+                attributes.get("meter_sub", "Red Hat Enterprise Linux"),
+                "1 vCPU VM License",
+                "1 Hour",
+            ),
+        )
+        self.SERVICE_INFO_2 = (attributes.get("service_info_2", "Red Hat"),)
+        self._CCSP = True
+        super().__init__(start_date, end_date, currency, account_info, attributes)

--- a/nise/generators/azure/virtual_machine_generator.py
+++ b/nise/generators/azure/virtual_machine_generator.py
@@ -24,7 +24,6 @@ class VMGenerator(AzureGenerator):
     SERVICE_METER = (
         ("A Series", "A Series", "A0", "100 Hours"),
         ("BS Series", "BS Series", "B2s", "100 Hours"),
-        ("Red Hat Enterprise Linux", "Red Hat Enterprise Linux", "1 vCPU VM License", "1 Hour"),
     )
     SERVICE_INFO_2 = ("Canonical", "")
     EXAMPLE_RESOURCE = (

--- a/nise/generators/azure/virtual_machine_generator.py
+++ b/nise/generators/azure/virtual_machine_generator.py
@@ -21,7 +21,11 @@ from nise.generators.azure.azure_generator import AzureGenerator
 class VMGenerator(AzureGenerator):
     """Generator for Virtual Machine data."""
 
-    SERVICE_METER = (("A Series", "A Series", "A0", "100 Hours"), ("BS Series", "BS Series", "B2s", "100 Hours"))
+    SERVICE_METER = (
+        ("A Series", "A Series", "A0", "100 Hours"),
+        ("BS Series", "BS Series", "B2s", "100 Hours"),
+        ("Red Hat Enterprise Linux", "Red Hat Enterprise Linux", "1 vCPU VM License", "1 Hour"),
+    )
     SERVICE_INFO_2 = ("Canonical", "")
     EXAMPLE_RESOURCE = (
         ("RG1", "mysa1"),

--- a/nise/generators/azure/virtual_machine_generator.py
+++ b/nise/generators/azure/virtual_machine_generator.py
@@ -25,7 +25,7 @@ class VMGenerator(AzureGenerator):
         ("A Series", "A Series", "A0", "100 Hours"),
         ("BS Series", "BS Series", "B2s", "100 Hours"),
     )
-    SERVICE_INFO_2 = ("Canonical", "")
+    SERVICE_INFO_2 = ("Canonical",)
     EXAMPLE_RESOURCE = (
         ("RG1", "mysa1"),
         ("RG1", "costmgmtacct1234"),

--- a/nise/report.py
+++ b/nise/report.py
@@ -50,6 +50,7 @@ from nise.generators.aws import Route53Generator
 from nise.generators.aws import S3Generator
 from nise.generators.aws import VPCGenerator
 from nise.generators.azure import BandwidthGenerator
+from nise.generators.azure import CCSPGenerator
 from nise.generators.azure import SQLGenerator
 from nise.generators.azure import StorageGenerator
 from nise.generators.azure import VMGenerator
@@ -668,6 +669,7 @@ def azure_create_report(options):  # noqa: C901
     else:
         generators = [
             {"generator": BandwidthGenerator, "attributes": {}},
+            {"generator": CCSPGenerator, "attributes": {}},
             {"generator": SQLGenerator, "attributes": {}},
             {"generator": StorageGenerator, "attributes": {}},
             {"generator": VMGenerator, "attributes": {}},


### PR DESCRIPTION
This change allows the generation of CCSP data for AWS/Azure. 

For AWS marketplace generator, if the legal entity is `Amazon Web Services, Inc` then it will get the required data for us to associate it as CCSP Data.
Testing:
- Either do it with nise defaults for a marketplace generator or specify a yaml with a legal entity to generate the data. A legal entity of `Red Hat, Inc` will generate private offer data whereas a legal entity of `Amazon Web Services, Inc.` will generate CCSP data. Example (note the local folder samples should exist to use that as the bucket name, if you need help creating a static yaml for this please ask):
1. `nise report aws-marketplace --aws-s3-bucket-name samples --aws-s3-report-name both --static-report-file aws-market.yaml`


For Azure, a new generator type was created, `CCSPGenerator` and it will generate CCSP matching data since VMGenerator does private offer data. Example (note the local folder samples should exist to use that as the bucket name, if you need help creating a static yaml and using it, please ask):
 2. `nise report azure  --azure-container-name samples --azure-report-name taco -s 2022-10-01` 


3. Create koku sources with both of these source types and verify there are HCS generated files that matches the expected data. If you need help with step, please ask.