### PR TITLE
[COST-6158] - Fix ec2 tags (regression)

### DIFF
--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.7.3"
+__version__ = "4.7.4"
 
 
 VERSION = __version__.split(".")

--- a/nise/generators/aws/ec2_generator.py
+++ b/nise/generators/aws/ec2_generator.py
@@ -237,7 +237,7 @@ class EC2Generator(AWSGenerator):
         if saving is not None:
             row["lineItem/LineItemType"] = "SavingsPlanCoveredUsage"
         # Overwrite lineitem/LineItemType for RI's discount usage
-        elif reserved_instance:
+        if reserved_instance:
             row["lineItem/LineItemType"] = "DiscountedUsage"
             row["lineItem/UnblendedCost"] = 0
             row["lineItem/UnblendedRate"] = 0
@@ -249,7 +249,7 @@ class EC2Generator(AWSGenerator):
             row["savingsPlan/SavingsPlanEffectiveCost"] = None
             row["savingsPlan/SavingsPlanRate"] = None
 
-        elif negation:
+        if negation:
             row["lineItem/LineItemType"] = "SavingsPlanNegation"
             row["lineItem/UnblendedCost"] = -abs(cost)
             row["lineItem/UnblendedRate"] = -abs(rate)
@@ -262,8 +262,12 @@ class EC2Generator(AWSGenerator):
             row["savingsPlan/SavingsPlanEffectiveCost"] = None
             row["savingsPlan/SavingsPlanRate"] = None
 
+        else:
+            self._add_tag_data(row)
+            self._add_category_data(row)
+
         # Overwrite lineitem/LineItemType for Savings plan upfront and recurring fees
-        elif recurring_fee or upfront_fee:
+        if recurring_fee or upfront_fee:
             if recurring_fee:
                 row["lineItem/LineItemType"] = "SavingsPlanRecurringFee"
                 row["lineItem/LineItemDescription"] = "3 year No Upfront Compute Savings Plan"
@@ -292,10 +296,6 @@ class EC2Generator(AWSGenerator):
             row["savingsPlan/SavingsPlanEffectiveCost"] = None
             row["savingsPlan/SavingsPlanRate"] = None
             row["product/operatingSystem"] = None
-
-        else:
-            self._add_tag_data(row)
-            self._add_category_data(row)
 
         return row
 


### PR DESCRIPTION
Fixing regression introduced by https://github.com/project-koku/nise/pull/544

## Summary by Sourcery

Fix a regression in EC2 tag handling by restructuring the conditional logic in the data update method

Bug Fixes:
- Corrected the logic for adding tag and category data in EC2 generator to ensure tags are properly added in all scenarios

Enhancements:
- Refactored the conditional branches in the _update_data method to improve tag and category data handling

Chores:
- Bumped package version from 4.7.3 to 4.7.4