### PR TITLE
[COST-4173] Add file row limit for Azure and GCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ All of the deployment is driven entirely by a Github Action workflow, so if issu
                                                     AWS/GCP/OCP: today at 23:59
                                                     Azure: now() + 24 hours
         -w, --write-monthly                     optional, keep the generated report files in the local dir.
-        --file-row-limit ROW_LIMIT              optional, default is 1,000,000. AWS and OCP only. Multiple reports
+        --file-row-limit ROW_LIMIT              optional, default is 1,000,000. Multiple reports
                                                 will be generated with line counts not exceeding the ROW_LIMIT.
         --static-report-file YAML_NAME          optional, static report generation based on specified yaml file.
                                                 See example_[provider]_static_data.yml for examples.

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ All of the deployment is driven entirely by a Github Action workflow, so if issu
                                                     AWS/GCP/OCP: today at 23:59
                                                     Azure: now() + 24 hours
         -w, --write-monthly                     optional, keep the generated report files in the local dir.
-        --file-row-limit ROW_LIMIT              optional, default is 100,000. AWS and OCP only. Multiple reports
+        --file-row-limit ROW_LIMIT              optional, default is 1,000,000. AWS and OCP only. Multiple reports
                                                 will be generated with line counts not exceeding the ROW_LIMIT.
         --static-report-file YAML_NAME          optional, static report generation based on specified yaml file.
                                                 See example_[provider]_static_data.yml for examples.

--- a/docs/cost_usage_report_generation.md
+++ b/docs/cost_usage_report_generation.md
@@ -12,7 +12,7 @@
                                                     AWS/GCP/OCP: today at 23:59
                                                     Azure: now() + 24 hours
         -w, --write-monthly                     optional, keep the generated report files in the local dir.
-        --file-row-limit ROW_LIMIT              optional, default is 100,000. AWS and OCP only. Multiple reports
+        --file-row-limit ROW_LIMIT              optional, default is 1,000,000. AWS and OCP only. Multiple reports
                                                 will be generated with line counts not exceeding the ROW_LIMIT.
         --static-report-file YAML_NAME          optional, static report generation based on specified yaml file.
                                                 See example_[provider]_static_data.yml for examples.

--- a/docs/cost_usage_report_generation.md
+++ b/docs/cost_usage_report_generation.md
@@ -12,7 +12,7 @@
                                                     AWS/GCP/OCP: today at 23:59
                                                     Azure: now() + 24 hours
         -w, --write-monthly                     optional, keep the generated report files in the local dir.
-        --file-row-limit ROW_LIMIT              optional, default is 1,000,000. AWS and OCP only. Multiple reports
+        --file-row-limit ROW_LIMIT              optional, default is 1,000,000. Multiple reports
                                                 will be generated with line counts not exceeding the ROW_LIMIT.
         --static-report-file YAML_NAME          optional, static report generation based on specified yaml file.
                                                 See example_[provider]_static_data.yml for examples.

--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "5.1.3"
+__version__ = "5.1.4"
 
 
 VERSION = __version__.split(".")

--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "5.1.2"
+__version__ = "5.1.3"
 
 
 VERSION = __version__.split(".")

--- a/nise/__main__.py
+++ b/nise/__main__.py
@@ -357,8 +357,8 @@ def create_parser():
         dest="row_limit",
         required=False,
         type=int,
-        default=100000,
-        help="Maximum number of lines per report file. Default is 100000.",
+        default=1_000_000,
+        help="Maximum number of lines per report file. Default is 1,000,000.",
     )
     parent_parser.add_argument(
         "--static-report-file", dest="static_report_file", required=False, help="Generate static data based on yaml."

--- a/nise/report.py
+++ b/nise/report.py
@@ -734,7 +734,9 @@ def azure_create_report(options):  # noqa: C901
     """Create a cost usage report file."""
     start_date = options.get("start_date")
     end_date = options.get("end_date")
-    row_limit = options.get("row_limit", 100000)
+    row_limit = options.get("row_limit")
+    if not row_limit:
+        row_limit = 10_000_000  # to avoid unintended splitting when flag is not passed
     static_report_data = options.get("static_report_data")
     if static_report_data:
         generators = _get_generators(static_report_data.get("generators"))
@@ -1183,7 +1185,9 @@ def gcp_create_report(options):  # noqa: C901
         months = _create_month_list(start_date, end_date)
         monthly_files = []
         output_files = []
-        row_limit = options.get("row_limit", 100000)
+        row_limit = options.get("row_limit")
+        if not row_limit:
+            row_limit = 10_000_000  # to avoid unintended splitting when flag is not passed
         file_number = 0
         for month in months:
             data = []

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1324,7 +1324,9 @@ class AzureReportTestCase(TestCase):
 
     def setUp(self):
         """Setup shared variables for AzureReportTestCase."""
-        self.MOCK_AZURE_REPORT_FILENAME = f"{os.getcwd()}/costreport_12345678-1234-5678-1234-567812345678.csv"
+        self.MOCK_AZURE_REPORT_FILENAME = os.path.join(
+            os.getcwd(), "costreport_12345678-1234-5678-1234-567812345678_0001.csv"
+        )
 
     @staticmethod
     def mock_generate_azure_filename(file_number):
@@ -1486,7 +1488,7 @@ class GCPReportTestCase(TestCase):
         options = {"start_date": yesterday, "end_date": now, "gcp_report_prefix": report_prefix, "write_monthly": True}
         fix_dates(options, "gcp")
         gcp_create_report(options)
-        output_file_name = f"{report_prefix}.csv"
+        output_file_name = f"{report_prefix}_0001.csv"
         expected_output_file_path = f"{os.getcwd()}/{output_file_name}"
 
         self.assertTrue(os.path.isfile(expected_output_file_path))
@@ -1576,7 +1578,7 @@ class GCPReportTestCase(TestCase):
         invoice_month = yesterday.strftime("%Y%m")
         scan_start = yesterday.date()
         scan_end = now.date()
-        expected_file_name = f"{invoice_month}_{patch_etag.return_value}_{scan_start}:{scan_end}.csv"
+        expected_file_name = f"{invoice_month}_{patch_etag.return_value}_{scan_start}:{scan_end}_0001.csv"
         expected_output_file_path = f"{os.getcwd()}/{expected_file_name}"
         self.assertTrue(os.path.isfile(expected_output_file_path))
         os.remove(expected_output_file_path)
@@ -1616,8 +1618,7 @@ class GCPReportTestCase(TestCase):
         fix_dates(options, "gcp")
         gcp_create_report(options)
         output_file_name = "{}-{}.csv".format(report_prefix, yesterday.strftime("%Y-%m-%d"))
-        expected_output_file_path = f"{os.getcwd()}/{output_file_name}"
-
+        expected_output_file_path = f"{os.getcwd()}/{output_file_name}_0001.csv"
         self.assertFalse(os.path.isfile(expected_output_file_path))
 
     def test_gcp_create_report_without_write_monthly_overlapping_month(self):

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1473,6 +1473,23 @@ class AzureReportTestCase(TestCase):
         local_path = self.MOCK_AZURE_REPORT_FILENAME
         self.assertFalse(os.path.isfile(local_path))
 
+    def test_azure_report_file_row_limit(self):
+        """Test Azure report splits files based on file_row_limit."""
+        now = datetime.datetime.now().replace(microsecond=0, second=0, minute=0, hour=0)
+        one_day = datetime.timedelta(days=1)
+        yesterday = now - one_day
+
+        options = {"start_date": yesterday, "end_date": now, "write_monthly": True, "row_limit": 10}
+
+        fix_dates(options, "azure")
+        azure_create_report(options)
+
+        files = [f for f in os.listdir(os.getcwd()) if re.match(r"^[\w-]+_\d{4}\.csv$", f)]
+        self.assertGreater(len(files), 1)
+
+        for f in files:
+            os.remove(f)
+
 
 class GCPReportTestCase(TestCase):
     """
@@ -1758,3 +1775,26 @@ class GCPReportTestCase(TestCase):
         expected_output_file_path = f"{os.getcwd()}/{output_file_name}"
 
         self.assertFalse(os.path.isfile(expected_output_file_path))
+
+    def test_gcp_report_file_row_limit(self):
+        """Test GCP report splits files based on file_row_limit."""
+        now = datetime.datetime.now().replace(microsecond=0, second=0, minute=0, hour=0)
+        one_day = datetime.timedelta(days=1)
+        yesterday = now - one_day
+
+        options = {
+            "start_date": yesterday,
+            "end_date": now,
+            "gcp_report_prefix": "test_report_gcp",
+            "write_monthly": True,
+            "row_limit": 10,  # força múltiplos arquivos
+        }
+
+        fix_dates(options, "gcp")
+        gcp_create_report(options)
+
+        files = [f for f in os.listdir(os.getcwd()) if re.match(r"^[\w-]+_\d{4}\.csv$", f)]
+        self.assertGreater(len(files), 1)
+
+        for f in files:
+            os.remove(f)

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1787,7 +1787,7 @@ class GCPReportTestCase(TestCase):
             "end_date": now,
             "gcp_report_prefix": "test_report_gcp",
             "write_monthly": True,
-            "row_limit": 10,  # força múltiplos arquivos
+            "row_limit": 10,
         }
 
         fix_dates(options, "gcp")

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1770,7 +1770,7 @@ class GCPReportTestCase(TestCase):
         yesterday = now - one_day
         report_prefix = "test_resource_report"
         data = [{"resource.name": "Baked", "resource.global_name": "Beans"}]
-        write_gcp_file(yesterday, now, data, {"gcp_report_prefix": report_prefix, "gcp_resource_level": True})
+        write_gcp_file(yesterday, now, data, {"gcp_report_prefix": report_prefix, "gcp_resource_level": True}, 1)
         output_file_name = "{}-{}.csv".format(report_prefix, yesterday.strftime("%Y-%m-%d"))
         expected_output_file_path = f"{os.getcwd()}/{output_file_name}"
 

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1327,19 +1327,20 @@ class AzureReportTestCase(TestCase):
         self.MOCK_AZURE_REPORT_FILENAME = f"{os.getcwd()}/costreport_12345678-1234-5678-1234-567812345678.csv"
 
     @staticmethod
-    def mock_generate_azure_filename():
-        """Create a fake azure filename."""
+    def mock_generate_azure_filename(file_number):
+        """Create a fake azure filename with file number."""
         fake_uuid = "12345678-1234-5678-1234-567812345678"
-        output_file_name = "{}_{}".format("costreport", fake_uuid)
-        local_path = f"{os.getcwd()}/{output_file_name}.csv"
-        output_file_name = output_file_name + ".csv"
+        suffix = f"{file_number:04d}"
+        output_file_name = f"costreport_{fake_uuid}_{suffix}.csv"
+        local_path = os.path.join(os.getcwd(), output_file_name)
         return local_path, output_file_name
 
     def test_generate_azure_filename(self):
         """Test that _generate_azure_filename returns not empty tuple."""
-        tup = _generate_azure_filename()
+        tup = _generate_azure_filename(1)
         self.assertIsNotNone(tup[0])
         self.assertIsNotNone(tup[1])
+        self.assertTrue(tup[1].endswith("_0001.csv"))
 
     @patch("nise.report._generate_azure_filename")
     def test_azure_create_report(self, mock_name):
@@ -1738,7 +1739,7 @@ class GCPReportTestCase(TestCase):
         }
         fix_dates(options, "gcp")
         gcp_create_report(options)
-        output_file_name = f"{report_prefix}.csv"
+        output_file_name = f"{report_prefix}_0001.csv"
         expected_output_file_path = f"{os.getcwd()}/{output_file_name}"
 
         self.assertTrue(os.path.isfile(expected_output_file_path))


### PR DESCRIPTION
# Testing instructions
1. Generate a single file (to double-check if everything is working as expected):

GCP:
`uv run nise report gcp --start-date 2024-01-01 --end-date 2024-01-02 --gcp-bucket-name ./out --write-monthly`

Azure:
`uv run nise report azure --start-date 2024-01-01 --end-date 2024-01-02 --write-monthly`

2. Run the command with the new `--file-row-limit` flag to split the output into multiple files. The `--file-row-limit` flag defines the maximum number of rows per CSV file. The tool will automatically split the report into multiple files if the total number of generated rows exceeds this limit. 

To test it, set the limit low enough so that multiple files are guaranteed to be created. 

For example, if your first file (Step 1) has 100 rows, set `--file-row-limit 50` and you should see 2 files with up to 50 rows each.

GCP:
`uv run nise report gcp --start-date 2024-01-01 --end-date 2024-01-02 --gcp-bucket-name ./out --write-monthly --file-row-limit 50`

Azure:
`uv run nise report azure --start-date 2024-01-01 --end-date 2024-01-02 --write-monthly --file-row-limit 50`

3. Verify the output:
The number of CSV files generated should reflect the total number of rows divided by the `--file-row-limit` value.

## Summary by Sourcery

Implement file row limit splitting for GCP and Azure reports with a new `--file-row-limit` option

New Features:
- Add `--file-row-limit` flag to specify maximum rows per CSV file
- Split Azure report into multiple CSV files when the row limit is reached and upload each chunk
- Split GCP report into multiple CSV files when the row limit is reached and upload each chunk

Enhancements:
- Refactor Azure and GCP filename generators to include file sequence suffix