### PR TITLE
Add fields for AWS node network costs

### DIFF
--- a/nise/generators/aws/aws_constants.py
+++ b/nise/generators/aws/aws_constants.py
@@ -17,6 +17,7 @@
 """AWS Report Constants"""
 
 REGIONS = (
+    # (location description, region code, sub region code, storage region)
     ("US East (N. Virginia)", "us-east-1", "us-east-1a", "USE1-EBS"),
     ("US East (N. Virginia)", "us-east-1", "us-east-1b", "USE1-EBS"),
     ("US East (N. Virginia)", "us-east-1", "us-east-1c", "USE1-EBS"),

--- a/nise/generators/aws/aws_generator.py
+++ b/nise/generators/aws/aws_generator.py
@@ -324,8 +324,7 @@ class AWSGenerator(AbstractGenerator):
     def _get_location(self):
         """Pick instance location."""
         options = None
-        if self.attributes and self.attributes.get("region"):
-            region = self.attributes.get("region")
+        if region := self.attributes.get("region"):
             options = [option for option in REGIONS if region in option]
         if options:
             location = choice(options)

--- a/nise/generators/aws/data_transfer_generator.py
+++ b/nise/generators/aws/data_transfer_generator.py
@@ -38,31 +38,16 @@ class DataTransferGenerator(AWSGenerator):
     def __init__(self, start_date, end_date, currency, payer_account, usage_accounts, attributes=None, tag_cols=None):
         """Initialize the data transfer generator."""
         super().__init__(start_date, end_date, currency, payer_account, usage_accounts, attributes, tag_cols)
-        self._amount = None
-        self._rate = None
-        self._saving = None
-        self._product_sku = None
-        self._resource_id = None
-        self._product_code = "AmazonEC2"
-        self._product_name = "Amazon Elastic Compute Cloud"
-        if attributes:
-            if attributes.get("product_code"):
-                self._product_code = attributes.get("product_code")
-            if attributes.get("product_name"):
-                self._product_name = attributes.get("product_name")
-            if attributes.get("resource_id"):
-                self._resource_id = attributes.get("resource_id")
-            if attributes.get("amount"):
-                self._amount = float(attributes.get("amount"))
-            if attributes.get("rate"):
-                self._rate = float(attributes.get("rate"))
-            if attributes.get("product_sku"):
-                self._product_sku = attributes.get("product_sku")
-            if attributes.get("tags"):
-                self._tags = attributes.get("tags")
-            if attributes.get("saving"):
-                self._saving = float(attributes.get("saving"))
 
+        self._amount = float(self.attributes.get("amount", 0)) or None
+        self._direction = self.attributes.get("direction")
+        self._product_code = self.attributes.get("product_code", "AmazonEC2")
+        self._product_name = self.attributes.get("product_name", "Amazon Elastic Compute Cloud")
+        self._product_sku = self.attributes.get("product_sku")
+        self._rate = float(self.attributes.get("rate", 0)) or None
+        self._resource_id = self.attributes.get("resource_id")
+        self._saving = float(self.attributes.get("saving", 0)) or None
+        self._tags = self.attributes.get("tags", self._tags)
     def _get_data_transfer(self, rate):
         """Get data transfer info."""
         location1, aws_region, _, storage_region1 = self._get_location()

--- a/nise/generators/aws/data_transfer_generator.py
+++ b/nise/generators/aws/data_transfer_generator.py
@@ -26,13 +26,10 @@ class DataTransferGenerator(AWSGenerator):
 
     DATA_TRANSFER = (
         # (usage type, operation, transfer type)
-        ("{}-{}-AWS-In-Bytes", "PublicIP-In", "InterRegion Inbound"),
-        ("{}-{}-AWS-Out-Bytes", "PublicIP-Out", "InterRegion Outbound"),
-        ("DataTransfer-Out-Bytes", "RunInstances", ""),
-        ("DataTransfer-In-Bytes", "RunInstances", ""),
-        ("{}-DataTransfer-Regional-Bytes", "PublicIP-In", ""),
-        ("{}-DataTransfer-Regional-Bytes", "PublicIP-Out", ""),
-        ("{}-DataTransfer-Regional-Bytes", "InterZone-In", ""),
+        ("{region1}-{region2}-AWS-{direction}-Bytes", "PublicIP-{direction}", "InterRegion {direction}bound"),
+        ("DataTransfer-{direction}-Bytes", "RunInstances", ""),
+        ("{region1}-DataTransfer-Regional-Bytes", "PublicIP-{direction}", ""),
+        ("{region1}-DataTransfer-Regional-Bytes", "InterZone-{direction}", ""),
     )
 
     def __init__(self, start_date, end_date, currency, payer_account, usage_accounts, attributes=None, tag_cols=None):
@@ -54,6 +51,9 @@ class DataTransferGenerator(AWSGenerator):
         location2, _, _, storage_region2 = self._get_location()
         trans_desc, operation, trans_type = choice(self.DATA_TRANSFER)
         trans_desc = trans_desc.format(storage_region1, storage_region2)
+        trans_desc = trans_desc.format(region1=storage_region1, region2=storage_region2, direction=self.direction)
+        operation = operation.format(direction=self.direction)
+        trans_type = trans_type.format(direction=self.direction)
         description = f"${rate} per GB - {location1} data transfer to {location2}"
         return trans_desc, operation, description, location1, location2, trans_type, aws_region
 

--- a/nise/generators/aws/data_transfer_generator.py
+++ b/nise/generators/aws/data_transfer_generator.py
@@ -25,8 +25,14 @@ class DataTransferGenerator(AWSGenerator):
     """Generator for Data Transfer data."""
 
     DATA_TRANSFER = (
+        # (usage type, operation, transfer type)
         ("{}-{}-AWS-In-Bytes", "PublicIP-In", "InterRegion Inbound"),
         ("{}-{}-AWS-Out-Bytes", "PublicIP-Out", "InterRegion Outbound"),
+        ("DataTransfer-Out-Bytes", "RunInstances", ""),
+        ("DataTransfer-In-Bytes", "RunInstances", ""),
+        ("{}-DataTransfer-Regional-Bytes", "PublicIP-In", ""),
+        ("{}-DataTransfer-Regional-Bytes", "PublicIP-Out", ""),
+        ("{}-DataTransfer-Regional-Bytes", "InterZone-In", ""),
     )
 
     def __init__(self, start_date, end_date, currency, payer_account, usage_accounts, attributes=None, tag_cols=None):

--- a/nise/generators/aws/data_transfer_generator.py
+++ b/nise/generators/aws/data_transfer_generator.py
@@ -31,6 +31,7 @@ class DataTransferGenerator(AWSGenerator):
         ("{region1}-DataTransfer-Regional-Bytes", "PublicIP-{direction}", ""),
         ("{region1}-DataTransfer-Regional-Bytes", "InterZone-{direction}", ""),
     )
+    DATA_TRANSFER_DIRECTIONS = ("in", "out")
 
     def __init__(self, start_date, end_date, currency, payer_account, usage_accounts, attributes=None, tag_cols=None):
         """Initialize the data transfer generator."""
@@ -45,16 +46,24 @@ class DataTransferGenerator(AWSGenerator):
         self._resource_id = self.attributes.get("resource_id")
         self._saving = float(self.attributes.get("saving", 0)) or None
         self._tags = self.attributes.get("tags", self._tags)
+
+    @property
+    def direction(self):
+        if self._direction:
+            return self._direction.capitalize()
+
+        return choice(self.DATA_TRANSFER_DIRECTIONS).capitalize()
+
     def _get_data_transfer(self, rate):
         """Get data transfer info."""
         location1, aws_region, _, storage_region1 = self._get_location()
         location2, _, _, storage_region2 = self._get_location()
         trans_desc, operation, trans_type = choice(self.DATA_TRANSFER)
-        trans_desc = trans_desc.format(storage_region1, storage_region2)
         trans_desc = trans_desc.format(region1=storage_region1, region2=storage_region2, direction=self.direction)
         operation = operation.format(direction=self.direction)
         trans_type = trans_type.format(direction=self.direction)
         description = f"${rate} per GB - {location1} data transfer to {location2}"
+
         return trans_desc, operation, description, location1, location2, trans_type, aws_region
 
     def _get_product_sku(self):

--- a/nise/generators/aws/data_transfer_generator.py
+++ b/nise/generators/aws/data_transfer_generator.py
@@ -38,7 +38,7 @@ class DataTransferGenerator(AWSGenerator):
         super().__init__(start_date, end_date, currency, payer_account, usage_accounts, attributes, tag_cols)
 
         self._amount = float(self.attributes.get("amount", 0)) or None
-        self._direction = self.attributes.get("direction")
+        self._data_direction = self.attributes.get("data_direction")
         self._product_code = self.attributes.get("product_code", "AmazonEC2")
         self._product_name = self.attributes.get("product_name", "Amazon Elastic Compute Cloud")
         self._product_sku = self.attributes.get("product_sku")
@@ -48,9 +48,9 @@ class DataTransferGenerator(AWSGenerator):
         self._tags = self.attributes.get("tags", self._tags)
 
     @property
-    def direction(self):
-        if self._direction is not None:
-            return self._direction.capitalize()
+    def data_direction(self):
+        if self._data_direction is not None:
+            return self._data_direction.capitalize()
 
         # Purposefully not caching this value so a different value is returned on each call
         return choice(self.DATA_TRANSFER_DIRECTIONS).capitalize()
@@ -60,9 +60,9 @@ class DataTransferGenerator(AWSGenerator):
         location1, aws_region, _, storage_region1 = self._get_location()
         location2, _, _, storage_region2 = self._get_location()
         trans_desc, operation, trans_type = choice(self.DATA_TRANSFER)
-        trans_desc = trans_desc.format(region1=storage_region1, region2=storage_region2, direction=self.direction)
-        operation = operation.format(direction=self.direction)
-        trans_type = trans_type.format(direction=self.direction)
+        trans_desc = trans_desc.format(region1=storage_region1, region2=storage_region2, direction=self.data_direction)
+        operation = operation.format(direction=self.data_direction)
+        trans_type = trans_type.format(direction=self.data_direction)
         description = f"${rate} per GB - {location1} data transfer to {location2}"
 
         return trans_desc, operation, description, location1, location2, trans_type, aws_region

--- a/nise/generators/aws/data_transfer_generator.py
+++ b/nise/generators/aws/data_transfer_generator.py
@@ -49,9 +49,10 @@ class DataTransferGenerator(AWSGenerator):
 
     @property
     def direction(self):
-        if self._direction:
+        if self._direction is not None:
             return self._direction.capitalize()
 
+        # Purposefully not caching this value so a different value is returned on each call
         return choice(self.DATA_TRANSFER_DIRECTIONS).capitalize()
 
     def _get_data_transfer(self, rate):


### PR DESCRIPTION
Update AWS DataTransferGenerator to specificy ingress and egress network flows. An optional `direction` field will only generate flows in that direction, otherwise random in and out values will be chosen.



<details>
  <summary>Example YAML file</summary>
  
```
yaml
generators:
  - EC2Generator:
      start_date: 2024-04-01
      # end_date: {{end_date}}
      processor_arch: 64-bit
      resource_id: 55555555
      product_sku: VEAJHRNKTJZQ
      region: us-east-1a
      tags:
        resourceTags/user:version: prod
        resourceTags/user:dashed-key-on-aws: dashed-value
        resourceTags/user:Mapping: a1
        resourceTags/user:Map: a2
      cost_category:
        costCategory/env: prod
      instance_type:
        inst_type: m5.large
        physical_cores: 1
        vcpu: 2
        memory: '8 GiB'
        storage: 'EBS Only'
        family: 'General Purpose'
        cost: 0.096
        rate: 0.096
  - DataTransferGenerator:
      # data_direction: out  # If this is undefined, random in/out values are used for the direction
      product_sku: VEAJHRNKTJZQ
      resource_id: i-55555555
      tags:
        resourceTags/user:app: analytics
        resourceTags/user:Mapping: d1
        resourceTags/user:Map: d2
      cost_category:
        costCategory/env: prod
```

</details>