### PR TITLE
fix pvc capacity when using static file

### DIFF
--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "5.1.2"
+__version__ = "5.1.3"
 
 
 VERSION = __version__.split(".")

--- a/tests/test_ocp_generator.py
+++ b/tests/test_ocp_generator.py
@@ -490,6 +490,44 @@ class OCPGeneratorTestCase(TestCase):
                                             self.assertLessEqual(value * GIGABYTE, capacity)
                             self.assertLessEqual(total_capacity, volume.get("volume_request", MAX_VOL_GIGS * GIGABYTE))
 
+    def test_gen_specific_volume_raises_valueerror_when_claims_exceed_request(self):
+        """Test that _gen_specific_volume raises ValueError when total claims exceed volume request."""
+        generator = OCPGenerator(self.two_hours_ago, self.now, {})
+
+        # Create a fake node and namespace
+        node = {"name": "test-node"}
+        namespace = "test-namespace"
+
+        # Create a volume specification where volume claims exceed the volume request
+        specified_volume = {
+            "volume_name": "test-volume",
+            "volume_request_gig": 10,  # 10 GiB volume request
+            "volume_claims": [
+                {
+                    "volume_claim_name": "claim1",
+                    "pod_name": "pod1",
+                    "capacity_gig": 8,  # 8 GiB claim
+                },
+                {
+                    "volume_claim_name": "claim2",
+                    "pod_name": "pod2",
+                    "capacity_gig": 5,  # 5 GiB claim - total 13 GiB > 10 GiB request
+                },
+            ],
+        }
+
+        # Verify that ValueError is raised with expected message
+        with self.assertRaises(ValueError) as context:
+            generator._gen_specific_volume(node, namespace, specified_volume)
+
+        expected_total_claims = (8 + 5) * GIGABYTE  # 13 GiB in bytes
+        expected_volume_request = 10 * GIGABYTE  # 10 GiB in bytes
+        expected_message = (
+            f"Total claims {expected_total_claims} is greater than volume request {expected_volume_request}"
+        )
+
+        self.assertEqual(str(context.exception), expected_message)
+
     def test_generate_hourly_data(self):
         """Test that generate_hourly_data calls the test method."""
         generator = OCPGenerator(self.two_hours_ago, self.now, self.attributes)

--- a/tests/test_ocp_generator.py
+++ b/tests/test_ocp_generator.py
@@ -93,12 +93,12 @@ class OCPGeneratorTestCase(TestCase):
                             "volumes": [
                                 {
                                     "volume_name": f"vol_{self.fake.word()}",
-                                    "volume_request_gig": self.fake.pyint(1, MAX_VOL_GIGS),
+                                    "volume_request_gig": self.fake.pyint(50, MAX_VOL_GIGS),
                                     "volume_claims": [
                                         {
                                             "volume_claim_name": f"volumeclaim_{self.fake.word()}",
                                             "pod_name": f"pod_{self.fake.word()}",
-                                            "capacity_gig": self.fake.pyint(1, MAX_VOL_GIGS),
+                                            "capacity_gig": self.fake.pyint(1, 50),
                                             "volume_claim_usage_gig": self._usage_dict(),
                                             "labels": (
                                                 f"label_{self.fake.word()}:{self.fake.word()}"


### PR DESCRIPTION
## Summary by Sourcery

Enforce strict capacity validation for specific volumes and fix capacity computation in storage updates

Bug Fixes:
- Correct vc_capacity_gig calculation to use only the provided vc_capacity

Enhancements:
- Raise ValueError in _gen_specific_volume when total claims exceed the volume request

Tests:
- Add a test to verify that exceeding volume claims triggers a ValueError