### PR TITLE
fix oci end datetime

### DIFF
--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "4.4.9"
+__version__ = "4.4.10"
 
 VERSION = __version__.split(".")

--- a/nise/report.py
+++ b/nise/report.py
@@ -1294,7 +1294,7 @@ def oci_create_report(options):
 
     generate_daily_report = options.get("oci_daily_report", False)
     start_date = options.get("start_date")
-    end_date = start_date if generate_daily_report else options.get("end_date")
+    end_date = start_date.replace(hour=23) if generate_daily_report else options.get("end_date")
     static_report_data = options.get("static_report_data")
 
     if static_report_data:


### PR DESCRIPTION
Before adding the hourly generation OCI would generate a full day when using the `-d` option. That option would set the end date to match the start date since it would generate a full day. Now we are using the datetimes it needs to have the hours in the day to generate the daily date.