### PR TITLE
[COST-6270] Add ability to assign user to generator

### DIFF
--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "5.0.0"
+__version__ = "5.0.1"
 
 
 VERSION = __version__.split(".")

--- a/nise/generators/aws/aws_generator.py
+++ b/nise/generators/aws/aws_generator.py
@@ -342,7 +342,10 @@ class AWSGenerator(AbstractGenerator):
 
     def _add_common_usage_info(self, row, start, end, **kwargs):
         """Add common usage information."""
-        row["lineItem/UsageAccountId"] = choice(self.usage_accounts)
+        if user_account := self.attributes.get("user"):
+            row["lineItem/UsageAccountId"] = user_account
+        else:
+            row["lineItem/UsageAccountId"] = choice(self.usage_accounts)
         row["lineItem/LineItemType"] = "Usage"
         row["lineItem/UsageStartDate"] = start
         row["lineItem/UsageEndDate"] = end

--- a/nise/report.py
+++ b/nise/report.py
@@ -390,7 +390,7 @@ def _aws_finalize_report(data, static_data=None):
     return data
 
 
-def _generate_accounts(static_report_data=None):
+def _generate_aws_account_info(static_report_data=None):
     """Generate payer and usage accounts."""
     if static_report_data:
         payer_account = static_report_data.get("payer")
@@ -618,7 +618,7 @@ def aws_create_report(options):  # noqa: C901
 
     months = _create_month_list(start_date, end_date)
 
-    payer_account, usage_accounts, currency_code = _generate_accounts(accounts_list)
+    payer_account, usage_accounts, currency_code = _generate_aws_account_info(accounts_list)
     currency_code = default_currency(options.get("currency"), currency_code)
 
     aws_bucket_name = options.get("aws_bucket_name")

--- a/tests/test_aws_generator.py
+++ b/tests/test_aws_generator.py
@@ -171,6 +171,19 @@ class AbstractGeneratorTestCase(TestCase):
         legal_entity = generator._get_legal_entity()
         self.assertEqual(legal_entity, "Corey")
 
+    def test_add_common_usage_info(self):
+        """Test that add_common_usage_info updates usage timestamps."""
+        expected_usage_account = "Cody"
+        two_hours_ago = (self.now - self.one_hour) - self.one_hour
+        generator = TestGenerator(
+            two_hours_ago,
+            self.now,
+            self.currency,
+            self.payer_account,
+            self.usage_accounts,
+            {"user": "Cody"})
+        row = generator._add_common_usage_info({}, two_hours_ago, self.now)
+        self.assertEqual(row.get("lineItem/UsageAccountId"), expected_usage_account)
 
 class AWSGeneratorTestCase(TestCase):
     """Test Base for specific generator classes."""
@@ -212,6 +225,7 @@ class AWSGeneratorTestCase(TestCase):
         self.disk_size = 10
         self.currency = "USD"
         self.legal_entity = "Red Hat"
+        self.user_account = "0000000000"
         self.attributes = {
             "product_sku": self.product_sku,
             "tags": self.tags,

--- a/tests/test_aws_generator.py
+++ b/tests/test_aws_generator.py
@@ -176,14 +176,11 @@ class AbstractGeneratorTestCase(TestCase):
         expected_usage_account = "Cody"
         two_hours_ago = (self.now - self.one_hour) - self.one_hour
         generator = TestGenerator(
-            two_hours_ago,
-            self.now,
-            self.currency,
-            self.payer_account,
-            self.usage_accounts,
-            {"user": "Cody"})
+            two_hours_ago, self.now, self.currency, self.payer_account, self.usage_accounts, {"user": "Cody"}
+        )
         row = generator._add_common_usage_info({}, two_hours_ago, self.now)
         self.assertEqual(row.get("lineItem/UsageAccountId"), expected_usage_account)
+
 
 class AWSGeneratorTestCase(TestCase):
     """Test Base for specific generator classes."""


### PR DESCRIPTION
Our current Nise yaml structure lets you do: 
```
  user:
    - 9999999999999
    - 9999999999998
    - 9999999999997
 ```
 
However, this just results to each individual hour in the generator being randomly selected from this list. In order to replicate the issue I am seeing I need to be able to create a 1 to 1 relationship between the resource and the usage account. To do this I just added the ability to set and use the user at the attribute level:

Example:

```
- EC2Generator:
      start_date: last_month
      processor_arch: 64-bit
      product_sku: VEAJHRNKTJZA
      region: us-east-1b
      operating_system: "Amazon Linux"
      resource_id: "9999999999999"
      user: 9999999999999
```

Testing:
- I need to create the koku pr and link its instructions here.

## Summary by Sourcery

Add the ability to specify a specific usage account for a generator in AWS report generation

New Features:
- Allow setting a specific user/usage account at the generator attribute level

Bug Fixes:
- Ensure user-specified account takes precedence over random account selection

Enhancements:
- Modify AWS generator to support explicit user account assignment

Tests:
- Add test case for user account assignment in generator

Chores:
- Bump version from 5.0.0 to 5.0.1