### PR TITLE
Generete ROS-OCP data for job and manually created pods

### DIFF
--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "4.2.8"
+__version__ = "4.2.9"
 
 VERSION = __version__.split(".")

--- a/nise/generators/ocp/ocp_generator.py
+++ b/nise/generators/ocp/ocp_generator.py
@@ -136,8 +136,9 @@ OCP_REPORT_TYPE_TO_COLS = {
     OCP_ROS_USAGE: OCP_ROS_USAGE_COLUMN,
 }
 
+# No recommendations are generated for job and pod workloads! Keep these two options as the last two items
+# in the dict to guarantee they are not randomly picked in get_owner_workload function.
 OCP_OWNER_WORKLOAD_CHOICES = {
-    # "pod": ("<none>", "<none>", None, None),  # manually created Pod - recommendation won't be generated
     "deployment": (None, "ReplicaSet", None, "deployment"),
     "replicaset": (None, "ReplicaSet", "<none>", "deployment"),  # manually created ReplicaSet
     "replicationcontroller": (
@@ -149,15 +150,17 @@ OCP_OWNER_WORKLOAD_CHOICES = {
     "deploymentconfig": (None, "ReplicationController", None, "deploymentconfig"),
     "statefulset": (None, "StatefulSet", None, "statefulset"),
     "daemonset": (None, "DaemonSet", None, "daemonset"),
-    # "job": (None, "Job", None, "job"), # not supported by Kruize
+    "job": (None, "Job", None, "job"),  # not supported by Kruize - recommendation won't be generated!
+    "pod": ("<none>", "<none>", None, None),  # manually created Pod - recommendation won't be generated!
 }
 
 
 def get_owner_workload(pod, workload=None):
     if not workload:
-        workload = choice(list(OCP_OWNER_WORKLOAD_CHOICES.keys()))
+        workload = choice(list(OCP_OWNER_WORKLOAD_CHOICES.keys())[:-2])  # omit job and pod from random choices
     on, ok, wl, wt = OCP_OWNER_WORKLOAD_CHOICES.get(
-        workload.lower(), choice(list(OCP_OWNER_WORKLOAD_CHOICES.values()))
+        workload.lower(),
+        choice(list(OCP_OWNER_WORKLOAD_CHOICES.values())[:-2]),  # omit job and pod from random choices
     )
     if on == "<none>" and wl == "<none>":  # manually created Pod
         return on, ok, wl, wt

--- a/nise/generators/ocp/ocp_generator.py
+++ b/nise/generators/ocp/ocp_generator.py
@@ -136,7 +136,7 @@ OCP_REPORT_TYPE_TO_COLS = {
     OCP_ROS_USAGE: OCP_ROS_USAGE_COLUMN,
 }
 
-# No recommendations are generated for job and pod workloads! Keep these two options as the last two items
+# No recommendations are generated for job and manual_pod workloads! Keep these two options as the last two items
 # in the dict to guarantee they are not randomly picked in get_owner_workload function.
 OCP_OWNER_WORKLOAD_CHOICES = {
     "deployment": (None, "ReplicaSet", None, "deployment"),
@@ -151,7 +151,7 @@ OCP_OWNER_WORKLOAD_CHOICES = {
     "statefulset": (None, "StatefulSet", None, "statefulset"),
     "daemonset": (None, "DaemonSet", None, "daemonset"),
     "job": (None, "Job", None, "job"),  # not supported by Kruize - recommendation won't be generated!
-    "pod": ("<none>", "<none>", None, None),  # manually created Pod - recommendation won't be generated!
+    "manual_pod": ("<none>", "<none>", None, None),  # manually created Pod - recommendation won't be generated!
 }
 
 

--- a/nise/generators/ocp/ocp_generator.py
+++ b/nise/generators/ocp/ocp_generator.py
@@ -157,10 +157,10 @@ OCP_OWNER_WORKLOAD_CHOICES = {
 
 def get_owner_workload(pod, workload=None):
     if not workload:
-        workload = choice(list(OCP_OWNER_WORKLOAD_CHOICES.keys())[:-2])  # omit job and pod from random choices
+        workload = choice(list(OCP_OWNER_WORKLOAD_CHOICES.keys())[:-2])  # omit job and manual_pod from random choices
     on, ok, wl, wt = OCP_OWNER_WORKLOAD_CHOICES.get(
         workload.lower(),
-        choice(list(OCP_OWNER_WORKLOAD_CHOICES.values())[:-2]),  # omit job and pod from random choices
+        choice(list(OCP_OWNER_WORKLOAD_CHOICES.values())[:-2]),  # omit job and manual_pod from random choices
     )
     if on == "<none>" and wl == "<none>":  # manually created Pod
         return on, ok, wl, wt


### PR DESCRIPTION
Enable user to specify "job" and "manul_pod" as a workload in yaml. This is needed for testing purposes (to make sure that unsupported workload type doesn't break generation of recommendations for supported workload types).
At the same time, if user doesn't specify workload in the yaml, neither "job" nor "manul_pod" should be picked randomly.