### PR TITLE
Add contstaint to plette

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -23,7 +23,8 @@ jobs:
       - name: Install dependencies
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install pipenv-setup setuptools wheel twine chardet vistir==0.6.1
+          python3 -m pip install pipenv-setup setuptools wheel twine chardet vistir==0.6.1 -c requirements/build-constraints.txt
+
       - name: Build and publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/requirements/build-constraints.txt
+++ b/requirements/build-constraints.txt
@@ -1,0 +1,1 @@
+plette<1.0.0  # pipenv-check requires an old version of requirementslib which is incompatible with plette>=1


### PR DESCRIPTION
The recent release of `plette` 1.0.0 is not compatible with the quite old version of `requirementslib` required by `pipenv-checke`. Add a constraint to prevent spontaneous breakage in the future.