### PR TITLE
[COST-6643] limit length of cluster-id

### DIFF
--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "5.1.9"
+__version__ = "5.1.10"
 
 
 VERSION = __version__.split(".")

--- a/nise/__main__.py
+++ b/nise/__main__.py
@@ -261,6 +261,13 @@ def add_gcp_parser_args(parser):
     )
 
 
+def length_of_cluster_id(cluster_id):
+    """Check the length of the cluster id."""
+    if len(cluster_id) > 50:
+        raise argparse.ArgumentTypeError("--ocp-cluster-id must be less than 50 characters long.")
+    return cluster_id
+
+
 def add_ocp_parser_args(parser):
     """Add OCP sub-parser args."""
     parser.add_argument(
@@ -269,6 +276,7 @@ def add_ocp_parser_args(parser):
         dest="ocp_cluster_id",
         required=False,
         help="Cluster identifier for usage data.",
+        type=length_of_cluster_id,
     )
     parser.add_argument(
         "--insights-upload",
@@ -535,9 +543,7 @@ def _validate_ocp_arguments(parser, options):
 
     ocp_cluster_id, insights_upload, minio_upload, payload_name = _get_ocp_options(options)
     if ocp_cluster_id is None:
-        msg = "{} must be supplied."
-        msg = msg.format("--ocp-cluster-id")
-        parser.error(msg)
+        parser.error("--ocp-cluster-id must be supplied.")
     elif insights_upload is not None and not os.path.isdir(insights_upload):
         insights_user = os.environ.get("INSIGHTS_USER")
         insights_password = os.environ.get("INSIGHTS_PASSWORD")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -28,6 +28,7 @@ from unittest.mock import patch
 from nise.__main__ import _load_static_report_data
 from nise.__main__ import _validate_provider_inputs
 from nise.__main__ import create_parser
+from nise.__main__ import length_of_cluster_id
 from nise.__main__ import main
 from nise.__main__ import run
 from nise.__main__ import valid_currency
@@ -104,6 +105,30 @@ class CommandLineTestCase(TestCase):
         test_currency = "jpy"
         out_currency = valid_currency(test_currency)
         self.assertEqual(test_currency.upper(), out_currency)
+
+    def test_length_of_cluster_id_valid(self):
+        """
+        Test length_of_cluster_id with valid cluster ID (under 50 characters).
+        """
+        test_cluster_id = "my-cluster-123"
+        result = length_of_cluster_id(test_cluster_id)
+        self.assertEqual(test_cluster_id, result)
+
+    def test_length_of_cluster_id_valid_edge_case(self):
+        """
+        Test length_of_cluster_id with exactly 50 characters (edge case).
+        """
+        test_cluster_id = "a" * 50  # exactly 50 characters
+        result = length_of_cluster_id(test_cluster_id)
+        self.assertEqual(test_cluster_id, result)
+
+    def test_length_of_cluster_id_invalid(self):
+        """
+        Test length_of_cluster_id with invalid cluster ID (over 50 characters).
+        """
+        test_cluster_id = "a" * 51  # 51 characters, should be invalid
+        with self.assertRaises(argparse.ArgumentTypeError):
+            length_of_cluster_id(test_cluster_id)
 
     def test_valid_s3_no_input(self):
         """


### PR DESCRIPTION
Real cluster-ids are UUIDs (36 char). The [cluster-id field of OCPUsageReportPeriod](https://github.com/project-koku/koku/blob/main/koku/reporting/provider/ocp/models.py#L74) has a 50 char limit, so we should disallow cluster-ids greater than 50 char in nise.

example:
```
$ uv run nise report ocp --static-report-file example_ocp_static_data.yml --ocp-cluster-id my-vm-cluster-sdfkjhfdsakhsdfkjhsdfkjhsdfkjhsadfkjhsfdkhjsdfkhsdfkjhsdfkjhsdfklsfdalkjhdf -w
usage: nise report ocp [-h] [-s YYYY-MM-DD[THH:MM:SS +0000]]
                       [-e YYYY-MM-DD[THH:MM:SS +0000]] [--file-row-limit ROW_LIMIT]
                       [--static-report-file STATIC_REPORT_FILE] [-w]
                       [--ocp-cluster-id OCP_CLUSTER_ID]
                       [--insights-upload UPLOAD_ENDPOINT]
                       [--minio-upload MINIO_UPLOAD_ENDPOINT]
                       [--payload-name PAYLOAD_NAME] [--ros-ocp-info] [--daily-reports]
                       [--constant-values-ros-ocp]
nise report ocp: error: argument --ocp-cluster-id: --ocp-cluster-id must be less than 50 characters long.
```

## Summary by Sourcery

Add a new argparse type to enforce a 50-character limit on the OCP cluster ID, integrate it into the CLI parser with improved missing-argument messaging, and include corresponding unit tests and a version bump.

New Features:
- Validate --ocp-cluster-id to ensure it is at most 50 characters long

Enhancements:
- Provide a clearer error message when --ocp-cluster-id is not supplied

Tests:
- Add unit tests for valid, edge-case, and invalid cluster ID lengths

Chores:
- Bump version to 5.1.10