### PR TITLE
[COST-5222] Fix FileNotFoundError in GCP Unit Test

### DIFF
--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "4.5.6"
+__version__ = "4.5.7"
 
 VERSION = __version__.split(".")

--- a/nise/report.py
+++ b/nise/report.py
@@ -1189,7 +1189,8 @@ def gcp_create_report(options):  # noqa: C901
 
             local_file_path, output_file_name = write_gcp_file(gen_start_date, gen_end_date, data, options)
             output_files.append(output_file_name)
-            monthly_files.append(local_file_path)
+            if local_file_path not in monthly_files:
+                monthly_files.append(local_file_path)
 
         for index, month_file in enumerate(monthly_files):
             if gcp_bucket_name:

--- a/nise/report.py
+++ b/nise/report.py
@@ -1194,6 +1194,7 @@ def gcp_create_report(options):  # noqa: C901
 
         for index, month_file in enumerate(monthly_files):
             if gcp_bucket_name:
+                print("asdasdsadasdasddas")
                 gcp_route_file(gcp_bucket_name, month_file, output_files[index])
 
     write_monthly = options.get("write_monthly", False)

--- a/nise/report.py
+++ b/nise/report.py
@@ -1194,7 +1194,6 @@ def gcp_create_report(options):  # noqa: C901
 
         for index, month_file in enumerate(monthly_files):
             if gcp_bucket_name:
-                print("asdasdsadasdasddas")
                 gcp_route_file(gcp_bucket_name, month_file, output_files[index])
 
     write_monthly = options.get("write_monthly", False)

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -22,7 +22,6 @@ import json
 import os
 import re
 import shutil
-from datetime import date
 from tempfile import mkdtemp
 from tempfile import NamedTemporaryFile
 from tempfile import TemporaryDirectory

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1628,7 +1628,7 @@ class GCPReportTestCase(TestCase):
         self.assertFalse(os.path.isfile(expected_output_file_path))
 
     def test_gcp_create_report_without_write_monthly_overlapping_month(self):
-        """Test that monthly file is not created by default."""
+        """Test that there are no Exceptions when processing overlapping months dates."""
         now = datetime.datetime(2024, 7, 1, 0, 0)
         yesterday = datetime.datetime(2024, 6, 30, 0, 0)
         report_prefix = "test_report"

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1627,8 +1627,13 @@ class GCPReportTestCase(TestCase):
 
         self.assertFalse(os.path.isfile(expected_output_file_path))
 
-        report_prefix = "test_report1"
-        options = {"start_date": yesterday, "end_date": now, "gcp_report_prefix": report_prefix}
+    def test_gcp_create_report_without_write_monthly_1(self):
+        """Test that monthly file is not created by default."""
+        now = datetime.datetime.now().replace(microsecond=0, second=0, minute=0, hour=0)
+        one_day = datetime.timedelta(days=1)
+        yesterday = now - one_day
+        report_prefix = "test_report"
+        options = {"start_date": yesterday, "end_date": now, "gcp_report_prefix": report_prefix, "gcp_bucket_name": "gcp_bucket_name"}
         fix_dates(options, "gcp")
         gcp_create_report(options)
         output_file_name = "{}-{}.csv".format(report_prefix, yesterday.strftime("%Y-%m-%d"))

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1633,7 +1633,12 @@ class GCPReportTestCase(TestCase):
         one_day = datetime.timedelta(days=1)
         yesterday = now - one_day
         report_prefix = "test_report"
-        options = {"start_date": yesterday, "end_date": now, "gcp_report_prefix": report_prefix, "gcp_bucket_name": "gcp_bucket_name"}
+        options = {
+            "start_date": yesterday,
+            "end_date": now,
+            "gcp_report_prefix": report_prefix,
+            "gcp_bucket_name": "gcp_bucket_name",
+        }
         fix_dates(options, "gcp")
         gcp_create_report(options)
         output_file_name = "{}-{}.csv".format(report_prefix, yesterday.strftime("%Y-%m-%d"))

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1627,23 +1627,14 @@ class GCPReportTestCase(TestCase):
 
         self.assertFalse(os.path.isfile(expected_output_file_path))
 
-    def test_gcp_create_report_monthly_files(self):
-        """Test adding local_file_path to monthly_files."""
-        now = datetime.datetime.now().replace(microsecond=0, second=0, minute=0, hour=0)
-        one_day = datetime.timedelta(days=1)
-        yesterday = now - one_day
-        report_prefix = "test_report"
+        report_prefix = "test_report1"
         options = {"start_date": yesterday, "end_date": now, "gcp_report_prefix": report_prefix}
         fix_dates(options, "gcp")
+        gcp_create_report(options)
+        output_file_name = "{}-{}.csv".format(report_prefix, yesterday.strftime("%Y-%m-%d"))
+        expected_output_file_path = "{}/{}".format(os.getcwd(), output_file_name)
 
-        filename = "test_report.csv"
-        with open(filename, "w") as f:
-            f.write("test content")
-
-        with patch("nise.report.write_gcp_file") as mock_write_gcp_file:
-            mock_write_gcp_file.return_value = ("test_report.csv", "test_report.csv")
-            gcp_create_report(options)
-            self.assertTrue(mock_write_gcp_file.called)
+        self.assertFalse(os.path.isfile(expected_output_file_path))
 
     def test_gcp_create_report_with_dataset_name_static_data(self):
         """Test the gcp report creation method where a dataset name is included and static data used."""

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1627,11 +1627,10 @@ class GCPReportTestCase(TestCase):
 
         self.assertFalse(os.path.isfile(expected_output_file_path))
 
-    def test_gcp_create_report_without_write_monthly_1(self):
+    def test_gcp_create_report_without_write_monthly_overlapping_month(self):
         """Test that monthly file is not created by default."""
-        now = datetime.datetime.now().replace(microsecond=0, second=0, minute=0, hour=0)
-        one_day = datetime.timedelta(days=1)
-        yesterday = now - one_day
+        now = datetime.datetime(2024, 7, 1, 0, 0)
+        yesterday = datetime.datetime(2024, 6, 30, 0, 0)
         report_prefix = "test_report"
         options = {
             "start_date": yesterday,

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1629,18 +1629,21 @@ class GCPReportTestCase(TestCase):
 
     def test_gcp_create_report_monthly_files(self):
         """Test adding local_file_path to monthly_files."""
-
         now = datetime.datetime.now().replace(microsecond=0, second=0, minute=0, hour=0)
         one_day = datetime.timedelta(days=1)
         yesterday = now - one_day
-        report_prefix = "test_report1"
+        report_prefix = "test_report"
         options = {"start_date": yesterday, "end_date": now, "gcp_report_prefix": report_prefix}
         fix_dates(options, "gcp")
-        gcp_create_report(options)
-        output_file_name = "{}-{}.csv".format(report_prefix, yesterday.strftime("%Y-%m-%d"))
-        expected_output_file_path = "{}/{}".format(os.getcwd(), output_file_name)
 
-        self.assertFalse(os.path.isfile(expected_output_file_path))
+        filename = "test_report.csv"
+        with open(filename, "w") as f:
+            f.write("test content")
+
+        with patch("nise.report.write_gcp_file") as mock_write_gcp_file:
+            mock_write_gcp_file.return_value = ("test_report.csv", "test_report.csv")
+            gcp_create_report(options)
+            self.assertTrue(mock_write_gcp_file.called)
 
     def test_gcp_create_report_with_dataset_name_static_data(self):
         """Test the gcp report creation method where a dataset name is included and static data used."""

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -22,6 +22,7 @@ import json
 import os
 import re
 import shutil
+from datetime import date
 from tempfile import mkdtemp
 from tempfile import NamedTemporaryFile
 from tempfile import TemporaryDirectory
@@ -1626,6 +1627,28 @@ class GCPReportTestCase(TestCase):
         expected_output_file_path = "{}/{}".format(os.getcwd(), output_file_name)
 
         self.assertFalse(os.path.isfile(expected_output_file_path))
+
+    def test_gcp_create_report_monthly_files(self):
+        """Test adding local_file_path to monthly_files."""
+
+        options = {
+            "gcp_bucket_name": mkdtemp(),
+            "start_date": date(2023, 2, 1),
+            "end_date": date(2023, 1, 31),
+            "currency": "USD",
+            "write_monthly": True,
+            "static_report_data": None,
+            "gcp_dataset_name": None,
+        }
+
+        with patch("nise.report.write_gcp_file") as mock_write_gcp_file:
+            mock_write_gcp_file.return_value = ("/nise/test_report.csv", "test_report.csv")
+            gcp_create_report(options)
+            monthly_files = options.get("gcp_bucket_name")
+            local_file_path = "/nise/test_report.csv"
+            self.assertNotIn(local_file_path, monthly_files)
+            self.assertIn(monthly_files, monthly_files)
+            shutil.rmtree(options["gcp_bucket_name"])
 
     def test_gcp_create_report_with_dataset_name_static_data(self):
         """Test the gcp report creation method where a dataset name is included and static data used."""


### PR DESCRIPTION
- **Jira Link**: https://issues.redhat.com/browse/COST-5222

The error occurred in the GCP test `test_gcp_create_report_without_write_monthly` whenever it was executed on the first day of the month. This happened because a list was generated with a filename for each month. Consequently, when the range "last day of month X" to "first day of month Y" was processed, the list was populated with a file for month X and another for month Y. However, in a testing scenario, the report name was always `test_report.csv`, resulting in a list with this value repeated twice. Therefore, an attempt to delete the file was made twice, causing an error on the second attempt since it had already been deleted the first time.

This change ensures that if the csv file has the same name, it will be added to the list only once. This prevents a second (or nth) deletion attempt.

**How to test?**

1. Checkout branch
2. Adapt the `test_gcp_create_report_without_write_monthly` test (test_report.py) adding the following lines to force a test with different dates:
- Two months:
```
now = datetime.datetime(2024, 6, 30, 0, 0)
yesterday = datetime.datetime(2024, 7, 1, 0, 0)
```
- One month
```
now = datetime.datetime(2024, 7, 1, 0, 0)
yesterday = datetime.datetime(2024, 7, 2, 0, 0)
```
3. Run `python3 -m unittest tests.test_report` or `python3 -m unittest tests.test_report.GCPReportTestCase`