### PR TITLE
Update actions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,8 +9,13 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - name: Checkout
+      uses: actions/checkout@v3.2.0
+
+    - name: Install Python
+      uses: actions/setup-python@v4.4.0
       with:
         python-version: '3.8'
-    - uses: pre-commit/action@v2.0.0
+
+    - name: Run pre-commit checks
+      uses: pre-commit/action@v3.0.0

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -12,11 +12,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.2.0
         with:
           fetch-depth: 0
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v1
+      - name: Set up Python
+        uses: actions/setup-python@v4.4.0
         with:
           python-version: 3.8
 

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout repsository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.2.0
         with:
           fetch-depth: 0
 
@@ -25,7 +25,7 @@ jobs:
         run: printenv
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4.4.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -34,7 +34,7 @@ jobs:
 
       - name: Cache dependencies
         id: cache-dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3.2.2
         with:
           path: |
             ~/.cache/pipenv
@@ -56,7 +56,7 @@ jobs:
         run: pipenv run coverage xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3.1.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml


### PR DESCRIPTION
Actions that use node.js 12 are deprecated.

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/