### PR TITLE
Add argcomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,12 @@ The `make run-iqe` command by default will run the smoke tests. However, if you 
                                                 use internal config file
         -n, --num-nodes INT                     optional, Number of nodes to generate (default is 1)
 
+To enable tab completion for `zsh` and `bash`, install `argcomplete` in the virtual environment and configure it.
+
+      pip install argcomplete
+      activate-global-python-argcomplete
+
+To enable tab completion for other shells, see the [documentation][other-shells].
 
 ### Notes
 
@@ -208,3 +214,6 @@ generation.](docs/cost_usage_report_generation.md)
 
 Please refer to
 [Contributing](CONTRIBUTING.md).
+
+
+[other-shells]: https://kislyuk.github.io/argcomplete/#support-for-other-shells

--- a/nise/__main__.py
+++ b/nise/__main__.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
+# PYTHON_ARGCOMPLETE_OK
 """Cost and Usage Generator CLI."""
 import argparse
 import calendar
@@ -39,6 +40,13 @@ from nise.util import LOG_VERBOSITY
 from nise.yaml_gen import add_yaml_parser_args
 from nise.yaml_gen import yaml_main
 from oci.exceptions import InvalidConfig
+
+HAS_ARGCOMPLETE = False
+try:
+    import argcomplete  # fmt: skip
+    HAS_ARGCOMPLETE = True
+except ImportError:
+    pass
 
 os.environ["TZ"] = "UTC"
 time.tzset()
@@ -764,6 +772,9 @@ def run(provider_type, options):
 def main():
     """Run data generation program."""
     parser = create_parser()
+    if HAS_ARGCOMPLETE:
+        argcomplete.autocomplete(parser)
+
     args = parser.parse_args()
     if args.log_level:
         LOG.setLevel(LOG_VERBOSITY[args.log_level])


### PR DESCRIPTION
Since `nise` is a pretty complex command line tool, having tab completion makes it much easier to use. If `argcomplete` is installed and configured, this provides tab completion.