### PR TITLE
EBS: Add disk_size param to calculate hourly usage & rate

### DIFF
--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.6.7"
+__version__ = "4.6.8"
 
 
 VERSION = __version__.split(".")

--- a/tests/test_aws_generator.py
+++ b/tests/test_aws_generator.py
@@ -209,6 +209,7 @@ class AWSGeneratorTestCase(TestCase):
         self.amount = 1
         self.rate = 0.1
         self.saving = 0.1
+        self.disk_size = 10
         self.currency = "USD"
         self.legal_entity = "Red Hat"
         self.attributes = {
@@ -219,6 +220,7 @@ class AWSGeneratorTestCase(TestCase):
             "product_name": self.product_name,
             "resource_id": self.resource_id,
             "amount": self.amount,
+            "disk_size": self.disk_size,
             "rate": self.rate,
             "saving": self.saving,
             "product_family": self.product_family,
@@ -354,7 +356,7 @@ class TestEBSGenerator(AWSGeneratorTestCase):
         self.assertEqual(generator._product_sku, self.product_sku)
         self.assertEqual(generator._tags, self.tags)
         self.assertEqual(generator._resource_id, "vol-" + self.resource_id)
-        self.assertEqual(generator._amount, self.amount)
+        self.assertEqual(generator._disk_size, self.disk_size)
         self.assertEqual(generator._rate, self.rate)
 
     def test_update_data(self):


### PR DESCRIPTION
Add a disk_size param to the ebs generator and use it to calculate the cost & usage amount. 

I used this yaml file:
```
```---
  generators:
    - EBSGenerator:
        start_date: 2023-11-01
        product_sku: VEAJHRNBBBBD
        resource_id: 12345674
        disk_size: 10
        rate: 0.1
        tags:
          resourceTags/user:storageclass: gamma
          resourceTags/user:Mapping: d1
          resourceTags/user:Map: d2
        cost_category:
          costCategory/env: ephemeral



  accounts:
    payer: 9999999999999
    user:
      - 9999999999999
    currency_code: USD #can be changed when testing with foreign currency codes```
```
To produce this CSV file with these changes

[November-2023-None.csv](https://github.com/user-attachments/files/16626409/November-2023-None.csv)
