### PR TITLE
[COST-2373] Update AWS tags columns

### DIFF
--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "4.2.2"
+__version__ = "4.2.3"
 
 VERSION = __version__.split(".")

--- a/nise/generators/aws/aws_generator.py
+++ b/nise/generators/aws/aws_generator.py
@@ -229,6 +229,7 @@ class AWSGenerator(AbstractGenerator):
         "resourceTags/user:openshift_cluster",
         "resourceTags/user:openshift_project",
         "resourceTags/user:openshift_node",
+        "resourceTags/aws:createdBy",
     }
     COST_CATEGORY_COLS = {
         "costCategory/Charge type",
@@ -248,7 +249,7 @@ class AWSGenerator(AbstractGenerator):
         + tuple(COST_CATEGORY_COLS)
     )
 
-    def __init__(self, start_date, end_date, currency, payer_account, usage_accounts, attributes={}, tag_cols=None):
+    def __init__(self, start_date, end_date, currency, payer_account, usage_accounts, attributes=None, tag_cols=None):
         """Initialize the generator."""
         self.payer_account = payer_account
         self.currency = currency

--- a/nise/generators/aws/aws_generator.py
+++ b/nise/generators/aws/aws_generator.py
@@ -254,7 +254,7 @@ class AWSGenerator(AbstractGenerator):
         self.payer_account = payer_account
         self.currency = currency
         self.usage_accounts = usage_accounts
-        self.attributes = attributes
+        self.attributes = attributes if attributes else {}
         self._tags = None
         self._cost_category = None
         self.num_instances = 1 if attributes else randint(2, 60)

--- a/nise/generators/aws/marketplace_generator.py
+++ b/nise/generators/aws/marketplace_generator.py
@@ -43,8 +43,9 @@ class MarketplaceGenerator(AWSGenerator):
         self._resource_id = "i-{}".format(self.fake.ean8())
         self._product_sku = self.fake.pystr(min_chars=12, max_chars=12).upper()
 
-        for attribute in self.attributes:
-            setattr(self, f"_{attribute}", self.attributes.get(attribute))
+        if self.attributes:
+            for attribute in self.attributes:
+                setattr(self, f"_{attribute}", self.attributes.get(attribute))
 
         if tag_cols:
             self.RESOURCE_TAG_COLS.update(tag_cols)

--- a/nise/generators/aws/marketplace_generator.py
+++ b/nise/generators/aws/marketplace_generator.py
@@ -34,7 +34,7 @@ class MarketplaceGenerator(AWSGenerator):
         "Red Hat Enterprise Linux 8",
     )
 
-    def __init__(self, start_date, end_date, currency, payer_account, usage_accounts, attributes={}, tag_cols=None):
+    def __init__(self, start_date, end_date, currency, payer_account, usage_accounts, attributes=None, tag_cols=None):
         """Initialize the generator."""
         super().__init__(start_date, end_date, currency, payer_account, usage_accounts, attributes, tag_cols)
 


### PR DESCRIPTION
[COST-2373](https://issues.redhat.com/browse/COST-2373)

This pr updates AWS tag columns to resolve a `ValueError` raised when the is not in expected field names

## Testing

1. Checkout Branch
2. In you nise shell run the following the commands

```
make install
nise report aws-marketplace --static-report-file example_aws-marketplace_static_data.yml  -w
```
 - It should run successfully and you should see `resourceTags/aws:createdBy` column in the generated csv reports.
