### PR TITLE
Cost 6566

### DIFF
--- a/example_ocp_static_data.yml
+++ b/example_ocp_static_data.yml
@@ -10,6 +10,8 @@ generators:
           memory_gig: 16
           resource_id: 55555555
           namespaces:
+            Empty_namespace:
+            # This will generate a namespace with no running pods, It's also possible to define namespace labels if desired.
             openshift-kube-controller-manager-operator:
               namespace_labels: label_key1:label_value1|label_key2:label_value2
               pods:

--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "5.1.4"
+__version__ = "5.1.5"
 
 
 VERSION = __version__.split(".")

--- a/nise/generators/ocp/ocp_generator.py
+++ b/nise/generators/ocp/ocp_generator.py
@@ -476,12 +476,16 @@ class OCPGenerator(AbstractGenerator):
                 memory_gig = item.get("memory_gig", randint(2, 8))
                 memory_bytes = memory_gig * GIGABYTE
                 resource_id = str(item.get("resource_id", self.fake.word()))
+                # This allows empty namespaces to be defined
+                processed_namespaces = {
+                    ns_name: ({} if ns_data is None else ns_data) for ns_name, ns_data in item.get("namespaces").items()
+                }
                 node = {
                     "name": item.get("node_name", "node_" + self.fake.word()),
                     "cpu_cores": item.get("cpu_cores", randint(2, 16)),
                     "memory_bytes": memory_bytes,
                     "resource_id": "i-" + resource_id,
-                    "namespaces": item.get("namespaces"),
+                    "namespaces": processed_namespaces,
                     "node_labels": item.get("node_labels"),
                 }
                 nodes.append(node)


### PR DESCRIPTION
You can technically generate empty namespaces today using static yamls by doing the following

```
namespaces:
    Empty_namespace:
        pods:
```
However its potentially a little confusing to define and empty namespace with an empty `pods` section.

The change now allows you to define a namespace with no content entirely.


# Testing

1. Checkout main
2. update your local static yaml file with an empty namespace (See example)
```
---
generators:
  - OCPGenerator:
      nodes:
        - node:
          node_name: test_node
          cpu_cores: 10
          memory_gig: 10
          namespaces:
            test_empty:
```
3. Run `nise -lll report ocp --ocp-cluster-id test_cluster --static-report-file /home/my-static-file.yml --write-monthly` (update the static file location)
4. See error raised
5. Checkout this branch
6. rerun nise command
7. You should have files generated correctly
8. Look at your namespace_labels file, see `test_empty` namespace is added and additionally look at other files and see no pods, volumes and/or vms have been generated for your namespace.


