### PR TITLE
[COST 5161] Drop azure v1 reports support

### DIFF
--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "4.5.7"
+__version__ = "4.5.8"
 
 VERSION = __version__.split(".")

--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "4.5.8"
+__version__ = "4.6.0"
 
 VERSION = __version__.split(".")

--- a/nise/__main__.py
+++ b/nise/__main__.py
@@ -196,12 +196,12 @@ def add_azure_parser_args(parser):
         help="Azure container to place the data.",
     )
     parser.add_argument(
-        "-v2",
-        "--version-two",
-        dest="version_two",
+        "-rg",
+        "--resource-group",
+        dest="resource_group",
         action="store_true",
         required=False,
-        help="Generate version two of the azure report.",
+        help="Generate resource group based azure report.",
     )
 
 

--- a/nise/generators/azure/__init__.py
+++ b/nise/generators/azure/__init__.py
@@ -15,14 +15,14 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 """Module for azure data generators."""
-from nise.generators.azure.azure_generator import AZURE_COLUMNS_V2_RESOURCE_GROUP  # noqa: F401
-from nise.generators.azure.azure_generator import AZURE_COLUMNS_V2_SUBSCRIPTION  # noqa: F401
-from nise.generators.azure.azure_generator import AzureGenerator  # noqa: F401
-from nise.generators.azure.bandwidth_generator import BandwidthGenerator  # noqa: F401
-from nise.generators.azure.ccsp_generator import CCSPGenerator  # noqa: F401
-from nise.generators.azure.data_transfer_generator import DTGenerator  # noqa: F401
-from nise.generators.azure.managed_disk_generator import ManagedDiskGenerator  # noqa: F401
-from nise.generators.azure.sql_database_generator import SQLGenerator  # noqa: F401
-from nise.generators.azure.storage_generator import StorageGenerator  # noqa: F401
-from nise.generators.azure.virtual_machine_generator import VMGenerator  # noqa: F401
-from nise.generators.azure.virtual_network_generator import VNGenerator  # noqa: F401
+from nise.generators.azure.azure_generator import AZURE_COLUMNS_V2_RESOURCE_GROUP
+from nise.generators.azure.azure_generator import AZURE_COLUMNS_V2_SUBSCRIPTION
+from nise.generators.azure.azure_generator import AzureGenerator
+from nise.generators.azure.bandwidth_generator import BandwidthGenerator
+from nise.generators.azure.ccsp_generator import CCSPGenerator
+from nise.generators.azure.data_transfer_generator import DTGenerator
+from nise.generators.azure.managed_disk_generator import ManagedDiskGenerator
+from nise.generators.azure.sql_database_generator import SQLGenerator
+from nise.generators.azure.storage_generator import StorageGenerator
+from nise.generators.azure.virtual_machine_generator import VMGenerator
+from nise.generators.azure.virtual_network_generator import VNGenerator

--- a/nise/generators/azure/__init__.py
+++ b/nise/generators/azure/__init__.py
@@ -15,8 +15,8 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 """Module for azure data generators."""
-from nise.generators.azure.azure_generator import AZURE_COLUMNS  # noqa: F401
-from nise.generators.azure.azure_generator import AZURE_COLUMNS_V2  # noqa: F401
+from nise.generators.azure.azure_generator import AZURE_COLUMNS_V2_SUBSCRIPTION  # noqa: F401
+from nise.generators.azure.azure_generator import AZURE_COLUMNS_V2_RESOURCE_GROUP  # noqa: F401
 from nise.generators.azure.azure_generator import AzureGenerator  # noqa: F401
 from nise.generators.azure.bandwidth_generator import BandwidthGenerator  # noqa: F401
 from nise.generators.azure.ccsp_generator import CCSPGenerator  # noqa: F401

--- a/nise/generators/azure/__init__.py
+++ b/nise/generators/azure/__init__.py
@@ -15,8 +15,8 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 """Module for azure data generators."""
-from nise.generators.azure.azure_generator import AZURE_COLUMNS_V2_SUBSCRIPTION  # noqa: F401
 from nise.generators.azure.azure_generator import AZURE_COLUMNS_V2_RESOURCE_GROUP  # noqa: F401
+from nise.generators.azure.azure_generator import AZURE_COLUMNS_V2_SUBSCRIPTION  # noqa: F401
 from nise.generators.azure.azure_generator import AzureGenerator  # noqa: F401
 from nise.generators.azure.bandwidth_generator import BandwidthGenerator  # noqa: F401
 from nise.generators.azure.ccsp_generator import CCSPGenerator  # noqa: F401

--- a/nise/generators/azure/azure_generator.py
+++ b/nise/generators/azure/azure_generator.py
@@ -419,7 +419,7 @@ class AzureGenerator(AbstractGenerator):
             row, meter_sub, str(amount), str(rate), str(cost), instance_id, service_tier
         )
 
-        if self.azure_columns == AZURE_COLUMNS_V2_SUBSCRIPTION:
+        if self.azure_columns is AZURE_COLUMNS_V2_SUBSCRIPTION:
             row["SubscriptionId"] = self.subscription_guid
             row["ResourceGroupName"] = resource_group
             row["ProductName"] = ""
@@ -505,7 +505,7 @@ class AzureGenerator(AbstractGenerator):
         row["UnitPrice"] = rate
         row["CostInBillingCurrency"] = cost
 
-        if self.azure_columns == AZURE_COLUMNS_V2_SUBSCRIPTION:
+        if self.azure_columns is AZURE_COLUMNS_V2_SUBSCRIPTION:
             row["ResourceId"] = instance_id
             row["BillingCurrency"] = self._billing_currency
         else:

--- a/nise/generators/azure/azure_generator.py
+++ b/nise/generators/azure/azure_generator.py
@@ -467,6 +467,26 @@ class AzureGenerator(AbstractGenerator):
         # row['PlanName'] =
         # row['PartNumber'] =
         # row['CostCenter'] =
+        # row['previousInvoiceId'] =
+        # row['resellerName'] =
+        # row['resellerMpnId'] =
+        # row['servicePeriodEndDate'] =
+        # row['servicePeriodStartDate'] =
+        # row['Product'] =
+        # row['ProductId'] =
+        # row['publisherId'] =
+        # row['Location'] =
+        # row['pricingCurrencyCode'] =
+        # row['costInPricingCurrency'] =
+        # row['costInUsd'] =
+        # row['paygCostInBillingCurrency'] =
+        # row['paygCostInUsd'] =
+        # row['exchangeRate'] =
+        # row['exchangeRateDate'] =
+        # row['offerid'] =
+        # row['serviceinfo1'] =
+        # row['instancename'] =
+        # row['invoiceId'] =
 
         if hasattr(self, "_product_id"):
             row["ProductId"] = self._product_id

--- a/nise/generators/azure/azure_generator.py
+++ b/nise/generators/azure/azure_generator.py
@@ -313,6 +313,9 @@ class AzureGenerator(AbstractGenerator):
             service_info_2,
         )
 
+    def _add_common_usage_info(self, row, start, end, **kwargs):
+        """Not needed for Azure."""
+
     def _get_location_info(self):
         """Get bandwidth info."""
         azure_region, meter_region = self._get_location()
@@ -456,6 +459,7 @@ class AzureGenerator(AbstractGenerator):
         row["Frequency"] = "UsageBased"
         row["PublisherType"] = publisher_type
         row["ChargeType"] = "Usage"
+        row["PublisherName"] = publisher_name
         # row['PricingModel'] =
         # row['ReservationId'] =
         # row['ReservationName'] =
@@ -463,7 +467,6 @@ class AzureGenerator(AbstractGenerator):
         # row['ProductOrderName'] =
         # row['AvailabilityZone'] =
         # row['Term'] =
-        row["PublisherName"] = publisher_name
         # row['PlanName'] =
         # row['PartNumber'] =
         # row['CostCenter'] =

--- a/nise/generators/azure/azure_generator.py
+++ b/nise/generators/azure/azure_generator.py
@@ -392,10 +392,11 @@ class AzureGenerator(AbstractGenerator):
         if not service_info_2:
             service_info_2 = ""
 
-        usage_account = choice(self.usage_accounts)
-        row["AccountName"] = usage_account[0]
+        if self.usage_accounts:
+            usage_account = choice(self.usage_accounts)
+            row["AccountName"] = usage_account[0]
+            row["AccountOwnerId"] = usage_account[1]
         row["SubscriptionName"] = self.account_info.get("subscription_name")
-        row["AccountOwnerId"] = usage_account[1]
         row["BillingAccountId"] = self.account_info.get("billing_account_id")
         row["BillingAccountName"] = self.account_info.get("billing_account_name")
         row["BillingProfileId"] = self.account_info.get("billing_account_id")

--- a/nise/generators/azure/azure_generator.py
+++ b/nise/generators/azure/azure_generator.py
@@ -25,40 +25,13 @@ from random import uniform
 
 from nise.generators.generator import AbstractGenerator
 
-AZURE_COLUMNS = (
-    "SubscriptionGuid",
-    "ResourceGroup",
-    "ResourceLocation",
-    "UsageDateTime",
-    "MeterCategory",
-    "MeterSubcategory",
-    "MeterId",
-    "MeterName",
-    "MeterRegion",
-    "UsageQuantity",
-    "ResourceRate",
-    "PreTaxCost",
-    "ConsumedService",
-    "ResourceType",
-    "InstanceId",
-    "Tags",
-    "OfferId",
-    "AdditionalInfo",
-    "ServiceInfo1",
-    "ServiceInfo2",
-    "ServiceName",
-    "ServiceTier",
-    "Currency",
-    "UnitOfMeasure",
-)
-
-AZURE_COLUMNS_V2 = (
+AZURE_COLUMNS_V2_SUBSCRIPTION = (
     "InvoiceSectionName",
     "AccountName",
     "AccountOwnerId",
     "SubscriptionId",
     "SubscriptionName",
-    "ResourceGroup",
+    "ResourceGroupName",
     "ResourceLocation",
     "Date",
     "ProductName",
@@ -93,12 +66,13 @@ AZURE_COLUMNS_V2 = (
     "PricingModel",
     "AvailabilityZone",
     "BillingAccountId",
+    "BillingCurrency",
     "BillingAccountName",
-    "BillingCurrencyCode",
     "BillingPeriodStartDate",
     "BillingPeriodEndDate",
     "BillingProfileId",
     "BillingProfileName",
+    "InstanceName",
     "InvoiceSectionId",
     "IsAzureCreditEligible",
     "PartNumber",
@@ -111,6 +85,7 @@ AZURE_COLUMNS_V2 = (
     "resellerMpnId",
     "servicePeriodEndDate",
     "servicePeriodStartDate",
+    "Product",
     "ProductId",
     "publisherId",
     "Location",
@@ -120,6 +95,77 @@ AZURE_COLUMNS_V2 = (
     "paygCostInBillingCurrency",
     "paygCostInUsd",
     "exchangeRatePricingToBilling",
+    "exchangeRateDate",
+)
+
+AZURE_COLUMNS_V2_RESOURCE_GROUP = (
+    "InvoiceSectionName",
+    "AccountName",
+    "AccountOwnerId",
+    "SubscriptionGuid",
+    "SubscriptionName",
+    "ResourceGroup",
+    "ResourceLocation",
+    "Date",
+    "MeterCategory",
+    "MeterSubCategory",
+    "MeterId",
+    "MeterName",
+    "MeterRegion",
+    "UnitOfMeasure",
+    "Quantity",
+    "EffectivePrice",
+    "CostInBillingCurrency",
+    "CostCenter",
+    "ConsumedService",
+    "Tags",
+    "OfferId",
+    "AdditionalInfo",
+    "ServiceInfo1",
+    "ServiceInfo2",
+    "ResourceName",
+    "ReservationId",
+    "ReservationName",
+    "UnitPrice",
+    "ProductOrderId",
+    "ProductOrderName",
+    "Term",
+    "PublisherType",
+    "PublisherName",
+    "ChargeType",
+    "Frequency",
+    "PricingModel",
+    "AvailabilityZone",
+    "BillingAccountId",
+    "BillingCurrencyCode",
+    "BillingAccountName",
+    "BillingPeriodStartDate",
+    "BillingPeriodEndDate",
+    "BillingProfileId",
+    "BillingProfileName",
+    "InstanceName",
+    "InvoiceSectionId",
+    "IsAzureCreditEligible",
+    "PartNumber",
+    "MarketPrice",
+    "PlanName",
+    "ServiceFamily",
+    "invoiceId",
+    "previousInvoiceId",
+    "resellerName",
+    "resellerMpnId",
+    "servicePeriodEndDate",
+    "servicePeriodStartDate",
+    "Product",
+    "ProductId",
+    "publisherId",
+    "Location",
+    "pricingCurrencyCode",
+    "costInPricingCurrency",
+    "costInUsd",
+    "paygCostInBillingCurrency",
+    "paygCostInUsd",
+    "exchangeRate",
     "exchangeRateDate",
 )
 
@@ -181,7 +227,7 @@ class AzureGenerator(AbstractGenerator):
 
     def __init__(self, start_date, end_date, currency, account_info, attributes=None):  # noqa: C901
         """Initialize the generator."""
-        self.azure_columns = AZURE_COLUMNS
+        self.azure_columns = AZURE_COLUMNS_V2_SUBSCRIPTION
         self.subscription_guid = account_info.get("subscription_guid")
         self.account_info = account_info
         self.usage_accounts = account_info.get("usage_accounts")
@@ -202,7 +248,6 @@ class AzureGenerator(AbstractGenerator):
         self._billing_currency = currency
         self._additional_info = None
         self._data_direction = None
-        # Version 2 fields
         self._invoice_section_id = None
         self._invoice_section_name = None
 
@@ -210,8 +255,8 @@ class AzureGenerator(AbstractGenerator):
             for key, value in attributes.items():
                 attr_name = "_" + key
                 setattr(self, attr_name, value)
-            if attributes.get("version_two"):
-                self.azure_columns = AZURE_COLUMNS_V2
+            if attributes.get("resource_group"):
+                self.azure_columns = AZURE_COLUMNS_V2_RESOURCE_GROUP
         super().__init__(start_date, end_date)
 
     @staticmethod
@@ -314,26 +359,6 @@ class AzureGenerator(AbstractGenerator):
         else:
             return choice(self.ADDITIONAL_INFO)
 
-    def _add_common_usage_info(self, row, start, end, **kwargs):
-        """Add common usage information."""
-        if self.azure_columns == AZURE_COLUMNS_V2:
-            usage_account = choice(self.usage_accounts)
-            row["SubscriptionId"] = self.subscription_guid
-            row["SubscriptionName"] = self.account_info.get("subscription_name")
-            row["AccountName"] = usage_account[0]
-            row["AccountOwnerId"] = usage_account[1]
-            row["BillingAccountId"] = self.account_info.get("billing_account_id")
-            row["BillingAccountName"] = self.account_info.get("billing_account_name")
-            row["BillingProfileId"] = self.account_info.get("billing_account_id")
-            row["BillingProfileName"] = self.account_info.get("billing_account_name")
-            row["Date"] = start.date().strftime(DATE_FMT)
-            row["BillingPeriodStartDate"] = self.first_day_of_month(start).strftime(DATE_FMT)
-            row["BillingPeriodEndDate"] = self.last_day_of_month(start).strftime(DATE_FMT)
-        else:
-            row["SubscriptionGuid"] = self.subscription_guid
-            row["UsageDateTime"] = start.strftime(DATE_FMT)
-        return row
-
     def _add_tag_data(self, row):
         """Add tag dictionary data options to the row."""
         if not self._tags:
@@ -344,8 +369,6 @@ class AzureGenerator(AbstractGenerator):
 
     def _update_data(self, row, start, end, **kwargs):
         """Update data with generator specific data."""
-        row = self._add_common_usage_info(row, start, end)
-
         meter_id = self._meter_id if self._meter_id else self.fake.uuid4()
         rate = self._resource_rate if self._resource_rate else round(uniform(0.1, 0.50), 5)
         amount = self._usage_quantity if self._usage_quantity else uniform(0.01, 1)
@@ -366,7 +389,17 @@ class AzureGenerator(AbstractGenerator):
         if not service_info_2:
             service_info_2 = ""
 
-        row["ResourceGroup"] = resource_group
+        usage_account = choice(self.usage_accounts)
+        row["AccountName"] = usage_account[0]
+        row["SubscriptionName"] = self.account_info.get("subscription_name")
+        row["AccountOwnerId"] = usage_account[1]
+        row["BillingAccountId"] = self.account_info.get("billing_account_id")
+        row["BillingAccountName"] = self.account_info.get("billing_account_name")
+        row["BillingProfileId"] = self.account_info.get("billing_account_id")
+        row["BillingProfileName"] = self.account_info.get("billing_account_name")
+        row["Date"] = start.date().strftime(DATE_FMT)
+        row["BillingPeriodStartDate"] = self.first_day_of_month(start).strftime(DATE_FMT)
+        row["BillingPeriodEndDate"] = self.last_day_of_month(start).strftime(DATE_FMT)
         row["ResourceLocation"] = azure_region
         row["MeterCategory"] = self._service_name
         row["MeterId"] = str(self.meter_id)
@@ -381,22 +414,21 @@ class AzureGenerator(AbstractGenerator):
         row = self._map_header_to_report_version(
             row, meter_sub, str(amount), str(rate), str(cost), instance_id, service_tier
         )
-        if self.azure_columns == AZURE_COLUMNS_V2:
-            row = self.add_v2_specific_columns(row, instance_id=instance_id)
-        self._add_tag_data(row)
 
-        return row
-
-    def add_v2_specific_columns(self, row, **kwargs):
-        """Add values for columns specific to the V2 report."""
+        if self.azure_columns == AZURE_COLUMNS_V2_SUBSCRIPTION:
+            row["SubscriptionId"] = self.subscription_guid
+            row["ResourceGroupName"] = resource_group
+            row["ProductName"] = ""
+            row["PayGPrice"] = 0
+        else:
+            row["SubscriptionGuid"] = self.subscription_guid
+            row["ResourceGroup"] = resource_group
+            row["MarketPrice"] = 0
 
         resource_name = ""
         if kwargs.get("instance_id"):
             resource_name = kwargs.get("instance_id").split("/")
             resource_name = resource_name[len(resource_name) - 1]
-
-        # NOTE: Commented out columns exist in the report, but we don't have enough
-        # information to date to accurately simulate values.
         if self._service_name == "Virtual Machines":
             if getattr(self, "_CCSP", False):
                 publisher_name = "Microsoft"
@@ -415,14 +447,15 @@ class AzureGenerator(AbstractGenerator):
         row["InvoiceSectionName"] = (
             self._invoice_section_name if self._invoice_section_id else choice(self.INVOICE_SECTION_NAMES)
         )
-        row["ProductName"] = ""
+
+        # NOTE: Commented out columns exist in the report, but we don't have enough
+        # information to date to accurately simulate values.
         row["ResourceName"] = resource_name
         row["IsAzureCreditEligible"] = "TRUE"
         row["ServiceFamily"] = service_family
         row["Frequency"] = "UsageBased"
         row["PublisherType"] = publisher_type
         row["ChargeType"] = "Usage"
-        row["PayGPrice"] = 0
         # row['PricingModel'] =
         # row['ReservationId'] =
         # row['ReservationName'] =
@@ -437,28 +470,23 @@ class AzureGenerator(AbstractGenerator):
 
         if hasattr(self, "_product_id"):
             row["ProductId"] = self._product_id
+        self._add_tag_data(row)
+
         return row
 
     def _map_header_to_report_version(self, row, meter_sub, amount, rate, cost, instance_id, service_tier):
-        if self.azure_columns == AZURE_COLUMNS_V2:
-            row["MeterSubCategory"] = meter_sub
-            row["Quantity"] = amount
-            row["EffectivePrice"] = rate
-            row["UnitPrice"] = rate
-            row["CostInBillingCurrency"] = cost
+        row["Quantity"] = amount
+        row["MeterSubCategory"] = meter_sub
+        row["EffectivePrice"] = rate
+        row["UnitPrice"] = rate
+        row["CostInBillingCurrency"] = cost
+
+        if self.azure_columns == AZURE_COLUMNS_V2_SUBSCRIPTION:
             row["ResourceId"] = instance_id
-            row["BillingCurrencyCode"] = self._billing_currency
+            row["BillingCurrency"] = self._billing_currency
         else:
-            row["MeterSubcategory"] = meter_sub
-            row["UsageQuantity"] = amount
-            row["ResourceRate"] = rate
-            row["PreTaxCost"] = cost
-            row["InstanceId"] = instance_id
-            row["Currency"] = self._billing_currency
-            # Version one specific
-            row["ResourceType"] = self._resource_type
-            row["ServiceName"] = self._service_name
-            row["ServiceTier"] = service_tier
+            row["BillingCurrencyCode"] = self._billing_currency
+
         return row
 
     def _generate_hourly_data(self, **kwargs):

--- a/nise/report.py
+++ b/nise/report.py
@@ -768,7 +768,7 @@ def azure_create_report(options):  # noqa: C901
     storage_account_name = options.get("azure_account_name")
     azure_prefix_name = options.get("azure_prefix_name")
     azure_report_name = options.get("azure_report_name")
-    version_two = options.get("version_two", False)
+    resource_group = options.get("resource_group", False)
     write_monthly = options.get("write_monthly", False)
     for month in months:
         data = []

--- a/nise/report.py
+++ b/nise/report.py
@@ -768,7 +768,6 @@ def azure_create_report(options):  # noqa: C901
     storage_account_name = options.get("azure_account_name")
     azure_prefix_name = options.get("azure_prefix_name")
     azure_report_name = options.get("azure_report_name")
-    resource_group = options.get("resource_group", False)
     write_monthly = options.get("write_monthly", False)
     for month in months:
         data = []
@@ -795,7 +794,6 @@ def azure_create_report(options):  # noqa: C901
             if attributes.get("meter_cache"):
                 meter_cache.update(attributes.get("meter_cache"))  # needed so that meter_cache can be defined in yaml
             attributes["meter_cache"] = meter_cache
-            attributes["version_two"] = version_two
             gen = generator_cls(gen_start_date, gen_end_date, currency, account_info, attributes)
             azure_columns = gen.azure_columns
             data += gen.generate_data()

--- a/tests/test_azure_generator.py
+++ b/tests/test_azure_generator.py
@@ -432,8 +432,10 @@ class TestVNGenerator(AzureGeneratorTestCase):
             if generator.azure_columns == AZURE_COLUMNS_V2_SUBSCRIPTION:
                 self.assertEqual(row["SubscriptionId"], self.payer_account)
                 self.assertEqual(row["ResourceId"], self.instance_id)
+                row["BillingCurrency"] = self.currency
             else:
                 self.assertEqual(row["SubscriptionGuid"], self.payer_account)
+                row["BillingCurrencyCode"] = self.currency
 
 
 class TestDTGenerator(AzureGeneratorTestCase):

--- a/tests/test_azure_generator.py
+++ b/tests/test_azure_generator.py
@@ -432,10 +432,10 @@ class TestVNGenerator(AzureGeneratorTestCase):
             if generator.azure_columns == AZURE_COLUMNS_V2_SUBSCRIPTION:
                 self.assertEqual(row["SubscriptionId"], self.payer_account)
                 self.assertEqual(row["ResourceId"], self.instance_id)
-                row["BillingCurrency"] = self.currency
+                self.assertEqual(row["BillingCurrency"], self.currency)
             else:
                 self.assertEqual(row["SubscriptionGuid"], self.payer_account)
-                row["BillingCurrencyCode"] = self.currency
+                self.assertEqual(row["BillingCurrencyCode"], self.currency)
 
 
 class TestDTGenerator(AzureGeneratorTestCase):

--- a/tests/test_azure_generator.py
+++ b/tests/test_azure_generator.py
@@ -222,7 +222,7 @@ class AzureGeneratorTestCase(TestCase):
             "usage_quantity": self.usage_quantity,
             "resource_rate": self.resource_rate,
             "pre_tax_cost": self.pre_tax_cost,
-            "version_two": True,
+            "resource_group": True,
         }
         self.two_hours_ago = (self.now - self.one_hour) - self.one_hour
 

--- a/tests/test_azure_generator.py
+++ b/tests/test_azure_generator.py
@@ -20,8 +20,8 @@ from datetime import timedelta
 from unittest import TestCase
 
 from faker import Faker
-from nise.generators.azure import AZURE_COLUMNS_V2_SUBSCRIPTION
 from nise.generators.azure import AZURE_COLUMNS_V2_RESOURCE_GROUP
+from nise.generators.azure import AZURE_COLUMNS_V2_SUBSCRIPTION
 from nise.generators.azure import AzureGenerator
 from nise.generators.azure import BandwidthGenerator
 from nise.generators.azure import DTGenerator

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1619,9 +1619,6 @@ class GCPReportTestCase(TestCase):
         one_day = datetime.timedelta(days=1)
         yesterday = now - one_day
         report_prefix = "test_report"
-
-        now = datetime.datetime(2024, 6, 30, 0, 0)
-        yesterday = datetime.datetime(2024, 6, 29, 0, 0)
         options = {"start_date": yesterday, "end_date": now, "gcp_report_prefix": report_prefix}
         fix_dates(options, "gcp")
         gcp_create_report(options)

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1619,6 +1619,9 @@ class GCPReportTestCase(TestCase):
         one_day = datetime.timedelta(days=1)
         yesterday = now - one_day
         report_prefix = "test_report"
+
+        now = datetime.datetime(2024, 6, 30, 0, 0)
+        yesterday = datetime.datetime(2024, 6, 29, 0, 0)
         options = {"start_date": yesterday, "end_date": now, "gcp_report_prefix": report_prefix}
         fix_dates(options, "gcp")
         gcp_create_report(options)

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,8 @@ max-complexity = 10
 max-line-length = 120
 import-order-style = pycharm
 application-import-names = nise
+per-file-ignores =
+    __init__.py: F401
 
 [testenv]
 passenv = CI TRAVIS TRAVIS_*


### PR DESCRIPTION
This change will drop v1 report fields and add v2 Resource Group based fields and Subscription fields. 

In addition, it removes the `--version-two` flag and adds `--resource-group` flag (to specify that the report should be resource group based).