### PR TITLE
[COST-5432] - Add the ability to generate reserved instances

### DIFF
--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.7.0"
+__version__ = "4.7.1"
 
 
 VERSION = __version__.split(".")

--- a/nise/generators/aws/ec2_generator.py
+++ b/nise/generators/aws/ec2_generator.py
@@ -25,16 +25,16 @@ class EC2Generator(AWSGenerator):
 
     INSTANCE_TYPES = (
         # NOTE: Each tuple represents
-        # (instance type, 
-        # physical_cores, 
-        # vCPUs, 
-        # memory, 
-        # storage, 
-        # family, 
-        # cost, 
-        # rate, 
-        # Reserved_instances, 
-        # savings, 
+        # (instance type,
+        # physical_cores,
+        # vCPUs,
+        # memory,
+        # storage,
+        # family,
+        # cost,
+        # rate,
+        # Reserved_instances,
+        # savings,
         # description)
         (
             "m5.large",

--- a/nise/generators/aws/ec2_generator.py
+++ b/nise/generators/aws/ec2_generator.py
@@ -38,6 +38,7 @@ class EC2Generator(AWSGenerator):
             "0.045",
             1,
             False,
+            False,
             "${cost} per On Demand Linux {inst_type} Instance Hour",
         ),
         (
@@ -51,6 +52,7 @@ class EC2Generator(AWSGenerator):
             "0.34",
             "0.17",
             1,
+            False,
             False,
             "${cost} per On Demand Linux {inst_type} Instance Hour",
         ),
@@ -66,6 +68,7 @@ class EC2Generator(AWSGenerator):
             "0.099",
             1,
             False,
+            False,
             "${cost} per On Demand Linux {inst_type} Instance Hour",
         ),
         (
@@ -79,6 +82,7 @@ class EC2Generator(AWSGenerator):
             "0.133",
             "0.067",
             1,
+            False,
             False,
             "${cost} per On Demand Linux {inst_type} Instance Hour",
         ),
@@ -124,6 +128,7 @@ class EC2Generator(AWSGenerator):
                 instance_type.get("rate"),
                 instance_type.get("saving"),
                 instance_type.get("amount", "1"),
+                instance_type.get("reserved_instance", False),
                 instance_type.get("negation", False),
                 "${cost} per On Demand Linux {inst_type} Instance Hour",
             )
@@ -141,6 +146,7 @@ class EC2Generator(AWSGenerator):
             rate,
             saving,
             amount,
+            reserved_instance,
             negation,
             description,
         ) = self._instance_type
@@ -203,6 +209,20 @@ class EC2Generator(AWSGenerator):
         # Overwrite lineItem/LineItemType for items with applied Savings plan
         if saving is not None:
             row["lineItem/LineItemType"] = "SavingsPlanCoveredUsage"
+        # Overwrite lineitem/LineItemType for RI's discount usage
+        if reserved_instance:
+            row["lineItem/LineItemType"] = "DiscountedUsage"
+            row["lineItem/UnblendedCost"] = 0
+            row["lineItem/UnblendedRate"] = 0
+            row["lineItem/BlendedCost"] = 0
+            row["lineItem/BlendedRate"] = 0
+            row[
+                "lineItem/LineItemDescription"
+            ] = f"{inst_type} reserved instance applied"
+            row["pricing/publicOnDemandCost"] = 'convertible'
+            row["pricing/publicOnDemandRate"] = 'No Upfront'
+            row["savingsPlan/SavingsPlanEffectiveCost"] = None
+            row["savingsPlan/SavingsPlanRate"] = None
 
         if negation:
             row["lineItem/LineItemType"] = "SavingsPlanNegation"

--- a/nise/generators/aws/ec2_generator.py
+++ b/nise/generators/aws/ec2_generator.py
@@ -25,7 +25,7 @@ class EC2Generator(AWSGenerator):
 
     INSTANCE_TYPES = (
         # NOTE: Each tuple represents
-        # (instance type, physical_cores, vCPUs, memory, storage, family, cost, rate, savings, description)
+        # (instance type, physical_cores, vCPUs, memory, storage, family, cost, rate, Reserved_instances, savings, description)
         (
             "m5.large",
             "1",

--- a/nise/generators/aws/ec2_generator.py
+++ b/nise/generators/aws/ec2_generator.py
@@ -216,11 +216,9 @@ class EC2Generator(AWSGenerator):
             row["lineItem/UnblendedRate"] = 0
             row["lineItem/BlendedCost"] = 0
             row["lineItem/BlendedRate"] = 0
-            row[
-                "lineItem/LineItemDescription"
-            ] = f"{inst_type} reserved instance applied"
-            row["pricing/publicOnDemandCost"] = 'convertible'
-            row["pricing/publicOnDemandRate"] = 'No Upfront'
+            row["lineItem/LineItemDescription"] = f"{inst_type} reserved instance applied"
+            row["pricing/publicOnDemandCost"] = "convertible"
+            row["pricing/publicOnDemandRate"] = "No Upfront"
             row["savingsPlan/SavingsPlanEffectiveCost"] = None
             row["savingsPlan/SavingsPlanRate"] = None
 

--- a/nise/generators/aws/ec2_generator.py
+++ b/nise/generators/aws/ec2_generator.py
@@ -25,7 +25,17 @@ class EC2Generator(AWSGenerator):
 
     INSTANCE_TYPES = (
         # NOTE: Each tuple represents
-        # (instance type, physical_cores, vCPUs, memory, storage, family, cost, rate, Reserved_instances, savings, description)
+        # (instance type, 
+        # physical_cores, 
+        # vCPUs, 
+        # memory, 
+        # storage, 
+        # family, 
+        # cost, 
+        # rate, 
+        # Reserved_instances, 
+        # savings, 
+        # description)
         (
             "m5.large",
             "1",

--- a/tests/aws_static_report.yml
+++ b/tests/aws_static_report.yml
@@ -27,7 +27,7 @@ generators:
       resource_id: 55555555
       product_sku: VEAJHRNKTJZQ
       region: us-east-1a
-      resourved_instance: true
+      reserved_instance: True
   - S3Generator:
       start_date: last_month
       end_date: last_month

--- a/tests/aws_static_report.yml
+++ b/tests/aws_static_report.yml
@@ -20,6 +20,14 @@ generators:
         cost: 1.000
         rate: 0.500
         saving: 0.250
+  - EC2Generator:
+      start_date: today
+      end_date: today
+      processor_arch: 32-bit
+      resource_id: 55555555
+      product_sku: VEAJHRNKTJZQ
+      region: us-east-1a
+      resourved_instance: true
   - S3Generator:
       start_date: last_month
       end_date: last_month

--- a/tests/test_aws_generator.py
+++ b/tests/test_aws_generator.py
@@ -419,6 +419,18 @@ class TestEC2Generator(AWSGeneratorTestCase):
 
         self.assertEqual(row["lineItem/LineItemType"], "SavingsPlanNegation")
 
+    def test_update_data_ec2_negation(self):
+        """Test EC2 specific update data with Reserved Instances."""
+        self.instance_type = {"reserved_instance": True}
+        self.attributes["instance_type"] = self.instance_type
+        generator = EC2Generator(
+            self.two_hours_ago, self.now, self.currency, self.payer_account, self.usage_accounts, self.attributes
+        )
+        start_row = {}
+        row = generator._update_data(start_row, self.two_hours_ago, self.now)
+
+        self.assertEqual(row["lineItem/LineItemType"], "DiscountedUsage")
+
     def test_update_data(self):
         """Test EBS specific update data method."""
         generator = EC2Generator(

--- a/tests/test_aws_generator.py
+++ b/tests/test_aws_generator.py
@@ -395,6 +395,7 @@ class TestEC2Generator(AWSGeneratorTestCase):
             "rate": "1",
             "saving": "1",
             "amount": 1,
+            "reserved_instance": False,
             "negation": False,
         }
         self.attributes["instance_type"] = self.instance_type
@@ -419,7 +420,7 @@ class TestEC2Generator(AWSGeneratorTestCase):
 
         self.assertEqual(row["lineItem/LineItemType"], "SavingsPlanNegation")
 
-    def test_update_data_ec2_negation(self):
+    def test_update_data_ec2_reserved_instances(self):
         """Test EC2 specific update data with Reserved Instances."""
         self.instance_type = {"reserved_instance": True}
         self.attributes["instance_type"] = self.instance_type

--- a/tests/test_aws_generator.py
+++ b/tests/test_aws_generator.py
@@ -431,6 +431,7 @@ class TestEC2Generator(AWSGeneratorTestCase):
         row = generator._update_data(start_row, self.two_hours_ago, self.now)
 
         self.assertEqual(row["lineItem/LineItemType"], "DiscountedUsage")
+        self.assertEqual(row["lineItem/UnblendedCost"], 0)
 
     def test_update_data(self):
         """Test EBS specific update data method."""


### PR DESCRIPTION
Small EC2 generator update to add the ability to gen Reserved instances.

Testing:
`nise -lll report aws --aws-s3-bucket-name ~/location_to_gen_files_in/ --aws-s3-report-name my_report --static-report-file ~/location/yaml_file.yml`

Yaml example:

```
generators:
  - EC2Generator:
      start_date: last_month
      processor_arch: 64-bit
      resource_id: 55555555
      product_sku: VEAJHRNKTJZQ
      region: us-east-1a
      instance_type:
        inst_type: m5.large
        physical_cores: 1
        vcpu: 2
        memory: '8 GiB'
        storage: 'EBS Only'
        family: 'General Purpose'
        reserved_instance: True
  


accounts:
  payer: 9999999999998
  user:
    - 9999999999998