### PR TITLE
fix datetimes for passed in cli vars

### DIFF
--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "4.4.8"
+__version__ = "4.4.9"
 
 VERSION = __version__.split(".")

--- a/nise/__main__.py
+++ b/nise/__main__.py
@@ -742,7 +742,7 @@ def calculate_start_date(start_date):
     elif start_date == "today":
         generated_start_date = today().replace(hour=0, minute=0, second=0)
     elif start_date and isinstance(start_date, datetime.date):
-        generated_start_date = datetime.datetime.fromordinal(start_date.toordinal())
+        generated_start_date = start_date
     elif start_date:
         generated_start_date = date_parser.parse(start_date)
     else:
@@ -760,7 +760,7 @@ def calculate_end_date(start_date, end_date):
         elif end_date == "today":
             generated_end_date = today().replace(hour=0, minute=0, second=0)
         elif end_date and isinstance(end_date, datetime.date):
-            generated_end_date = datetime.datetime.fromordinal(end_date.toordinal())
+            generated_end_date = end_date
         else:
             generated_end_date = date_parser.parse(end_date)
     except TypeError:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -587,19 +587,19 @@ class MainDateTest(TestCase):
     def test_aws_dates(self, mock_load):
         """Test that select static-data-file dates return correct dates."""
         aws_gens = [
-            {"aws_gen_first": {"start_date": datetime(2020, 6, 1).date(), "end_date": datetime(2020, 6, 1).date()}},
+            {"aws_gen_first": {"start_date": datetime(2020, 6, 1), "end_date": datetime(2020, 6, 1)}},
             {
                 "aws_gen_first_second": {
-                    "start_date": datetime(2020, 6, 1).date(),
-                    "end_date": datetime(2020, 6, 2).date(),
+                    "start_date": datetime(2020, 6, 1),
+                    "end_date": datetime(2020, 6, 2),
                 }
             },
-            {"aws_gen_first_start": {"start_date": datetime(2020, 6, 1).date()}},
-            {"aws_gen_last": {"start_date": datetime(2020, 5, 31).date(), "end_date": datetime(2020, 5, 31).date()}},
+            {"aws_gen_first_start": {"start_date": datetime(2020, 6, 1)}},
+            {"aws_gen_last": {"start_date": datetime(2020, 5, 31), "end_date": datetime(2020, 5, 31)}},
             {
                 "aws_gen_last_first": {
-                    "start_date": datetime(2020, 5, 31).date(),
-                    "end_date": datetime(2020, 6, 1).date(),
+                    "start_date": datetime(2020, 5, 31),
+                    "end_date": datetime(2020, 6, 1),
                 }
             },
         ]
@@ -639,24 +639,24 @@ class MainDateTest(TestCase):
     def test_aws_market_dates(self, mock_load):
         """Test that select static-data-file dates return correct dates."""
         aws_mp_gens = [
-            {"aws_mp_gen_first": {"start_date": datetime(2020, 6, 1).date(), "end_date": datetime(2020, 6, 1).date()}},
+            {"aws_mp_gen_first": {"start_date": datetime(2020, 6, 1), "end_date": datetime(2020, 6, 1)}},
             {
                 "aws_mp_gen_first_second": {
-                    "start_date": datetime(2020, 6, 1).date(),
-                    "end_date": datetime(2020, 6, 2).date(),
+                    "start_date": datetime(2020, 6, 1),
+                    "end_date": datetime(2020, 6, 2),
                 }
             },
-            {"aws_mp_gen_first_start": {"start_date": datetime(2020, 6, 1).date()}},
+            {"aws_mp_gen_first_start": {"start_date": datetime(2020, 6, 1)}},
             {
                 "aws_mp_gen_last": {
-                    "start_date": datetime(2020, 5, 31).date(),
-                    "end_date": datetime(2020, 5, 31).date(),
+                    "start_date": datetime(2020, 5, 31),
+                    "end_date": datetime(2020, 5, 31),
                 }
             },
             {
                 "aws_mp_gen_last_first": {
-                    "start_date": datetime(2020, 5, 31).date(),
-                    "end_date": datetime(2020, 6, 1).date(),
+                    "start_date": datetime(2020, 5, 31),
+                    "end_date": datetime(2020, 6, 1),
                 }
             },
         ]
@@ -696,19 +696,19 @@ class MainDateTest(TestCase):
     def test_ocp_dates(self, mock_load):
         """Test that select static-data-file dates return correct dates."""
         ocp_gens = [
-            {"ocp_gen_first": {"start_date": "2020-06-01", "end_date": datetime(2020, 6, 1).date()}},
+            {"ocp_gen_first": {"start_date": "2020-06-01", "end_date": datetime(2020, 6, 1)}},
             {
                 "ocp_gen_first_second": {
-                    "start_date": datetime(2020, 6, 1).date(),
-                    "end_date": datetime(2020, 6, 2).date(),
+                    "start_date": datetime(2020, 6, 1),
+                    "end_date": datetime(2020, 6, 2),
                 }
             },
-            {"ocp_gen_first_start": {"start_date": datetime(2020, 6, 1).date()}},
-            {"ocp_gen_last": {"start_date": datetime(2020, 5, 31).date(), "end_date": datetime(2020, 5, 31).date()}},
+            {"ocp_gen_first_start": {"start_date": datetime(2020, 6, 1)}},
+            {"ocp_gen_last": {"start_date": datetime(2020, 5, 31), "end_date": datetime(2020, 5, 31)}},
             {
                 "ocp_gen_last_first": {
-                    "start_date": datetime(2020, 5, 31).date(),
-                    "end_date": datetime(2020, 6, 1).date(),
+                    "start_date": datetime(2020, 5, 31),
+                    "end_date": datetime(2020, 6, 1),
                 }
             },
             {"ocp_gen_times": {"start_date": "2023-08-01T05", "end_date": "2023-08-02T23:45"}},
@@ -753,19 +753,19 @@ class MainDateTest(TestCase):
     def test_azure_dates(self, mock_load):
         """Test that select static-data-file dates return correct dates."""
         azure_gens = [
-            {"azure_gen_first": {"start_date": datetime(2020, 6, 1).date(), "end_date": datetime(2020, 6, 1).date()}},
+            {"azure_gen_first": {"start_date": datetime(2020, 6, 1), "end_date": datetime(2020, 6, 1)}},
             {
                 "azure_gen_first_second": {
-                    "start_date": datetime(2020, 6, 1).date(),
-                    "end_date": datetime(2020, 6, 2).date(),
+                    "start_date": datetime(2020, 6, 1),
+                    "end_date": datetime(2020, 6, 2),
                 }
             },
-            {"azure_gen_first_start": {"start_date": datetime(2020, 6, 1).date()}},
-            {"azure_gen_last": {"start_date": datetime(2020, 5, 31).date(), "end_date": datetime(2020, 5, 31).date()}},
+            {"azure_gen_first_start": {"start_date": datetime(2020, 6, 1)}},
+            {"azure_gen_last": {"start_date": datetime(2020, 5, 31), "end_date": datetime(2020, 5, 31)}},
             {
                 "azure_gen_last_first": {
-                    "start_date": datetime(2020, 5, 31).date(),
-                    "end_date": datetime(2020, 6, 1).date(),
+                    "start_date": datetime(2020, 5, 31),
+                    "end_date": datetime(2020, 6, 1),
                 }
             },
         ]
@@ -806,19 +806,19 @@ class MainDateTest(TestCase):
     def test_oci_dates(self, mock_load):
         """Test that select static-data-file dates return correct dates."""
         oci_gens = [
-            {"oci_gen_first": {"start_date": datetime(2020, 6, 1).date(), "end_date": datetime(2020, 6, 1).date()}},
+            {"oci_gen_first": {"start_date": datetime(2020, 6, 1), "end_date": datetime(2020, 6, 1)}},
             {
                 "oci_gen_first_second": {
-                    "start_date": datetime(2020, 6, 1).date(),
-                    "end_date": datetime(2020, 6, 2).date(),
+                    "start_date": datetime(2020, 6, 1),
+                    "end_date": datetime(2020, 6, 2),
                 }
             },
-            {"oci_gen_first_start": {"start_date": datetime(2020, 6, 1).date()}},
-            {"oci_gen_last": {"start_date": datetime(2020, 5, 31).date(), "end_date": datetime(2020, 5, 31).date()}},
+            {"oci_gen_first_start": {"start_date": datetime(2020, 6, 1)}},
+            {"oci_gen_last": {"start_date": datetime(2020, 5, 31), "end_date": datetime(2020, 5, 31)}},
             {
                 "oci_gen_last_first": {
-                    "start_date": datetime(2020, 5, 31).date(),
-                    "end_date": datetime(2020, 6, 1).date(),
+                    "start_date": datetime(2020, 5, 31),
+                    "end_date": datetime(2020, 6, 1),
                 }
             },
         ]


### PR DESCRIPTION
Drops the `fromordinal(start_date.toordinal()` bit since we now want the time to persist with the datetime.