### PR TITLE
COST-3482: Update lineitem legal entity choices and description

### DIFF
--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "4.0.1"
+__version__ = "4.0.2"
 
 VERSION = __version__.split(".")

--- a/nise/generators/aws/marketplace_generator.py
+++ b/nise/generators/aws/marketplace_generator.py
@@ -25,7 +25,8 @@ from nise.generators.aws.aws_generator import AWSGenerator
 class MarketplaceGenerator(AWSGenerator):
     """Defines a generator for AWS Marketplace"""
 
-    LEGAL_ENTITY_CHOICES = ("Red Hat", "Red Hat, Inc.", "Amazon Web Services, Inc.")
+    LEGAL_ENTITY_CHOICES = ("Red Hat", "Red Hat, Inc.", "Amazon Web Services, Inc.", "AWS")
+    RHEL_DESCRIPTION_CHOICES = ("Red Hat Enterprise Linux", "RHEL")
 
     MARKETPLACE_PRODUCTS = (
         "Red Hat OpenShift Service on AWS",
@@ -112,7 +113,7 @@ class MarketplaceGenerator(AWSGenerator):
         row["lineItem/LineItemDescription"] = row_data.get("description")
 
         row["product/ProductName"] = self._get_product_name(legal_entity)
-        if legal_entity == "Amazon Web Services, Inc.":
+        if legal_entity in ["Amazon Web Services, Inc.", "AWS"]:
             row["product/instanceType"] = row_data.get("instancetype")
             row["product/productFamily"] = row_data.get("productfamily")
         row["product/region"] = aws_region
@@ -159,12 +160,12 @@ class MarketplaceGenerator(AWSGenerator):
 
     def _get_marketplace_data(self, legal_entity):
         """Return a dictionary of values based on the legal entity for CCSP vs Private offer testing."""
-        if legal_entity == "Amazon Web Services, Inc.":
+        if legal_entity in ["Amazon Web Services, Inc.", "AWS"]:
             return {
                 "description": getattr(
                     self,
                     "_lineitem_lineitemdescription",
-                    "$0.1158 per On Demand Red Hat Enterprise Linux with HA t3.small Instance Hour",
+                    f"$0.1158 per On Demand {choice(self.RHEL_DESCRIPTION_CHOICES)} with HA t3.small Instance Hour",
                 ),
                 "billingentity": "AWS",
                 "productcode": "AmazonEC2",


### PR DESCRIPTION
[COST-3482](https://issues.redhat.com/browse/COST-3482)

This change updates lineitem legal entity choices and adds RHEL to description to adds variant of the same seller or offering in CCSP data for AWS.

## Testing

Here's a minimal yaml file with `legal_entity` set to `AWS` under the place generator:

```
---
generators:
  - EC2Generator:
      start_date: today
      processor_arch: 64-bit
      resource_id: 55555557
      product_sku: VEAJHRNKTJAB
      region: us-east-1a
      tags:
        resourceTags/user:environment: dev
        resourceTags/user:version: gamma
        resourceTags/user:dashed-key-on-aws: dashed-value
      instance_type:
        inst_type: m5.large
        vcpu: 2
        memory: '8 GiB'
        storage: 'EBS Only'
        family: 'General Purpose'
        cost: 0.096
        rate: 0.096
  - EC2Generator:
      start_date: today
      processor_arch: 64-bit
      resource_id: 55555558
      product_sku: VEAJHRNKTJAC
      region: us-east-1a
      tags:
        resourceTags/user:version: master
        resourceTags/user:dashed-key-on-aws: dashed-value
      cost_category:
        costCategory/Cody: is-awesome
      instance_type:
        inst_type: m5.large
        vcpu: 2
        memory: '8 GiB'
        storage: 'EBS Only'
        family: 'General Purpose'
        cost: 0.096
        rate: 0.096
  - S3Generator:
      start_date: today
      product_sku: VEAJHRNAAAAA
      amount: 10
      rate: 0.05
      tags:
        resourceTags/user:storageclass: charlie
  - EBSGenerator:
      product_sku: VEAJHRNBBBBA
      resource_id: 12345671
      amount: 10
      rate: 0.01
      tags:
        resourceTags/user:storageclass: bravo
  - RDSGenerator:
      start_date: today
      tags:
        resourceTags/user:app: analytics
  - VPCGenerator:
      start_date: today
      tags:
        resourceTags/user:app: cost
  - Route53Generator:
      start_date: today
      product_family: DNS Query
      tags:
        resourceTags/user:app: cost
  - DataTransferGenerator:
      resource_id: ''
      product_sku: AERJHRNCCCCD
      product_code: AmazonDynamoDB
      product_name: Amazon DynamoDB
      tags:
        resourceTags/user:app: catalog
  - MarketplaceGenerator:
      start_date: today
      processor_arch: 32-bit
      resource_id: 25555555
      product_sku: VEAJHRNKTJZZ
      legal_entity: 'AWS'
      region: us-east-1a
      tags:
        resourceTags/aws:createdBy: AssumedRole:AROAYSLL3JVQ6DYUNKWQJ:1637692740557658269
      instance_type:
        inst_type: m5.large
        vcpu: 2
        memory: '8 GiB'
        storage: 'EBS Only'
        family: 'General Purpose'
        cost: 1.000
        rate: 0.500
        rate_code: SDFKLSDHCICLKKDS.LKHSSDUQHI.SDHLJKKJDQ
        rate_id: 2343582976
        subscription_id: 2346788732


accounts:
  payer: 9999999999999
  user:
    - 9999999999999
```



1. checkout this branch
2. copy and save the above yml in an `aws_static_data.yml` file.
3. run `make install` inside your nise pipenv shell
4. then run `nise report aws --static-report-file aws_static_data.yml  -w`
5. In the report generated, you should see some rows with `AWS` in the `lineItem/LegalEntity` column and rows with `$0.1158 per On Demand ("Red Hat Enterprise Linux" or "RHEL") with HA t3.small Instance Hour` in the `lineItem/LineItemDescription` column.