### PR TITLE
[COST-5623] Change GCP credits to represnt hourly value

### DIFF
--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.6.9"
+__version__ = "4.6.10"
 
 
 VERSION = __version__.split(".")

--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.6.10"
+__version__ = "4.7.0"
 
 
 VERSION = __version__.split(".")

--- a/nise/generators/gcp/cloud_storage_generator.py
+++ b/nise/generators/gcp/cloud_storage_generator.py
@@ -44,7 +44,6 @@ class CloudStorageGenerator(GCPGenerator):
     def __init__(self, start_date, end_date, currency, project, attributes=None):
         """Initialize the cloud storage generator."""
         super().__init__(start_date, end_date, currency, project, attributes)
-        self.credit_total = 0
         self._currency = currency
         if self.attributes:
             if self.attributes.get("labels"):
@@ -82,9 +81,7 @@ class CloudStorageGenerator(GCPGenerator):
         row["usage.amount_in_pricing_units"] = self._gen_pricing_unit_amount(pricing_unit, row["usage.amount"])
         cost = self._gen_cost(row["usage.amount_in_pricing_units"])
         row["cost"] = cost
-        credit, credit_total = self._gen_credit(self.credit_total, self._credit_amount)
-        self.credit_total = credit_total
-        row["credits"] = credit
+        row["credits"] = self._gen_credit(self._credit_amount)
         usage_date = datetime.strptime(row.get("usage_start_time")[:7], "%Y-%m")
         row["invoice.month"] = f"{usage_date.year}{usage_date.month:02d}"
 
@@ -145,9 +142,7 @@ class JSONLCloudStorageGenerator(CloudStorageGenerator):
         cost = self._gen_cost(usage["amount_in_pricing_units"])
         row["cost"] = cost
         row["usage"] = usage
-        credit, credit_total = self._gen_credit(self.credit_total, self._credit_amount, True)
-        self.credit_total = credit_total
-        row["credits"] = credit
+        row["credits"] = self._gen_credit(self._credit_amount, json_return=True)
         row["cost_type"] = "regular"
         row["currency_conversion_rate"] = 1
         invoice = {}

--- a/nise/generators/gcp/compute_engine_generator.py
+++ b/nise/generators/gcp/compute_engine_generator.py
@@ -61,7 +61,6 @@ class ComputeEngineGenerator(GCPGenerator):
     def __init__(self, start_date, end_date, currency, project, attributes=None):  # noqa: C901
         """Initialize the cloud storage generator."""
         super().__init__(start_date, end_date, currency, project, attributes)
-        self.credit_total = 0
         for attribute in self.attributes:
             setattr(self, f"_{attribute}", self.attributes.get(attribute))
         if self.attributes:
@@ -83,6 +82,7 @@ class ComputeEngineGenerator(GCPGenerator):
                         self._sku = sku
             if self.attributes.get("instance_type"):
                 self._instance_type = self.attributes.get("instance_type")
+
             if self.attributes.get("credit_amount"):
                 self._credit_amount = self.attributes.get("credit_amount")
             if self.attributes.get("resource.name"):
@@ -109,9 +109,7 @@ class ComputeEngineGenerator(GCPGenerator):
         row["usage.amount_in_pricing_units"] = self._gen_pricing_unit_amount(pricing_unit, row["usage.amount"])
         cost = self._gen_cost(row["usage.amount_in_pricing_units"])
         row["cost"] = cost
-        credit, credit_total = self._gen_credit(self.credit_total, self._credit_amount)
-        self.credit_total = credit_total
-        row["credits"] = credit
+        row["credits"] = self._gen_credit(self._credit_amount)
         usage_date = datetime.strptime(row.get("usage_start_time")[:7], "%Y-%m")
         row["invoice.month"] = f"{usage_date.year}{usage_date.month:02d}"
 
@@ -173,9 +171,7 @@ class JSONLComputeEngineGenerator(ComputeEngineGenerator):
         cost = self._gen_cost(usage["amount_in_pricing_units"])
         row["cost"] = cost
         row["usage"] = usage
-        credit, credit_total = self._gen_credit(self.credit_total, self._credit_amount, True)
-        self.credit_total = credit_total
-        row["credits"] = credit
+        row["credits"] = self._gen_credit(self._credit_amount, json_return=True)
         row["cost_type"] = "regular"
         row["currency_conversion_rate"] = 1
         invoice = {}

--- a/nise/generators/gcp/gcp_database_generator.py
+++ b/nise/generators/gcp/gcp_database_generator.py
@@ -44,7 +44,6 @@ class GCPDatabaseGenerator(GCPGenerator):
     def __init__(self, start_date, end_date, currency, project, attributes=None):  # noqa: C901
         """Initialize the cloud storage generator."""
         super().__init__(start_date, end_date, currency, project, attributes)
-        self.credit_total = 0
         self._currency = currency
         if self.attributes:
             if self.attributes.get("labels"):
@@ -87,9 +86,7 @@ class GCPDatabaseGenerator(GCPGenerator):
         row["usage.amount_in_pricing_units"] = self._gen_pricing_unit_amount(pricing_unit, row["usage.amount"])
         cost = self._gen_cost(row["usage.amount_in_pricing_units"])
         row["cost"] = cost
-        credit, credit_total = self._gen_credit(self.credit_total, self._credit_amount)
-        self.credit_total = credit_total
-        row["credits"] = credit
+        row["credits"] = self._gen_credit(self._credit_amount)
         usage_date = datetime.strptime(row.get("usage_start_time")[:7], "%Y-%m")
         row["invoice.month"] = f"{usage_date.year}{usage_date.month:02d}"
 
@@ -154,9 +151,7 @@ class JSONLGCPDatabaseGenerator(GCPDatabaseGenerator):
         cost = self._gen_cost(usage["amount_in_pricing_units"])
         row["cost"] = cost
         row["usage"] = usage
-        credit, credit_total = self._gen_credit(self.credit_total, self._credit_amount, True)
-        self.credit_total = credit_total
-        row["credits"] = credit
+        row["credits"] = self._gen_credit(self._credit_amount, json_return=True)
         usage_date = datetime.strptime(row.get("usage_start_time")[:7], "%Y-%m")
         invoice = {}
         usage_date = datetime.strptime(row.get("usage_start_time")[:7], "%Y-%m")

--- a/nise/generators/gcp/gcp_generator.py
+++ b/nise/generators/gcp/gcp_generator.py
@@ -227,9 +227,9 @@ class GCPGenerator(AbstractGenerator):
         """Generate the credit dict based off the hourly credit_amount."""
         if json_return:
             default_dict = {"name": "", "amount": 0, "full_name": "", "id": "", "type": ""}
-            empty_return = [default_dict, None]
+            empty_return = default_dict
         else:
-            empty_return = ["[]", None]
+            empty_return = "[]"
         if not credit_amount:
             return empty_return
         else:

--- a/nise/generators/gcp/gcp_generator.py
+++ b/nise/generators/gcp/gcp_generator.py
@@ -223,35 +223,29 @@ class GCPGenerator(AbstractGenerator):
                 invoice_months.append(invoice_month)
         return invoice_months
 
-    def _gen_credit(self, credit_distributed, credit_amount, json_return=False):
-        """Generate the credit based off the cost amount."""
+    def _gen_credit(self, credit_amount, json_return=False):
+        """Generate the credit dict based off the hourly credit_amount."""
         if json_return:
-            if credit_amount:
-                # When using the csv generator it runs per invoice month so this will equal that logic
-                invoice_months = self._gcp_find_invoice_months_in_date_range()
-                invoice_month_count = len(invoice_months)
-                credit_amount = credit_amount * invoice_month_count
             default_dict = {"name": "", "amount": 0, "full_name": "", "id": "", "type": ""}
             empty_return = [default_dict, None]
         else:
             empty_return = ["[]", None]
-        if not credit_amount or credit_distributed is None:
+        if not credit_amount:
             return empty_return
         else:
-            mock_credit = credit_amount / len(self.hours)
-            credit_distributed = credit_distributed - abs(mock_credit)
             credit_name = "FreeTrial"
             credit_dict = {
                 "name": credit_name,
-                "amount": mock_credit,
+                "amount": credit_amount,
                 "full_name": "",
                 "id": credit_name,
                 "type": "PROMOTION",
             }
+
             if json_return:
-                return [credit_dict, credit_distributed]
+                return credit_dict
             else:
-                return [str([credit_dict]), credit_distributed]
+                return str([credit_dict])
 
     def determine_system_labels(self, pricing_unit):
         """Determine the system labels if instance-type exists."""

--- a/nise/generators/gcp/gcp_network_generator.py
+++ b/nise/generators/gcp/gcp_network_generator.py
@@ -50,7 +50,6 @@ class GCPNetworkGenerator(GCPGenerator):
     def __init__(self, start_date, end_date, currency, project, attributes=None):  # noqa: C901
         """Initialize the cloud storage generator."""
         super().__init__(start_date, end_date, currency, project, attributes)
-        self.credit_total = 0
         self._currency = currency
         if self.attributes:
             if self.attributes.get("labels"):
@@ -93,9 +92,7 @@ class GCPNetworkGenerator(GCPGenerator):
         row["usage.amount_in_pricing_units"] = self._gen_pricing_unit_amount(pricing_unit, row["usage.amount"])
         cost = self._gen_cost(row["usage.amount_in_pricing_units"])
         row["cost"] = cost
-        credit, credit_total = self._gen_credit(self.credit_total, self._credit_amount)
-        self.credit_total = credit_total
-        row["credits"] = credit
+        row["credits"] = self._gen_credit(self._credit_amount)
         usage_date = datetime.strptime(row.get("usage_start_time")[:7], "%Y-%m")
         row["invoice.month"] = f"{usage_date.year}{usage_date.month:02d}"
 
@@ -159,9 +156,7 @@ class JSONLGCPNetworkGenerator(GCPNetworkGenerator):
         cost = self._gen_cost(usage["amount_in_pricing_units"])
         row["cost"] = cost
         row["usage"] = usage
-        credit, credit_total = self._gen_credit(self.credit_total, self._credit_amount, True)
-        self.credit_total = credit_total
-        row["credits"] = credit
+        row["credits"] = self._gen_credit(self._credit_amount, json_return=True)
         usage_date = datetime.strptime(row.get("usage_start_time")[:7], "%Y-%m")
         invoice = {}
         usage_date = datetime.strptime(row.get("usage_start_time")[:7], "%Y-%m")

--- a/tests/test_gcp_generator.py
+++ b/tests/test_gcp_generator.py
@@ -343,14 +343,11 @@ class TestGCPGenerator(TestCase):
             gen_handler = generator(self.yesterday, self.now, self.currency, self.project, attributes=attributes)
             generated_data = gen_handler.generate_data()
             list_data = list(generated_data)
-            credit_rows = []
             for row in list_data:
-                if row.get("credits") != "[]":
-                    credit_dict = row.get("credits").replace("'", '"').strip("][")
-                    credit_dict = json.loads(credit_dict)
-                    credit_amount = credit_dict.get("amount", 0)
-                    credit_rows.append(credit_amount)
-            self.assertEqual(sum(credit_rows), expected_credit_amount)
+                credit_dict = row.get("credits").replace("'", '"').strip("][")
+                credit_dict = json.loads(credit_dict)
+                credit_amount = credit_dict.get("amount", 0)
+                self.assertEqual(credit_amount, expected_credit_amount)
 
     def test_gcp_jsonl_generators_with_credit_attributes(self):
         """Test json generators with credit attributes."""
@@ -369,10 +366,7 @@ class TestGCPGenerator(TestCase):
         for generator in generators_list:
             gen_handler = generator(self.yesterday, self.now, self.currency, self.project, attributes=attributes)
             generated_data = gen_handler.generate_data()
-            num_invoice_months = gen_handler._gcp_find_invoice_months_in_date_range()
             list_data = list(generated_data)
-            credit_rows = []
             for row in list_data:
                 credit_amount = row.get("credits", {}).get("amount", 0)
-                credit_rows.append(credit_amount)
-            self.assertEqual(sum(credit_rows), expected_credit_amount * len(num_invoice_months))
+                self.assertEqual(credit_amount, expected_credit_amount)


### PR DESCRIPTION
[COST-5623](https://issues.redhat.com/browse/COST-5623)
This PR changes credit_amount from yaml to represent hourly rate instead of monthly rate. This will help to generate more reasonable credits in case that we want to generate only few days in a month (e.g, for testing day-to-day flow)