### PR TITLE
Remove `pipenv-setup` in order to publish PEP 625 compliant sdist and wheel

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install pipenv-setup setuptools wheel twine chardet vistir==0.6.1 -c requirements/build-constraints.txt
+          python3 -m pip install setuptools wheel twine chardet vistir==0.6.1 -c requirements/build-constraints.txt
 
       - name: Build and publish
         env:
@@ -35,9 +35,6 @@ jobs:
           VERSION=$(python setup.py --version)
           if [ ! -z $(git tag -l "${VERSION}") ]; then
             echo "Tag already exists, doing nothing";
-            exit_code=1
-          elif [ -z "$(pipenv-setup check)" ]; then
-            echo "setup.py out of sync with Pipfile"
             exit_code=1
           else
             echo "Creating tag ${VERSION}";

--- a/Pipfile
+++ b/Pipfile
@@ -17,7 +17,6 @@ oci = ">=2.64.0"
 [dev-packages]
 tox = ">=3.14"
 coverage = ">=5.0"
-pipenv-setup = "*"
 setuptools = ">=44.0"
 twine = ">=3.1"
 importlib-resources = ">=1.5.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "23f3cfca6eaab6214036091a147014f6e3caca149e830b02c9cd10861358179a"
+            "sha256": "c72c5cf7678f59926a1b0136a90b4aa46642056944d3071b84ad8e540cc72819"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -761,21 +761,6 @@
         }
     },
     "develop": {
-        "appdirs": {
-            "hashes": [
-                "sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92",
-                "sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e"
-            ],
-            "version": "==1.4.3"
-        },
-        "attrs": {
-            "hashes": [
-                "sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79",
-                "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==19.1.0"
-        },
         "backports.tarfile": {
             "hashes": [
                 "sha256:77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34",
@@ -783,14 +768,6 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==1.2.0"
-        },
-        "black": {
-            "hashes": [
-                "sha256:09a9dcb7c46ed496a9850b76e4e825d6049ecd38b611f1224857a79bd985a8cf",
-                "sha256:68950ffd4d9169716bcb8719a56c07a2f4485354fec061cdd5910aa07369731c"
-            ],
-            "markers": "python_version >= '3.6'",
-            "version": "==19.3b0"
         },
         "cachetools": {
             "hashes": [
@@ -921,14 +898,6 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==3.4.1"
-        },
-        "click": {
-            "hashes": [
-                "sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13",
-                "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==7.0"
         },
         "colorama": {
             "hashes": [
@@ -1174,20 +1143,6 @@
             "markers": "python_version >= '3.8'",
             "version": "==24.2"
         },
-        "pipenv-setup": {
-            "hashes": [
-                "sha256:f65fe799297facfe5ac1b03e2f55525135e0bf521ca7c175331bb59133c302b3"
-            ],
-            "index": "pypi",
-            "markers": "python_version >= '3.6'",
-            "version": "==2.0.0"
-        },
-        "pipfile": {
-            "hashes": [
-                "sha256:f7d9f15de8b660986557eb3cc5391aa1a16207ac41bc378d03f414762d36c984"
-            ],
-            "version": "==0.0.2"
-        },
         "platformdirs": {
             "hashes": [
                 "sha256:357fb2acbc885b0419afd3ce3ed34564c13c9b95c89360cd9563f73aa5e2b907",
@@ -1338,14 +1293,6 @@
             "index": "pypi",
             "markers": "python_version >= '3.9'",
             "version": "==75.8.0"
-        },
-        "toml": {
-            "hashes": [
-                "sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c",
-                "sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e",
-                "sha256:f1db651f9657708513243e61e6cc67d101a39bad662eaa9b5546f789338e07a3"
-            ],
-            "version": "==0.10.0"
         },
         "tox": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -73,27 +73,28 @@ To run pre-commit checks:
 
 #### Publishing
 
-Please remember to sync your updated dependecies to setup.py with :
-
-    pipenv-setup sync -p
-
-After that, make sure to increment the version in setup.py. As soon as your PR is merged to main, a new koku-nise package will built, tagged, and deployed to PyPI.
+Increment the version in `setup.py`. As soon as your PR is merged to main, a new `koku-nise` package will built, tagged, and deployed to PyPI.
 
 ##### Finer Publishing Details
 
-All of the deployment is driven entirely by a Github Action workflow, so if issues ever crop up, start in `publish-to-pypi.yml`. When a branch is merged into main, the Action will kick off. There are three things that must happen before a deployment is successful, a successful artifact build, dependencies verified in sync between the requirements files, and setup.py, and the tag must not yet exist in git. The dependency syncing/verification is done with the [pipenv-setup](https://github.com/Madoshakalaka/pipenv-setup) tool. After the artifact is deployed, it\'ll be available at [PyPI](https://pypi.org/project/koku-nise/#history).
+All of the deployment is driven entirely by a Github Action workflow, so if issues ever crop up, start in `publish-to-pypi.yml`. When a branch is merged into `main`, the Action will kick off. There are two things that must happen before a deployment is successful:
+
+1. A successful artifact build
+2. The tag must not yet exist in `git`.
+
+After the artifact is deployed, it'll be available at [PyPI](https://pypi.org/project/koku-nise/#history).
 
 #### Nise, Koku, and IQE Integration
 
-The iqe tests use nise to generate mock data; therefore, we need to ensure that our nise changes do not break the iqe tests. To do this you will need to copy `.env.example` to `.env` and customize as necessary. After the `.env` file is configured you will then need to run
+The IQE tests use nise to generate mock data; therefore, we need to ensure that our nise changes do not break the IQE tests. To do this you will need to copy `.env.example` to `.env` and customize as necessary. After the `.env` file is configured you will then need to run
 
     make run-iqe
 
-The `make run-iqe` command by default will run the smoke tests. However, if you want to run a specific iqe test command you can pass it in through the `IQE_CMD` parameter
+The `make run-iqe` command by default will run the smoke tests. However, if you want to run a specific IQE test command you can pass it in through the `IQE_CMD` parameter
 
     make run-iqe IQE_CMD='iqe tests plugin hccm -k test_api_aws_provider_create_foo_resource_name'
 
-### Prereqs
+### Prerequisites
 
 - AWS population requires prior setup of AWS Cost and Usage Report of same name to be created, as well as associated Bucket, Policy, Role, etc.
 


### PR DESCRIPTION
`pipenv-setup` depends on an older version of `packaging` which creates sdist and wheel files that do not comply with PEP 625. This results in the following notice from PyPI:

>This email is notifying you of an upcoming deprecation that we have determined may affect you as a result of your recent upload to 'koku-nise'.
> In the future, PyPI will require all newly uploaded source distribution filenames to comply with [PEP 625](https://peps.python.org/pep-0625/). Any source distributions already uploaded will remain in place as-is and do not need to be updated.
> Specifically, your recent upload of 'koku-nise-4.7.2.tar.gz' is incompatible with PEP 625 because it does not contain the normalized project name 'koku_nise'.
> In most cases, this can be resolved by upgrading the version of your build tooling to a later version that supports PEP 625 and produces compliant filenames. You do not need to remove the file.

`pipenv-setup` seems abandoned as the [last commit](https://github.com/Madoshakalaka/pipenv-setup/commits/master/) was almost three years ago.

Pipfile and `setup.py` [serve different purposes](https://pipenv-searchable.readthedocs.io/advanced.html#pipfile-vs-setup-py). Keeping them in sync shouldn't necessarily be a goal. `Pipfile.lock` serves developers working on `nise`. `setup.py` requirements serve those installing the application for use.


**Steps to duplicate the problem**

```
> python3 -m pip install --force setuptools wheel twine chardet pipenv-setup vistir==0.6.1 -c requirements/build-constraints.txt
> python setup.py sdist bdist_wheel
> ls -1 dist
koku-nise-4.7.2.tar.gz
koku_nise-4.7.2-py3-none-any.whl
```