### PR TITLE
one more fix for publish action

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -26,7 +26,6 @@ jobs:
       - name: Build and publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          UV_PUBLISH_USERNAME: __token__
           UV_PUBLISH_TOKEN: ${{ secrets.pypi_password }}
         run: |
           set -e


### PR DESCRIPTION
* remove username from publish action

See:
https://github.com/project-koku/nise/actions/runs/14643012061/job/41089829883

## Summary by Sourcery

CI:
- Simplified PyPI publish action by removing the hardcoded username environment variable