### PR TITLE
fix publish action

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -30,6 +30,7 @@ jobs:
           UV_PUBLISH_TOKEN: ${{ secrets.pypi_password }}
         run: |
           set -e
+          uv venv
           uv pip install hatch
           VERSION=$(uv run hatch version)
           if [ ! -z $(git tag -l "${VERSION}") ]; then

--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.7.4"
+__version__ = "4.7.5"
 
 
 VERSION = __version__.split(".")


### PR DESCRIPTION
* Run `uv venv` to create a virtual env to install packages during the build and publish action.

See:
https://github.com/project-koku/nise/actions/runs/14642400445/job/41087763409

## Summary by Sourcery

Update publish action to use `uv venv` for creating a virtual environment during package build and publish process

Bug Fixes:
- Improve package publishing workflow by ensuring a clean virtual environment is created before package installation

CI:
- Modified publish-to-pypi workflow to add `uv venv` step before package installation

Chores:
- Bump package version from 4.7.4 to 4.7.5