### PR TITLE
[COST-6158] - Add the ability to generate AWS Savings Plan Upfront and Recurring fees

### DIFF
--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.7.2"
+__version__ = "4.7.3"
 
 
 VERSION = __version__.split(".")

--- a/nise/generators/aws/ec2_generator.py
+++ b/nise/generators/aws/ec2_generator.py
@@ -268,11 +268,12 @@ class EC2Generator(AWSGenerator):
                 row["lineItem/LineItemType"] = "SavingsPlanRecurringFee"
                 row["lineItem/LineItemDescription"] = "3 year No Upfront Compute Savings Plan"
                 row["lineItem/UsageType"] = "ComputeSP:3yrNoUpfront"
+
             else:  # upfront
+                row["lineItem/LineItemType"] = "SavingsPlanUpfrontFee"
                 row[
                     "lineItem/LineItemDescription"
                 ] = f"USD {cost} one-time fee for 1 year All Upfront Compute Savings Plan ID: 123456"
-                row["lineItem/LineItemType"] = "SavingsPlanUpfrontFee"
                 row["lineItem/UsageType"] = "ComputeSP:1yrAllUpfront"
                 row["lineItem/UsageEndDate"] = start + relativedelta(years=+1)
                 end_upfront = start + relativedelta(years=+1)

--- a/tests/test_aws_generator.py
+++ b/tests/test_aws_generator.py
@@ -396,6 +396,8 @@ class TestEC2Generator(AWSGeneratorTestCase):
             "saving": "1",
             "amount": 1,
             "reserved_instance": False,
+            "upfront_fee": False,
+            "recurring_fee": False,
             "negation": False,
         }
         self.attributes["instance_type"] = self.instance_type
@@ -432,6 +434,30 @@ class TestEC2Generator(AWSGeneratorTestCase):
 
         self.assertEqual(row["lineItem/LineItemType"], "DiscountedUsage")
         self.assertEqual(row["lineItem/UnblendedCost"], 0)
+
+    def test_update_data_ec2_upfront_fee(self):
+        """Test EC2 specific update data for Upfront fee."""
+        self.instance_type = {"upfront_fee": True}
+        self.attributes["instance_type"] = self.instance_type
+        generator = EC2Generator(
+            self.two_hours_ago, self.now, self.currency, self.payer_account, self.usage_accounts, self.attributes
+        )
+        start_row = {}
+        row = generator._update_data(start_row, self.two_hours_ago, self.now)
+
+        self.assertEqual(row["lineItem/LineItemType"], "SavingsPlanUpfrontFee")
+
+    def test_update_data_ec2_recurring_fee(self):
+        """Test EC2 specific update data for Recurring fee."""
+        self.instance_type = {"recurring_fee": True}
+        self.attributes["instance_type"] = self.instance_type
+        generator = EC2Generator(
+            self.two_hours_ago, self.now, self.currency, self.payer_account, self.usage_accounts, self.attributes
+        )
+        start_row = {}
+        row = generator._update_data(start_row, self.two_hours_ago, self.now)
+
+        self.assertEqual(row["lineItem/LineItemType"], "SavingsPlanRecurringFee")
 
     def test_update_data(self):
         """Test EBS specific update data method."""


### PR DESCRIPTION
## Summary by Sourcery

Add support for AWS Savings Plan Upfront and Recurring fees in the EC2 generator

New Features:
- Implement support for AWS Savings Plan Upfront fees in the EC2 cost generator
- Add support for AWS Savings Plan Recurring fees in the EC2 cost generator

Enhancements:
- Extend the EC2 generator to handle additional Savings Plan fee types
- Update the data generation logic to support more AWS billing scenarios

Tests:
- Add test cases for Savings Plan Upfront fee generation
- Add test cases for Savings Plan Recurring fee generation