### PR TITLE
Correct format for AWS DataTransferGenerator resource_id

### DIFF
--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "4.6.0"
+__version__ = "4.6.1"
 
 VERSION = __version__.split(".")

--- a/nise/generators/aws/data_transfer_generator.py
+++ b/nise/generators/aws/data_transfer_generator.py
@@ -43,7 +43,7 @@ class DataTransferGenerator(AWSGenerator):
         self._product_name = self.attributes.get("product_name", "Amazon Elastic Compute Cloud")
         self._product_sku = self.attributes.get("product_sku")
         self._rate = float(self.attributes.get("rate", 0)) or None
-        self._resource_id = self.attributes.get("resource_id")
+        self._resource_id = f"i-{self.attributes.get('resource_id', self.fake.ean8())}"
         self._saving = float(self.attributes.get("saving", 0)) or None
         self._tags = self.attributes.get("tags", self._tags)
 

--- a/tests/test_aws_generator.py
+++ b/tests/test_aws_generator.py
@@ -311,7 +311,7 @@ class TestDataTransferGenerator(AWSGeneratorTestCase):
         )
         self.assertEqual(generator._product_code, self.product_code)
         self.assertEqual(generator._tags, self.tags)
-        self.assertEqual(generator._resource_id, self.resource_id)
+        self.assertEqual(generator._resource_id, f"i-{self.resource_id}")
         self.assertEqual(generator._amount, self.amount)
         self.assertEqual(generator._rate, self.rate)
 


### PR DESCRIPTION
Make it match the behavior of the EC2 generator.