### PR TITLE
[COST-4215] send OCP payload to minio

### DIFF
--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "4.4.2"
+__version__ = "4.4.3"
 
 VERSION = __version__.split(".")

--- a/nise/__main__.py
+++ b/nise/__main__.py
@@ -279,6 +279,13 @@ def add_ocp_parser_args(parser):
         help="URL for Minio (S3).",
     )
     parser.add_argument(
+        "--payload-name",
+        metavar="PAYLOAD_NAME",
+        dest="payload_name",
+        required=False,
+        help="The name used to save a payload.",
+    )
+    parser.add_argument(
         "--ros-ocp-info",
         dest="ros_ocp_info",
         required=False,
@@ -466,7 +473,8 @@ def _get_ocp_options(options):
     ocp_cluster_id = options.get("ocp_cluster_id")
     insights_upload = options.get("insights_upload")
     minio_upload = options.get("minio_upload")
-    return (ocp_cluster_id, insights_upload, minio_upload)
+    payload_name = options.get("payload_name")
+    return (ocp_cluster_id, insights_upload, minio_upload, payload_name)
 
 
 def _get_gcp_options(options):
@@ -542,7 +550,7 @@ def _validate_ocp_arguments(parser, options):
 
     """
 
-    ocp_cluster_id, insights_upload, minio_upload = _get_ocp_options(options)
+    ocp_cluster_id, insights_upload, minio_upload, payload_name = _get_ocp_options(options)
     if ocp_cluster_id is None:
         msg = "{} must be supplied."
         msg = msg.format("--ocp-cluster-id")
@@ -575,6 +583,10 @@ def _validate_ocp_arguments(parser, options):
             )
             msg = msg.format("--minio-upload", minio_upload)
             parser.error(msg)
+    if payload_name and not minio_upload:
+        msg = "\n\t--payload-name is only used with --minio-upload\n"
+        msg = msg.format("--payload-name", payload_name)
+        parser.error(msg)
 
     return True
 

--- a/nise/report.py
+++ b/nise/report.py
@@ -826,6 +826,7 @@ def ocp_create_report(options):  # noqa: C901
     minio_upload = options.get("minio_upload")
     write_monthly = options.get("write_monthly", False)
     for month in months:
+        print(month)
         data = {OCP_POD_USAGE: [], OCP_STORAGE_USAGE: [], OCP_NODE_LABEL: [], OCP_NAMESPACE_LABEL: []}
         file_numbers = {OCP_POD_USAGE: 0, OCP_STORAGE_USAGE: 0, OCP_NODE_LABEL: 0, OCP_NAMESPACE_LABEL: 0}
         if ros_ocp_info:
@@ -964,7 +965,9 @@ def ocp_create_report(options):  # noqa: C901
             else:
                 report_files = list(temp_files.values()) + list(temp_ros_files.values()) + [temp_manifest_name]
                 temp_usage_zip = _tar_gzip_report_files(report_files)
-                payload_key = f"{options.get('payload_name') or ocp_assembly_id.hex}.tar.gz"
+                payload_key = (
+                    f"{options.get('payload_name') or ocp_assembly_id.hex}.{gen_start_date.strftime('%Y_%m')}.tar.gz"
+                )
                 ocp_route_file_minio(minio_upload, temp_usage_zip, payload_key)
                 os.remove(temp_usage_zip)
 

--- a/nise/report.py
+++ b/nise/report.py
@@ -228,7 +228,7 @@ def ocp_route_file(insights_upload, local_path):
         LOG.info(response.text)
 
 
-def ocp_route_file_minio(minio_upload, local_path, key):
+def ocp_route_file_minio(minio_upload, local_path, key):  # pragma: no cover
     """Route file to either Upload Service or local filesystem."""
     response = post_payload_to_minio(minio_upload, local_path, key)
     if response.status_code == 200:
@@ -239,7 +239,7 @@ def ocp_route_file_minio(minio_upload, local_path, key):
         LOG.info(response.text)
 
 
-def get_s3_signature(url, file_name):
+def get_s3_signature(url, file_name):  # pragma: no cover
     s3 = boto3.client(
         "s3",
         endpoint_url=url,
@@ -254,7 +254,7 @@ def get_s3_signature(url, file_name):
     )
 
 
-def upload_file_to_s3(signature, file_path):
+def upload_file_to_s3(signature, file_path):  # pragma: no cover
     with open(file_path, "rb") as f:
         response = requests.put(signature, data=f)
     return response
@@ -315,7 +315,7 @@ def post_payload_to_ingest_service(insights_upload, local_path):
         )
 
 
-def post_payload_to_minio(minio_upload, local_path, key):
+def post_payload_to_minio(minio_upload, local_path, key):  # pragma: no cover
     """Upload the payload to Minio (or S3)."""
     signature = get_s3_signature(minio_upload, key)
     return upload_file_to_s3(signature, local_path)

--- a/nise/report.py
+++ b/nise/report.py
@@ -826,7 +826,6 @@ def ocp_create_report(options):  # noqa: C901
     minio_upload = options.get("minio_upload")
     write_monthly = options.get("write_monthly", False)
     for month in months:
-        print(month)
         data = {OCP_POD_USAGE: [], OCP_STORAGE_USAGE: [], OCP_NODE_LABEL: [], OCP_NAMESPACE_LABEL: []}
         file_numbers = {OCP_POD_USAGE: 0, OCP_STORAGE_USAGE: 0, OCP_NODE_LABEL: 0, OCP_NAMESPACE_LABEL: 0}
         if ros_ocp_info:
@@ -957,8 +956,8 @@ def ocp_create_report(options):  # noqa: C901
             if insights_upload:
                 report_files = list(temp_files.values()) + list(temp_ros_files.values())
                 for temp_usage_file in report_files:
-                    report_files = [temp_usage_file, temp_manifest_name]
-                    temp_usage_zip = _tar_gzip_report_files(report_files)
+                    files_to_zip = [temp_usage_file, temp_manifest_name]
+                    temp_usage_zip = _tar_gzip_report_files(files_to_zip)
                     ocp_route_file(insights_upload, temp_usage_zip)
                     os.remove(temp_usage_zip)
                 os.remove(temp_manifest_name)

--- a/nise/report.py
+++ b/nise/report.py
@@ -964,7 +964,7 @@ def ocp_create_report(options):  # noqa: C901
             else:
                 report_files = list(temp_files.values()) + list(temp_ros_files.values()) + [temp_manifest_name]
                 temp_usage_zip = _tar_gzip_report_files(report_files)
-                payload_key = f"{ocp_assembly_id.hex}.tar.gz"
+                payload_key = f"{options.get('payload_name') or ocp_assembly_id.hex}.tar.gz"
                 ocp_route_file_minio(minio_upload, temp_usage_zip, payload_key)
                 os.remove(temp_usage_zip)
 

--- a/nise/report.py
+++ b/nise/report.py
@@ -214,7 +214,7 @@ def azure_route_file(storage_account_name, storage_file_name, local_path, storag
         copy_to_local_dir(storage_account_name, local_path, storage_file_name)
 
 
-def ocp_route_file(insights_upload, local_path, *args):
+def ocp_route_file(insights_upload, local_path):
     """Route file to either Upload Service or local filesystem."""
     if os.path.isdir(insights_upload):
         extract_payload(insights_upload, local_path)

--- a/tests/test_gcp_generator.py
+++ b/tests/test_gcp_generator.py
@@ -369,9 +369,10 @@ class TestGCPGenerator(TestCase):
         for generator in generators_list:
             gen_handler = generator(self.yesterday, self.now, self.currency, self.project, attributes=attributes)
             generated_data = gen_handler.generate_data()
+            num_invoice_months = gen_handler._gcp_find_invoice_months_in_date_range()
             list_data = list(generated_data)
             credit_rows = []
             for row in list_data:
                 credit_amount = row.get("credits", {}).get("amount", 0)
                 credit_rows.append(credit_amount)
-            self.assertEqual(sum(credit_rows), expected_credit_amount)
+            self.assertEqual(sum(credit_rows), expected_credit_amount * len(num_invoice_months))

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -907,10 +907,8 @@ class OCPReportTestCase(TestCase):
         fix_dates(options, "ocp")
         ocp_create_report(options)
         for report_type in OCP_REPORT_TYPE_TO_COLS.keys():
-            month_output_file_name = "{}-{}-{}-{}".format(
-                calendar.month_name[now.month], now.year, cluster_id, report_type
-            )
-            expected_month_output_file = "{}/{}.csv".format(os.getcwd(), month_output_file_name)
+            month_output_file_name = f"{calendar.month_name[now.month]}-{now.year}-{cluster_id}-{report_type}"
+            expected_month_output_file = f"{os.getcwd()}/{month_output_file_name}.csv"
             self.assertTrue(os.path.isfile(expected_month_output_file))
             os.remove(expected_month_output_file)
         shutil.rmtree(local_insights_upload)
@@ -981,9 +979,7 @@ class OCPReportTestCase(TestCase):
         for report_type in OCP_REPORT_TYPE_TO_COLS.keys():
             if "ocp_ros_usage" == report_type:
                 continue
-            month_output_file_name = "{}-{}-{}-{}".format(
-                calendar.month_name[now.month], now.year, cluster_id, report_type
-            )
+            month_output_file_name = f"{calendar.month_name[now.month]}-{now.year}-{cluster_id}-{report_type}"
             expected_month_output_file = "{}/{}.csv".format(os.getcwd(), month_output_file_name)
             self.assertTrue(os.path.isfile(expected_month_output_file))
             os.remove(expected_month_output_file)

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -605,7 +605,7 @@ class AWSReportTestCase(TestCase):
         local_bucket_path = mkdtemp()
 
         static_aws_data = {
-            "generators": [{"EC2Generator": {"start_date": str(now), "end_date": str(now)}}],
+            "generators": [{"EC2Generator": {"start_date": str(yesterday), "end_date": str(now)}}],
             "accounts": {"payer": 9999999999999, "user": [9999999999999]},
         }
         options = {
@@ -618,8 +618,8 @@ class AWSReportTestCase(TestCase):
         }
         fix_dates(options, "aws")
         aws_create_report(options)
-        month_output_file_name = "{}-{}-{}".format(calendar.month_name[now.month], now.year, "cur_report")
-        expected_month_output_file = "{}/{}.csv".format(os.getcwd(), month_output_file_name)
+        month_output_file_name = f"{calendar.month_name[now.month]}-{now.year}-cur_report"
+        expected_month_output_file = f"{os.getcwd()}/{month_output_file_name}.csv"
         self.assertTrue(os.path.isfile(expected_month_output_file))
         os.remove(expected_month_output_file)
         shutil.rmtree(local_bucket_path)


### PR DESCRIPTION
## Summary

Adds 2 new CLI args for OCP report generation:
* `--minio-upload`: the url to minio
  * `S3_ACCESS_KEY`, `S3_SECRET_KEY`, `S3_BUCKET_NAME` env variables must be set. These are the credentials to access minio and the bucket in minio where the payload will be sent.
* `--payload-name`: a static name for the payload uploaded to minio. if not provided, the payload name will start with the assembly-id of the payload manifest.
  * payload-name is only used in tandem with minio-upload. If provided without minio-upload, the CLI will exit with an error
  * the payloads generated are monthly. all payload names will contain the month of the payload. the payload name is in the form `{payload-name}.{YYYY_MM}.tar.gz`.


## Testing:
##### with `--payload-name`
1. using payload name:
```
$ S3_ACCESS_KEY="kokuminioaccess" S3_SECRET_KEY="kokuminiosecret" S3_BUCKET_NAME="ocp-ingress" nise -lll report ocp -s 2023-10-01 --ocp-cluster-id test-001 --minio-upload http://localhost:9000 --daily-reports --payload-name my-payload-name
```
2. look in minio and see these payloads:
```
my-payload-name.2023_10.tar.gz
my-payload-name.2023_11.tar.gz
```

##### without `--payload-name`
1. cmd:
```
$ S3_ACCESS_KEY="kokuminioaccess" S3_SECRET_KEY="kokuminiosecret" S3_BUCKET_NAME="ocp-ingress" nise -lll report ocp -s 2023-10-01 --ocp-cluster-id test-001 --minio-upload http://localhost:9000 --daily-reports
```
2. without the payload-name, the name uses the random manifest-id:
```
8fb1c12b76ff4eafbc7c81cf90775c32.2023_10.tar.gz
939f025fc5064809a646bde4102e86ee.2023_11.tar.gz
```

##### some error pathways:
1. 
```
$ S3_ACCESS_KEY="kokuminioaccess" S3_SECRET_KEY="kokuminiosecret" nise -lll report ocp -s 2023-10-01 --ocp-cluster-id test-001 --minio-upload http://localhost:9000 --daily-reports

nise: error: 
        --minio-upload http://localhost:9000 was supplied as an argument
        but the environment must have 
                S3_ACCESS_KEY and S3_SECRET_KEY and S3_BUCKET_NAME
        defined when attempting an upload to Minio (or S3).
```

2.
```
$ S3_ACCESS_KEY="kokuminioaccess" S3_SECRET_KEY="kokuminiosecret" S3_BUCKET_NAME="ocp-ingress" nise -lll report ocp -s 2023-10-01 --ocp-cluster-id test-001 --daily-reports --payload-name my-payload-name  

nise: error: 
        --payload-name is only used with --minio-upload
```
