### PR TITLE
[COST-6499] do not automatically create PVC for each VM

### DIFF
--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "5.1.7"
+__version__ = "5.1.8"
 
 
 VERSION = __version__.split(".")

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ skipsdist = True
 
 [testenv]
 runner = uv-venv-lock-runner
-extras =
+dependency_groups =
   dev
 allowlist_externals=
   /bin/sh


### PR DESCRIPTION
## Summary by Sourcery

Prevent automatic PVC creation for each virtual machine by introducing a static_report flag, refining PVC handling within VM generation, and updating related data calculations while expanding test coverage and bumping the library version.

Enhancements:
- Add static_report option to get_vm_disk to suppress default PVC creation
- Prevent automatic PVC creation during VM generation by passing static_report to get_vm_disk and skipping existing PVCs
- Update update_vm_data to only compute disk_allocated_size_byte_seconds when vc_capacity is provided

Build:
- Bump version to 5.1.8
- Replace extras with dependency_groups in tox.ini

Tests:
- Add comprehensive tests for various get_vm_disk scenarios, including default behavior, specified settings, pod-based PVC lookup, fallback logic, and capacity range