### PR TITLE
Add exceptions to .gitignore for build files in Nise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,10 @@ venv.bak/
 # Generated .json
 *.json
 
+# EXCEPTIONS (files that must go into builds)
+!nise/aws-template-manifest.json
+!nise/yaml_generators/static/*.json
+
 # Mac OSX
 .DS_Store
 


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Add project-specific build file exceptions to version control ignore list