### PR TITLE
[COST-4869] add node, csi-driver, and csi-volume-handle to OCP storage reports

### DIFF
--- a/example_ocp_static_data.yml
+++ b/example_ocp_static_data.yml
@@ -54,7 +54,7 @@ generators:
                       # 2-5-2019: 3
                       # 2-6-2019: 4
                 - volume:
-                  volume_name: pvc-volume_2
+                  volume_name: pvc-volume_claimless
                   storage_class: gp3-csi
                   csi_driver: ebs.csi.aws.com
                   csi_volume_handle: vol-55555555

--- a/example_ocp_static_data.yml
+++ b/example_ocp_static_data.yml
@@ -1,7 +1,7 @@
 ---
 generators:
   - OCPGenerator:
-      start_date: 2020-04-01
+      start_date: 2024-05-01
       nodes:
         - node:
           node_name: alpha
@@ -36,7 +36,7 @@ generators:
                   volume_name: pvc-volume_1
                   storage_class: gp2
                   volume_request_gig: 20
-                  labels: label_key3:label_value3|label_key4:label_value4|label_storageclass:bravo
+                  labels: label_key3:label_value3|label_key4:label_value4|label_storageclass:gp2
                   volume_claims:
                   - volume_claim:
                     volume_claim_name: pod_name1_data
@@ -51,3 +51,10 @@ generators:
                       # 2-4-2019: 4
                       # 2-5-2019: 3
                       # 2-6-2019: 4
+                - volume:
+                  volume_name: pvc-volume_2
+                  storage_class: gp2
+                  csi_driver:
+                  csi_volume_handle:
+                  volume_request_gig: 20
+                  labels: label_key5:label_value5|label_key6:label_value6|label_storageclass:gp2

--- a/example_ocp_static_data.yml
+++ b/example_ocp_static_data.yml
@@ -35,6 +35,8 @@ generators:
                 - volume:
                   volume_name: pvc-volume_1
                   storage_class: gp2
+                  csi_driver:
+                  csi_volume_handle:
                   volume_request_gig: 20
                   labels: label_key3:label_value3|label_key4:label_value4|label_storageclass:gp2
                   volume_claims:
@@ -57,4 +59,4 @@ generators:
                   csi_driver: ebs.csi.aws.com
                   csi_volume_handle: vol-55555555
                   volume_request_gig: 20
-                  labels: label_key5:label_value5|label_key6:label_value6|label_storageclass:gp2
+                  labels: label_key5:label_value5|label_key6:label_value6|label_storageclass:gp3-csi

--- a/example_ocp_static_data.yml
+++ b/example_ocp_static_data.yml
@@ -53,8 +53,8 @@ generators:
                       # 2-6-2019: 4
                 - volume:
                   volume_name: pvc-volume_2
-                  storage_class: gp2
-                  csi_driver:
-                  csi_volume_handle:
+                  storage_class: gp3-csi
+                  csi_driver: ebs.csi.aws.com
+                  csi_volume_handle: vol-55555555
                   volume_request_gig: 20
                   labels: label_key5:label_value5|label_key6:label_value6|label_storageclass:gp2

--- a/examples/ocp_on_aws/aws_static_data.yml
+++ b/examples/ocp_on_aws/aws_static_data.yml
@@ -86,11 +86,11 @@ generators:
       start_date: 2019-04-01
       end_date: 2019-07-31
       product_sku: VEAJHRNBBBBA
-      resource_id: 12345671
+      resource_id: vol-12345671
       amount: 10
       rate: 0.01
       tags:
-        resourceTags/user:storageclass: bravo
+        resourceTags/user:storageclass: gp3-csi
   - EBSGenerator:
       start_date: 2019-04-01
       end_date: 2019-07-31

--- a/examples/ocp_on_aws/ocp_static_data.yml
+++ b/examples/ocp_on_aws/ocp_static_data.yml
@@ -1,8 +1,8 @@
 ---
 generators:
   - OCPGenerator:
-      start_date: 2024-05-01
-      # end_date: 2019-07-31
+      start_date: 2019-04-01
+      end_date: 2019-07-31
       nodes:
         - node:
           node_name: aws_compute1

--- a/examples/ocp_on_aws/ocp_static_data.yml
+++ b/examples/ocp_on_aws/ocp_static_data.yml
@@ -1,8 +1,8 @@
 ---
 generators:
   - OCPGenerator:
-      start_date: 2019-05-01
-      end_date: 2019-07-31
+      start_date: 2024-05-01
+      # end_date: 2019-07-31
       nodes:
         - node:
           node_name: aws_compute1
@@ -24,14 +24,16 @@ generators:
               volumes:
                 - volume:
                   volume_name: pvc-volume_1
-                  storage_class: gp2
+                  csi_driver: ebs.csi.aws.com
+                  csi_volume_handle: vol-12345671
+                  storage_class: gp3-csi
                   volume_request_gig: 20
-                  labels: label_environment:dev|label_app:catalog|label_version:prod|label_storageclass:bravo
+                  labels: label_environment:dev|label_app:catalog|label_version:prod|label_storageclass:gp3-csi
                   volume_claims:
                   - volume_claim:
                     volume_claim_name: pod_name1_data
                     pod_name: pod_name1
-                    labels: label_environment:dev|label_app:catalog|label_version:prod|label_storageclass:bravo
+                    labels: label_environment:dev|label_app:catalog|label_version:prod|label_storageclass:gp3-csi
                     capacity_gig: 20
             catalog:
               pods:

--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "4.4.18"
+__version__ = "4.5.0"
 
 VERSION = __version__.split(".")

--- a/nise/generators/ocp/__init__.py
+++ b/nise/generators/ocp/__init__.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
-"""Module for aws data generators."""
+"""Module for ocp data generators."""
 from nise.generators.ocp.ocp_generator import OCP_NAMESPACE_LABEL  # noqa: F401
 from nise.generators.ocp.ocp_generator import OCP_NODE_LABEL  # noqa: F401
 from nise.generators.ocp.ocp_generator import OCP_POD_USAGE  # noqa: F401

--- a/nise/generators/ocp/ocp_generator.py
+++ b/nise/generators/ocp/ocp_generator.py
@@ -597,7 +597,7 @@ class OCPGenerator(AbstractGenerator):
                             break
                         vol_claim = self.fake.word()
                         pod = choice(namespace2pods[namespace])
-                        claim_capacity = round(uniform(1.0, vol_request_gig), 2) * GIGABYTE
+                        claim_capacity = round(uniform(1.0, (vol_request_gig - total_claims / GIGABYTE)), 2) * GIGABYTE
                         volume_claims[vol_claim] = {
                             "namespace": namespace,
                             "volume": volume,

--- a/nise/generators/ocp/ocp_generator.py
+++ b/nise/generators/ocp/ocp_generator.py
@@ -63,6 +63,7 @@ OCP_STORAGE_COLUMNS = (
     "interval_end",
     "namespace",
     "pod",
+    "node",
     "persistentvolumeclaim",
     "persistentvolume",
     "storageclass",
@@ -569,6 +570,7 @@ class OCPGenerator(AbstractGenerator):
                     volumes.append(
                         {
                             volume: {
+                                "node": node.get("name"),
                                 "namespace": namespace,
                                 "volume": volume,
                                 "storage_class": specified_volume.get("storage_class", storage_class_default),
@@ -618,6 +620,7 @@ class OCPGenerator(AbstractGenerator):
                         {
                             volume: {
                                 "namespace": namespace,
+                                "node": node.get("name"),
                                 "volume": volume,
                                 "storage_class": storage_class_default,
                                 "csi_driver": csi_default,
@@ -723,6 +726,7 @@ class OCPGenerator(AbstractGenerator):
         data = {
             "namespace": kwargs.get("namespace"),
             "pod": kwargs.get("pod"),
+            "node": kwargs.get("node"),
             "persistentvolumeclaim": kwargs.get("volume_claim"),
             "persistentvolume": kwargs.get("volume_name"),
             "storageclass": kwargs.get("storage_class"),
@@ -828,6 +832,7 @@ class OCPGenerator(AbstractGenerator):
             end = hour.get("end")
             for volume_dict in self.volumes:
                 for volume_name, volume in volume_dict.items():
+                    node = volume.get("node")
                     namespace = volume.get("namespace", None)
                     storage_class = volume.get("storage_class", None)
                     csi_driver = volume.get("csi_driver", None)
@@ -847,6 +852,7 @@ class OCPGenerator(AbstractGenerator):
                             end,
                             volume_claim=vc_name,
                             pod=pod,
+                            node=node,
                             volume_claim_labels=vc_labels,
                             vc_capacity=capacity,
                             volume_claim_usage_gig=volume_claim_usage_gig,

--- a/tests/test_ocp_generator.py
+++ b/tests/test_ocp_generator.py
@@ -220,6 +220,10 @@ class OCPGeneratorTestCase(TestCase):
                             with self.subTest(row=row):
                                 with self.subTest(col=col):
                                     self.assertIn(col, row)
+                        # the following columns are not required to be not-null for claimless persistent-volumes
+                        for col in set(OCP_STORAGE_COLUMNS).difference({"pod", "namespace", "persistentvolumeclaim"}):
+                            with self.subTest(row=row):
+                                with self.subTest(col=col):
                                     self.assertIsNotNone(row[col])
                         break  # only test one row
 
@@ -409,7 +413,7 @@ class OCPGeneratorTestCase(TestCase):
         namespaces = self.attributes.get("nodes")[0].get("namespaces")
         volume_names = [vol.get("volume_name") for ns in namespaces for vol in namespaces.get(ns).get("volumes")]
         for vol_dict in out_volumes:
-            self.assertEqual(list(vol_dict.keys()), volume_names)
+            self.assertTrue(all(v in volume_names for v in vol_dict.keys()))
 
         expected = [
             "namespace",

--- a/tests/test_ocp_generator.py
+++ b/tests/test_ocp_generator.py
@@ -109,7 +109,15 @@ class OCPGeneratorTestCase(TestCase):
                                         f"label_{self.fake.word()}:{self.fake.word()}",
                                         f"|label_{self.fake.word()}:{self.fake.word()}",
                                     ),
-                                }
+                                },
+                                {
+                                    "volume_name": f"vol_{self.fake.word()}",
+                                    "volume_request_gig": self.fake.pyint(1, MAX_VOL_GIGS),
+                                    "labels": (
+                                        f"label_claimless:{self.fake.word()}",
+                                        f"|label_{self.fake.word()}:{self.fake.word()}",
+                                    ),
+                                },
                             ],
                         }
                     },
@@ -449,8 +457,7 @@ class OCPGeneratorTestCase(TestCase):
 
     def test_gen_volumes_usage_lt_capacity(self):
         """Test that gen_volumes generates requests and usage values which don't exceed capacity."""
-        # for attributes in [self.attributes, {}]:
-        for attributes in [{}]:
+        for attributes in [self.attributes, {}]:
             with self.subTest(attributes=attributes):
                 generator = OCPGenerator(self.two_hours_ago, self.now, attributes)
                 for volume_dict in generator.volumes:

--- a/tests/test_ocp_generator.py
+++ b/tests/test_ocp_generator.py
@@ -425,6 +425,7 @@ class OCPGeneratorTestCase(TestCase):
             self.assertTrue(all(v in volume_names for v in vol_dict.keys()))
 
         expected = [
+            "node",
             "namespace",
             "volume",
             "storage_class",
@@ -455,6 +456,7 @@ class OCPGeneratorTestCase(TestCase):
 
         expected = [
             "namespace",
+            "node",
             "volume",
             "storage_class",
             "csi_driver",

--- a/tests/test_ocp_generator.py
+++ b/tests/test_ocp_generator.py
@@ -223,10 +223,12 @@ class OCPGeneratorTestCase(TestCase):
                         # the following columns are not required to be not-null for claimless persistent-volumes
                         for col in set(OCP_STORAGE_COLUMNS).difference(
                             {
-                                "pod",
                                 "namespace",
+                                "pod",
+                                "node",
                                 "persistentvolumeclaim",
-                                "persistentvolumeclaim_capacity_bytes",
+                                "volume_request_storage_byte_seconds",
+                                "persistentvolumeclaim_usage_byte_seconds",
                                 "persistentvolumeclaim_labels",
                             }
                         ):

--- a/tests/test_ocp_generator.py
+++ b/tests/test_ocp_generator.py
@@ -449,12 +449,11 @@ class OCPGeneratorTestCase(TestCase):
 
     def test_gen_volumes_usage_lt_capacity(self):
         """Test that gen_volumes generates requests and usage values which don't exceed capacity."""
-        for attributes in [self.attributes, {}]:
+        # for attributes in [self.attributes, {}]:
+        for attributes in [{}]:
             with self.subTest(attributes=attributes):
                 generator = OCPGenerator(self.two_hours_ago, self.now, attributes)
-                # gen_volumes depends on the output formatting of gen_namespaces and gen_pods.
-                out_volumes = generator._gen_volumes(generator.namespaces, generator.namespace2pods)
-                for volume_dict in out_volumes:
+                for volume_dict in generator.volumes:
                     for volume in volume_dict.values():
                         with self.subTest(volume=volume):
                             total_capacity = 0

--- a/tests/test_ocp_generator.py
+++ b/tests/test_ocp_generator.py
@@ -221,11 +221,18 @@ class OCPGeneratorTestCase(TestCase):
                                 with self.subTest(col=col):
                                     self.assertIn(col, row)
                         # the following columns are not required to be not-null for claimless persistent-volumes
-                        for col in set(OCP_STORAGE_COLUMNS).difference({"pod", "namespace", "persistentvolumeclaim"}):
+                        for col in set(OCP_STORAGE_COLUMNS).difference(
+                            {
+                                "pod",
+                                "namespace",
+                                "persistentvolumeclaim",
+                                "persistentvolumeclaim_capacity_bytes",
+                                "persistentvolumeclaim_labels",
+                            }
+                        ):
                             with self.subTest(row=row):
                                 with self.subTest(col=col):
                                     self.assertIsNotNone(row[col])
-                        break  # only test one row
 
     def test_gen_namespaces_with_namespace(self):
         """Test that gen_namespaces arranges the output dict in the expected way.

--- a/tests/test_ocp_generator.py
+++ b/tests/test_ocp_generator.py
@@ -403,7 +403,16 @@ class OCPGeneratorTestCase(TestCase):
         for vol_dict in out_volumes:
             self.assertEqual(list(vol_dict.keys()), volume_names)
 
-        expected = ["namespace", "volume", "storage_class", "volume_request", "labels", "volume_claims"]
+        expected = [
+            "namespace",
+            "volume",
+            "storage_class",
+            "csi_driver",
+            "csi_volume_handle",
+            "volume_request",
+            "labels",
+            "volume_claims",
+        ]
         for vol_dict in out_volumes:
             for vol in vol_dict.values():
                 with self.subTest(volume=vol):
@@ -423,7 +432,16 @@ class OCPGeneratorTestCase(TestCase):
         self.assertGreaterEqual(len(out_volumes), 2 * 2 * 1)
         self.assertLessEqual(len(out_volumes), 6 * 12 * 3)
 
-        expected = ["namespace", "volume", "storage_class", "volume_request", "labels", "volume_claims"]
+        expected = [
+            "namespace",
+            "volume",
+            "storage_class",
+            "csi_driver",
+            "csi_volume_handle",
+            "volume_request",
+            "labels",
+            "volume_claims",
+        ]
         for vol_dict in out_volumes:
             for vol in vol_dict.values():
                 with self.subTest(volume=vol):
@@ -603,6 +621,8 @@ class OCPGeneratorTestCase(TestCase):
             "persistentvolumeclaim",
             "persistentvolume",
             "storageclass",
+            "csi_driver",
+            "csi_volume_handle",
             "persistentvolumeclaim_capacity_bytes",
             "persistentvolumeclaim_capacity_byte_seconds",
             "volume_request_storage_byte_seconds",


### PR DESCRIPTION
* add node to OCP storage report
* add csi-driver and csi-volume-handle to OCP storage report
* enable ability to create pvc-less persistent volumes
* we can also create rows with csi-driver and csi-volume-handle not populated by simple adding them to a static data file and leaving the value empty -> this is good for PVs created not using the csi drivers

Some testing:
1. see populated `May-2024-your-cluster-ocp_storage_usage.csv` file:
```
$ nise report ocp -s 2024-05-01 --ocp-cluster-id your-cluster --write-monthly
```
this file is completely random
2. see populated `May-2024-your-cluster-ocp_storage_usage.csv` with static data and a claimless pv:
```
todo
```