### PR TITLE
Update SavingsPlan line items

### DIFF
--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.6.8"
+__version__ = "4.6.9"
 
 
 VERSION = __version__.split(".")

--- a/nise/generators/aws/data_transfer_generator.py
+++ b/nise/generators/aws/data_transfer_generator.py
@@ -116,6 +116,7 @@ class DataTransferGenerator(AWSGenerator):
         row["pricing/term"] = "OnDemand"
         row["pricing/unit"] = "GB"
         row["savingsPlan/SavingsPlanEffectiveCost"] = str(saving)
+        row["savingsPlan/SavingsPlanRate"] = str(saving)
 
         # Overwrite lineItem/LineItemType for items with applied Savings plan
         if saving is not None:

--- a/nise/generators/aws/data_transfer_generator.py
+++ b/nise/generators/aws/data_transfer_generator.py
@@ -124,11 +124,16 @@ class DataTransferGenerator(AWSGenerator):
         if negation:
             row["lineItem/LineItemType"] = "SavingsPlanNegation"
             row["lineItem/UnblendedCost"] = -abs(cost)
-            row["lineItem/LineItemDescription"] = f"SavingsPlanNegation used by AccountId : {self.payer_account}"
-            row["lineItem/ResourceId"] = None
+            row["lineItem/UnblendedRate"] = -abs(rate)
             row["lineItem/BlendedCost"] = -abs(cost)
-
-        if not negation:
+            row["lineItem/BlendedRate"] = -abs(rate)
+            row[
+                "lineItem/LineItemDescription"
+            ] = f"SavingsPlanNegation used by AccountId : {self.payer_account} and UsageSku : {self._product_sku}"
+            row["lineItem/ResourceId"] = None
+            row["savingsPlan/SavingsPlanEffectiveCost"] = None
+            row["savingsPlan/SavingsPlanRate"] = None
+        else:
             self._add_tag_data(row)
             self._add_category_data(row)
         return row

--- a/nise/generators/aws/ec2_generator.py
+++ b/nise/generators/aws/ec2_generator.py
@@ -198,20 +198,29 @@ class EC2Generator(AWSGenerator):
         row["pricing/term"] = "OnDemand"
         row["pricing/unit"] = "Hrs"
         row["savingsPlan/SavingsPlanEffectiveCost"] = saving
+        row["savingsPlan/SavingsPlanRate"] = saving
 
         # Overwrite lineItem/LineItemType for items with applied Savings plan
         if saving is not None:
             row["lineItem/LineItemType"] = "SavingsPlanCoveredUsage"
+
         if negation:
             row["lineItem/LineItemType"] = "SavingsPlanNegation"
             row["lineItem/UnblendedCost"] = -abs(cost)
-            row["lineItem/LineItemDescription"] = f"SavingsPlanNegation used by AccountId : {self.payer_account}"
-            row["lineItem/ResourceId"] = None
+            row["lineItem/UnblendedRate"] = -abs(rate)
             row["lineItem/BlendedCost"] = -abs(cost)
+            row["lineItem/BlendedRate"] = -abs(rate)
+            row[
+                "lineItem/LineItemDescription"
+            ] = f"SavingsPlanNegation used by AccountId : {self.payer_account} and UsageSku : {self._product_sku}"
+            row["lineItem/ResourceId"] = None
+            row["savingsPlan/SavingsPlanEffectiveCost"] = None
+            row["savingsPlan/SavingsPlanRate"] = None
 
-        if not negation:
+        else:
             self._add_tag_data(row)
             self._add_category_data(row)
+
         return row
 
     def generate_data(self, report_type=None):

--- a/tests/test_aws_generator.py
+++ b/tests/test_aws_generator.py
@@ -409,7 +409,7 @@ class TestEC2Generator(AWSGeneratorTestCase):
 
     def test_update_data_ec2_negation(self):
         """Test EC2 specific update data with negation costs."""
-        self.instance_type = {"negation": True, "cost": 10}
+        self.instance_type = {"negation": True, "cost": 10, "rate": 1}
         self.attributes["instance_type"] = self.instance_type
         generator = EC2Generator(
             self.two_hours_ago, self.now, self.currency, self.payer_account, self.usage_accounts, self.attributes


### PR DESCRIPTION
This PR updates **SavingsPlanNegation** line items as follows:
- `savingsPlan/SavingsPlanEffectiveCost` and `savingsPlan/SavingsPlanRate` are supposed to be empty
- `lineItem/BlendedRate` and `lineItem/UnBlendedRate` are supposed to be negative

Additionally it adds values to `savingsPlan/SavingsPlanRate` column for SavingsPlanCoveredUsage line items