### PR TITLE
AWS: Change LineItemType when a savings plan exists

### DIFF
--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "4.2.9"
+__version__ = "4.3.0"
 
 VERSION = __version__.split(".")

--- a/nise/generators/aws/data_transfer_generator.py
+++ b/nise/generators/aws/data_transfer_generator.py
@@ -113,6 +113,10 @@ class DataTransferGenerator(AWSGenerator):
         row["pricing/term"] = "OnDemand"
         row["pricing/unit"] = "GB"
         row["savingsPlan/SavingsPlanEffectiveCost"] = str(saving)
+
+        # Overwrite lineItem/LineItemType for items with applied Savings plan
+        if saving is not None:
+            row["lineItem/LineItemType"] = "SavingsPlanCoveredUsage"
         self._add_tag_data(row)
         self._add_category_data(row)
         return row

--- a/nise/generators/aws/ec2_generator.py
+++ b/nise/generators/aws/ec2_generator.py
@@ -151,6 +151,11 @@ class EC2Generator(AWSGenerator):
         row["pricing/term"] = "OnDemand"
         row["pricing/unit"] = "Hrs"
         row["savingsPlan/SavingsPlanEffectiveCost"] = saving
+
+        # Overwrite lineItem/LineItemType for items with applied Savings plan
+        if saving is not None:
+            row["lineItem/LineItemType"] = "SavingsPlanCoveredUsage"
+
         self._add_tag_data(row)
         self._add_category_data(row)
         return row


### PR DESCRIPTION
Override the default "lineItem/LineItemType" in AWS items with applied Savings plan (set "saving" in the yaml file)