### PR TITLE
[COST-4269] Fix GCP datetime format for BigQuery

### DIFF
--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "4.4.3"
+__version__ = "4.4.4"
 
 VERSION = __version__.split(".")

--- a/nise/generators/gcp/gcp_generator.py
+++ b/nise/generators/gcp/gcp_generator.py
@@ -135,7 +135,8 @@ class GCPGenerator(AbstractGenerator):
         """Provide timestamp for a date."""
         if not in_date or not isinstance(in_date, datetime.datetime):
             raise ValueError("in_date must be a date object.")
-        return in_date.strftime("%Y-%m-%dT%H:%M:%S%z")
+        # Bigquery doesn't support UTC offset in the form of +HHMM -> using %Z instead of %z
+        return in_date.strftime("%Y-%m-%dT%H:%M:%S%Z")
 
     @abstractmethod
     def generate_data(self, report_type=None):


### PR DESCRIPTION
A fix for [COST-4269](https://issues.redhat.com/browse/COST-4269)
the BigQuery doesn't support datetime formats with UTC offset in the form +HHMM or -HHMM.