### PR TITLE
[COST-6097] - utilize cpu_limit/cpu_request in VM static

### DIFF
--- a/example_ocp_static_data.yml
+++ b/example_ocp_static_data.yml
@@ -64,8 +64,8 @@ generators:
                 - virtual_machine:
                   vm_name: my_big_beautiful_vm_name
                   cpu_cores: 10
-                  cpu_limit_cores: 5
-                  cpu_request_cores: 4
+                  cpu_limit: 5  # corresponds to cpu_limit_cores
+                  cpu_request: 4  # corresponds to cpu_request_cores
                   cpu_request_sockets: 3
                   cpu_request_threads: 2
                   cpu_usage:

--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "5.1.1"
+__version__ = "5.1.2"
 
 
 VERSION = __version__.split(".")

--- a/nise/generators/ocp/ocp_generator.py
+++ b/nise/generators/ocp/ocp_generator.py
@@ -665,6 +665,8 @@ class OCPGenerator(AbstractGenerator):
                             continue
                         pod_copy = deepcopy(specified_pod)
                         pod_copy["vm_name"] = vm
+                        if vm_seconds := pod_copy.get("pod_seconds"):
+                            pod_copy["vm_seconds"] = vm_seconds
                         vms.append(pod_copy)
                         node["namespaces"][namespace]["virtual_machines"] = vms
             else:
@@ -917,7 +919,6 @@ class OCPGenerator(AbstractGenerator):
                             "resource_id": node.get("resource_id"),
                             "namespace": namespace,
                             "vm_name": vm,
-                            "vm_uptime_total_seconds": ("some number between 0 and 60"),
                             "vm_cpu_limit_cores": cpu_limit_cores,
                             "vm_cpu_request_cores": cpu_request_cores,
                             "vm_cpu_request_sockets": cpu_request_sockets,
@@ -956,7 +957,6 @@ class OCPGenerator(AbstractGenerator):
                             "resource_id": node.get("resource_id"),
                             "namespace": namespace,
                             "vm_name": vm,
-                            "vm_uptime_total_seconds": ("some number between 0 and 60"),
                             "vm_cpu_limit_cores": cpu_limit_cores,
                             "vm_cpu_request_cores": cpu_request_cores,
                             "vm_cpu_request_sockets": cpu_request_sockets,
@@ -977,6 +977,8 @@ class OCPGenerator(AbstractGenerator):
                     # create pod corresponding to VM since it does not exist
                     vm_copy["pod_name"] = vm
                     vm_copy["labels"] = f"label_vm_kubevirt_io_name:{vm}"
+                    if pod_seconds := vm_copy.get("vm_seconds"):
+                        vm_copy["pod_seconds"] = pod_seconds
                     pod_name, pod, ros_pod = self._gen_specific_pod(node, namespace, vm_copy)
                     self.pods[pod_name] = pod
                     self.ros_data[pod_name] = ros_pod

--- a/nise/generators/ocp/ocp_generator.py
+++ b/nise/generators/ocp/ocp_generator.py
@@ -883,9 +883,9 @@ class OCPGenerator(AbstractGenerator):
                     cpu_cores = node.get("cpu_cores")
                     memory_bytes = node.get("memory_bytes")
 
-                    cpu_limit_cores = min(specified_vm.get("cpu_limit_cores", cpu_cores), cpu_cores)
+                    cpu_limit_cores = min(specified_vm.get("cpu_limit", cpu_cores), cpu_cores)
                     cpu_request_cores = min(
-                        specified_vm.get("cpu_request_cores", round(uniform(0.02, cpu_limit_cores), 5)),
+                        specified_vm.get("cpu_request", round(uniform(0.02, cpu_limit_cores), 5)),
                         cpu_limit_cores,
                     )
                     cpu_request_sockets = min(


### PR DESCRIPTION
## Summary by Sourcery

Adopt consistent cpu_limit/cpu_request naming in VM static data, propagate pod_seconds through VM generation, remove placeholder uptime, update example config, and bump version

Enhancements:
- Switch VM spec fields from cpu_limit_cores/cpu_request_cores to cpu_limit/cpu_request
- Propagate pod_seconds to vm_seconds when generating pods and back to pod_seconds for VM-derived pods
- Remove placeholder vm_uptime_total_seconds entries from VM metadata

Documentation:
- Update example_ocp_static_data.yml to use new cpu_limit and cpu_request keys

Chores:
- Bump version to 5.1.2