### PR TITLE
Plopezpe/add static subscription name

### DIFF
--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "4.3.1"
+__version__ = "4.3.2"
 
 VERSION = __version__.split(".")

--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "4.3.2"
+__version__ = "4.3.3"
 
 VERSION = __version__.split(".")

--- a/nise/report.py
+++ b/nise/report.py
@@ -364,7 +364,7 @@ def _generate_azure_account_info(static_report_data=None):
         subscription_guid = static_report_data.get("payer")
         usage_accounts = tuple(static_report_data.get("user"))
         currency_code = static_report_data.get("currency_code", "USD")
-        subscription_name = static_report_data.get("subscription_name",f"{company_name} Azure Subscription" )
+        subscription_name = static_report_data.get("subscription_name", f"{company_name} Azure Subscription")
         for _ in usage_accounts:
             account_name = fake.city()
             trimmed_account_name = account_name.replace(" ", "")
@@ -380,7 +380,7 @@ def _generate_azure_account_info(static_report_data=None):
             fake.ean(length=13),
         )
         currency_code = "USD"
-        subscription_name = f"{company_name} Azure Subscription"        
+        subscription_name = f"{company_name} Azure Subscription"
         for _ in usage_accounts:
             account_name = fake.city()
             trimmed_account_name = account_name.replace(" ", "")

--- a/nise/report.py
+++ b/nise/report.py
@@ -356,7 +356,7 @@ def _generate_azure_account_info(static_report_data=None):
     company_name = fake.company()
     company_email = company_name.replace(" ", "").replace(",", "")
     email_suffix = f"@{company_email}.com"
-    subscription_name = f"{company_name} Azure Subscription"
+
     billing_account_id = fake.ean(length=8)
     billing_account_name = company_name
     accounts = []
@@ -364,6 +364,7 @@ def _generate_azure_account_info(static_report_data=None):
         subscription_guid = static_report_data.get("payer")
         usage_accounts = tuple(static_report_data.get("user"))
         currency_code = static_report_data.get("currency_code", "USD")
+        subscription_name = static_report_data.get("subscription_name",f"{company_name} Azure Subscription" )
         for _ in usage_accounts:
             account_name = fake.city()
             trimmed_account_name = account_name.replace(" ", "")
@@ -379,6 +380,7 @@ def _generate_azure_account_info(static_report_data=None):
             fake.ean(length=13),
         )
         currency_code = "USD"
+        subscription_name = f"{company_name} Azure Subscription"        
         for _ in usage_accounts:
             account_name = fake.city()
             trimmed_account_name = account_name.replace(" ", "")

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1195,7 +1195,11 @@ class AzureReportTestCase(TestCase):
                     }
                 },
             ],
-            "accounts": {"payer": 9999999999999, "user": [9999999999999], "subscription_name": "static_subs_name"},
+            "accounts": {
+                "payer": "38f1d748-3ac7-4b7f-a5ae-8b5ff16db82c",
+                "user": ["38f1d748-3ac7-4b7f-a5ae-8b5ff16db82c"],
+                "subscription_name": "static_subscription_name",
+            },
         }
         options = {
             "start_date": yesterday,

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1194,7 +1194,8 @@ class AzureReportTestCase(TestCase):
                         "end_date": str(now.date() + relativedelta(months=+2)),
                     }
                 },
-            ]
+            ],
+            "accounts": {"payer": 9999999999999, "user": [9999999999999], "subscription_name": "static_subs_name"},
         }
         options = {
             "start_date": yesterday,
@@ -1205,6 +1206,7 @@ class AzureReportTestCase(TestCase):
             "static_report_data": static_azure_data,
             "write_monthly": True,
         }
+
         azure_create_report(options)
         local_path = self.MOCK_AZURE_REPORT_FILENAME
         self.assertTrue(os.path.isfile(local_path))


### PR DESCRIPTION
This PR adds support to create an Azure report (--version-two) with an static subscription_name

To test this:

add the subscription name key to an Azure yml static file:

```
# SubscriptionGuid
accounts:
  payer: 38f1d748-3ac7-4b7f-a5ae-8b5ff16db82d
  subscription_name: 'azure_multi_source0 subs name'
  user:
    - 38f1d748-3ac7-4b7f-a5ae-8b5ff16db82d
  currency_code: USD

```
And run:
`nise -lll report azure --azure-container-name dest_directory_for_report --azure-report-name costnise04 --static-report-file static_file_with_subs_name.yml --version-two`