### PR TITLE
Add import sanity test

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -46,6 +46,9 @@ jobs:
         run: |
           pipenv install --dev --ignore-pipfile --python ${{ matrix.python-version }}
 
+      - name: Run sanity tests
+        run: pipenv run tox -e sanity
+
       - name: Run unit tests
         run: pipenv run coverage run -m unittest discover ./tests/ -v
 

--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,10 @@ Nise uses tox to standardize the environment used when running tests. Essentiall
 
 This will rebuild the tox virtual env and then run all tests.
 
+To run sanity tests
+
+    tox -e sanity
+
 To run all unit tests specifically::
 
     make test

--- a/tests/sanity/import/importer.py
+++ b/tests/sanity/import/importer.py
@@ -1,0 +1,53 @@
+def main():  # noqa: C901
+    """Isolate globals from imported code"""
+
+    import os
+    import pathlib
+    import sys
+    import traceback
+
+    from importlib import import_module
+
+    def convert_path_to_name(path: str) -> str:
+        clean_path = pathlib.Path(path)
+        if clean_path.name == "__init__.py":
+            clean_path = clean_path.parent
+
+        clean_path = clean_path.with_suffix("")
+        name = str(clean_path).replace(os.path.sep, ".")
+
+        return name
+
+    def test_module(path: str, name: str, messages: set) -> None:
+        try:
+            import_module(name)
+        except Exception as exc:
+            exc_type, _exc, exc_tb = sys.exc_info()
+            frames = reversed(traceback.extract_tb(exc_tb))
+            line = 0
+            message = str(exc)
+            for frame in frames:
+                if frame.filename.endswith(path):
+                    line = frame.lineno or 0
+                    break
+
+            if message not in messages:
+                print(f"{path}:{line}: traceback: {exc_type.__name__} {message}")
+                messages.add(message)
+
+    messages = set()
+    files = sys.argv[1:]
+    if not files:
+        source = pathlib.Path(__file__).parent.parent.parent.parent.joinpath("nise")
+        files = [str(file) for file in source.rglob("*.py")]
+
+    for path in files:
+        name = convert_path_to_name(path)
+        test_module(path, name, messages)
+
+    if messages:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tox.ini
+++ b/tox.ini
@@ -53,3 +53,8 @@ commands =
   flake8 nise --ignore=C901,Q000
   coverage run -m unittest discover {toxinidir}/tests/ -v
   coverage report --show-missing
+
+[testenv:sanity]
+usedevelop = True
+deps =
+commands = {basepython} {toxinidir}/tests/sanity/import/importer.py {posargs}


### PR DESCRIPTION
Add a basic sanity test to ensure all Python files are importable.

### Note

The sanity test was added to the existing job for simplicity. It should eventually be refactored into a separate test that can run in parallel with the unit tests.