### PR TITLE
fix ROS report generation when using static file

### DIFF
--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "4.2.1"
+__version__ = "4.2.2"
 
 VERSION = __version__.split(".")

--- a/nise/generators/ocp/ocp_generator.py
+++ b/nise/generators/ocp/ocp_generator.py
@@ -729,16 +729,9 @@ class OCPGenerator(AbstractGenerator):
             end = hour.get("end")
             if self._nodes:
                 for pod_name, _ in self.pods.items():
-                    pod = deepcopy(self.pods[pod_name])
+                    pod = deepcopy(self.ros_data[pod_name])
                     row = self._init_data_row(start, end, **kwargs)
-                    row = self._update_data(
-                        row,
-                        start,
-                        end,
-                        pod=pod,
-                        **kwargs,
-                    )
-                    yield row
+                    yield self._update_data(row, start, end, pod=pod, **kwargs)
             else:
                 pod_count = len(self.pods)
                 num_pods = randint(2, pod_count)
@@ -749,8 +742,7 @@ class OCPGenerator(AbstractGenerator):
                     pod_name = pod_keys[pod_choice]
                     pod = deepcopy(self.ros_data[pod_name])
                     row = self._init_data_row(start, end, **kwargs)
-                    row = self._update_data(row, start, end, pod=pod, **kwargs)
-                    yield row
+                    yield self._update_data(row, start, end, pod=pod, **kwargs)
 
     def _gen_hourly_storage_usage(self, **kwargs):
         """Create hourly data for storage usage."""


### PR DESCRIPTION
This can be tested with this command:
```
nise report ocp --ros-ocp-info  --ocp-cluster-id abcd  --start-date  2023-03-01 --end-date 2023-04-12 --insights-upload testing/pvc_dir/insights_local --static-report-file examples/ocp_on_aws/ocp_static_data.yml
```

This will fail on 4.2.1, and will successfully generate reports on this branch.