### PR TITLE
[COST-6582] Add more flexibility to generation of the GCP cross over data

### DIFF
--- a/example_gcp_static_data.yml
+++ b/example_gcp_static_data.yml
@@ -11,7 +11,10 @@ generators:
       resource.name: projects/tests
       resource.global_name: //compute.googleapis.com/projects/tests
       labels: [{"environment": "ci", "project":"p1"}]
-      cross_over_data: True
+      cross_over:
+        month: current # options: current & all
+        days: [1, 2]
+        overwrite: True
   - CloudStorageGenerator:
       start_date: last_month
       price: 2
@@ -20,6 +23,9 @@ generators:
       currency: EUR
       location.region: us-east4-a
       credit_amount: -0.10
+      cross_over:
+        days: [1]
+        overwrite: False
   - GCPNetworkGenerator:
       start_date: last_month
       service.description: Cloud

--- a/example_gcp_static_data.yml
+++ b/example_gcp_static_data.yml
@@ -33,6 +33,11 @@ generators:
       usage.amount_in_pricing_units: 1
       currency: EUR
       location.region: us-east4-a
+      cross_over:
+        month: all # options: current & all
+        days: [29]
+        invoice: next
+        overwrite: True
   - GCPDatabaseGenerator:
       start_date: last_month
       service.description: Fire

--- a/example_gcp_static_data.yml
+++ b/example_gcp_static_data.yml
@@ -12,8 +12,8 @@ generators:
       resource.global_name: //compute.googleapis.com/projects/tests
       labels: [{"environment": "ci", "project":"p1"}]
       cross_over:
-        month: current # options: current & all
-        days: [1, 2]
+        month: current
+        days: [ 1 ] # shift invoice of 1st of the current month to the previous month
         overwrite: True
   - CloudStorageGenerator:
       start_date: last_month
@@ -24,7 +24,8 @@ generators:
       location.region: us-east4-a
       credit_amount: -0.10
       cross_over:
-        days: [1]
+        month: previous
+        days: [ -1, -3 ] # shift invoice of the last and 3rd to the last of previous month to the next month
         overwrite: False
   - GCPNetworkGenerator:
       start_date: last_month
@@ -34,9 +35,8 @@ generators:
       currency: EUR
       location.region: us-east4-a
       cross_over:
-        month: all # options: current & all
-        days: [29]
-        invoice: next
+        month: all
+        days: [2, -1] # on every month, shift invoice of 2nd day to previous month and invoice of the last day to the next month
         overwrite: True
   - GCPDatabaseGenerator:
       start_date: last_month

--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "5.1.12"
+__version__ = "5.1.13"
 
 
 VERSION = __version__.split(".")

--- a/nise/generators/gcp/gcp_generator.py
+++ b/nise/generators/gcp/gcp_generator.py
@@ -311,6 +311,6 @@ class GCPGenerator(AbstractGenerator):
             row = self._init_data_row(start, end)
             row = self._update_data(row)
             # shift invoice month
-            if self._cross_over_data and start.day in [1, 2] and start.month == now.month:
+            if self._cross_over_data and start.day in [1, 2] and start.month == now.month and start.year == now.year:
                 row = apply_previous_invoice_month(row)
             yield row

--- a/nise/generators/gcp/gcp_generator.py
+++ b/nise/generators/gcp/gcp_generator.py
@@ -24,6 +24,7 @@ from dateutil.relativedelta import relativedelta
 from random import choice
 from random import randint
 from random import uniform
+import calendar
 
 from nise.generators.generator import AbstractGenerator
 
@@ -84,23 +85,58 @@ GCP_REPORT_COLUMNS_JSONL = (
 GCP_INSTANCE_TYPES = ("e2-medium", "n1-standard-4", "m2-megamem-416", "a2-highgpu-1g")
 
 
-def apply_different_invoice_month(row, invoice):
+def apply_different_invoice_month(row, invoice_shift):
+    """
+    Adjusts the invoice month of a data row by a given month shift.
+
+    This function handles two possible data structures for the invoice month:
+    1. A flat key: `{"invoice.month": "202509", ...}`
+    2. A nested dictionary: `{"invoice": {"month": "202509"}, ...}`
+
+    It creates a copy of the row, finds the month, applies the shift, and
+    updates the row while preserving the original structure.
+
+    Args:
+        row (dict): The data row containing invoice information.
+        invoice_shift (int): The number of months to shift. Can be positive
+                             (for future months) or negative (for past months).
+
+    Returns:
+        dict: A new dictionary with the adjusted invoice month. If the invoice
+              month cannot be found or is malformed, it returns an unmodified
+              copy of the original row.
+    """
     new_row = row.copy()
     if invoice_month := new_row.get("invoice.month"):
-        date_object = datetime.datetime.strptime(invoice_month, "%Y%m")
+        invoice_month_date_object = datetime.datetime.strptime(invoice_month, "%Y%m")
     elif invoice_dict := new_row.get("invoice"):
-        date_object = datetime.datetime.strptime(invoice_dict["month"], "%Y%m")
+        invoice_month_date_object = datetime.datetime.strptime(invoice_dict["month"], "%Y%m")
     else:
         return new_row
 
-    delta = relativedelta(months=1)
-    adjusted_date = date_object + delta if invoice == "next" else date_object - delta
+    adjusted_date = invoice_month_date_object + relativedelta(months=invoice_shift)
     adjusted_month = adjusted_date.strftime("%Y%m")
     if "invoice.month" in new_row:
         new_row["invoice.month"] = adjusted_month
     elif "invoice" in new_row:
         new_row["invoice"] = {"month": adjusted_month}
     return new_row
+
+
+def get_months_in_range(start_date, end_date):
+    """
+    Generates a list of all months between a start and end date, inclusive.
+    """
+
+    months = []
+    current_date = start_date.date().replace(day=1)
+    end_month_start = end_date.date().replace(day=1)
+
+    while current_date <= end_month_start:
+        months.append(current_date)
+        current_date += relativedelta(months=1)
+
+    return months
 
 
 class GCPGenerator(AbstractGenerator):
@@ -307,24 +343,111 @@ class GCPGenerator(AbstractGenerator):
     def _update_data(self, row, start, end, **kwargs):
         """Update a data row."""
 
-    def _generate_hourly_data(self, **kwargs):
-        """Not needed for GCP."""
+    def _is_invoice_shift_applicable_to_month(self, month_to_check_start):
+        """
+        Determines if the cross-over logic applies to a specific month.
+
+        Args:
+            month_to_check_start (datetime.date): The first day of the month to check.
+
+        Returns:
+            bool: True if the invoice shift logic should be applied, False otherwise.
+        """
         now = datetime.datetime.now(datetime.UTC)
-        should_crossover = self._cross_over_metadata.get("days", [])
-        overwrite = self._cross_over_metadata.get("overwrite")
-        is_current_month = self._cross_over_metadata.get("month") == "current"
+        month_setting = self._cross_over_metadata.get("month", "all")
+
+        if month_setting == "current":
+            current_month_start = now.date().replace(day=1)
+            is_applicable_this_month = month_to_check_start == current_month_start
+        elif month_setting == "previous":
+            previous_month_start = (now - relativedelta(months=1)).date().replace(day=1)
+            is_applicable_this_month = month_to_check_start == previous_month_start
+        else:
+            is_applicable_this_month = True
+        return is_applicable_this_month
+
+    def _get_day_to_shift_map(self, cross_over_day_specifiers, start_dt, end_dt):
+        """
+        Calculates the map of days to invoice shifts based on cross-over settings.
+        """
+        day_to_shift_map = {}
+        if not cross_over_day_specifiers:
+            return day_to_shift_map
+
+        # Get list of all months generated in current batch
+        months_in_data = get_months_in_range(start_dt, end_dt)
+
+        # Check which of those months the invoice shift is applicable to
+        months_to_shift = [month for month in months_in_data if self._is_invoice_shift_applicable_to_month(month)]
+
+        # Build a mapping of {month: {day_of_month: invoice_month_shift}}
+        for month in months_to_shift:
+            month_key = month.month
+            day_to_shift_map[month_key] = {}
+            _, num_days_in_month = calendar.monthrange(month.year, month_key)
+
+            # A shift of -1 moves the cost to the previous month's invoice.
+            # A shift of +1 moves the cost to the next month's invoice.
+            for day in cross_over_day_specifiers:
+                if day > 0:  # Day is from the start of the month
+                    day_to_shift_map[month_key][day] = -1
+                else:  # Day is from the end of the month
+                    day_from_start = num_days_in_month + day + 1
+                    day_to_shift_map[month_key][day_from_start] = 1
+
+        return day_to_shift_map
+
+    def _generate_hourly_data(self, **kwargs):
+        """
+        Generates hourly cost data, applying invoice date shifts for specific days.
+
+        This generator function iterates through hourly usage data. For specific days
+        defined in the 'cross_over' configuration, it can shift the cost to the
+        invoice of the previous or next month. This is useful for simulating billing
+        scenarios where costs incurred at the very beginning or end of a month are
+        billed in an adjacent month.
+
+        The behavior is controlled by `self._cross_over_metadata` (from YAML):
+        - `month` (str): 'current', 'previous', or 'all'. Determines to which month(s)
+                         the cross-over logic should apply. Defaults to 'all'.
+        - `days` (list[int]): A list of day specifiers.
+                            - Positive numbers (e.g., 2) shift costs to the *previous* month.
+                            - Negative numbers (e.g., -1 for the last day) count from the end of the month and shift
+                            costs to the *next* month.
+        - `overwrite` (bool): If True, the original cost entry is replaced by the
+                              shifted one. If False, the original is kept, and a new
+                              shifted entry is also created.
+
+        Note:
+            This function assumes that all data in `self.hours` belongs to the
+            same calendar month. Behavior is undefined if hours span a month boundary.
+        """
+
+        if not self.hours:
+            return
+
+        # --- 1. Initialization and Setup ---
+        overwrite = self._cross_over_metadata.get("overwrite", False)
+        cross_over_day_specifiers = self._cross_over_metadata.get("days", [])
+
+        # --- 2. Calculate Invoice Shifts  ---
+        start_dt = self.hours[0].get("start")
+        end_dt = self.hours[-1].get("start")
+        day_to_shift_map = self._get_day_to_shift_map(cross_over_day_specifiers, start_dt, end_dt)
+
+        # --- 3. Process Each Hour, Applying Invoice Shifts Where Necessary ---
         for hour in self.hours:
-            start = hour.get("start")
-            end = hour.get("end")
+            start, end = hour.get("start"), hour.get("end")
             row = self._init_data_row(start, end)
             row = self._update_data(row)
-            generate_crossover = False
-            if start.day in should_crossover:
-                if not is_current_month or (start.month == now.month and start.year == now.year):
-                    generate_crossover = True
 
-            if generate_crossover:
-                yield apply_different_invoice_month(row, self._cross_over_metadata.get("invoice", "previous"))
+            # Check if the current day has a defined shift
+            if shift_direction := day_to_shift_map.get(start.month, {}).get(start.day):
+                # This is a cross-over day, so yield the modified row.
+                yield apply_different_invoice_month(row, shift_direction)
                 if overwrite:
+                    # If overwriting, skip yielding the original row.
                     continue
+
+            # Yield the original row (always, unless it was overwritten).
             yield row

--- a/nise/upload.py
+++ b/nise/upload.py
@@ -328,7 +328,7 @@ def gcp_bucket_to_dataset(
         #  partition time for some items in a day to investigate it - e.g., by using usage_end_time instead
         #  of usage_start_time, or by using export_time (would have to be adjusted first)
         partition_date_sql = f"""
-        UPDATE `{table_id}` SET _PARTITIONTIME=CAST(DATE_TRUNC(DATE(usage_start_time), DAY) AS timestamp) WHERE 1=1;
+        UPDATE `{table_id}` SET _PARTITIONTIME=CAST(DATE_TRUNC(DATE(usage_end_time), DAY) AS timestamp) WHERE 1=1;
         """
         bigquery_client.query(partition_date_sql)
 

--- a/tests/test_gcp_generator.py
+++ b/tests/test_gcp_generator.py
@@ -592,7 +592,6 @@ class TestGCPGenerator(TestCase):
         end_date = datetime(2024, 1, 2, 23, 0, 0)
 
         for overwrite_value in overwrite_params:
-            # Use self.subTest to create a distinct test cases
             with self.subTest(overwrite=overwrite_value):
                 attributes = {"cross_over": {"month": "current", "days": [1, 2], "overwrite": overwrite_value}}
 
@@ -622,7 +621,6 @@ class TestGCPGenerator(TestCase):
         end_date = self.now.replace(day=4)
 
         for month_value, overwrite_value in param_combinations:
-            # Use self.subTest to create a distinct test cases
             with self.subTest(month=month_value, overwrite=overwrite_value):
                 attributes = {"cross_over": {"month": month_value, "days": [1, 2, 5], "overwrite": overwrite_value}}
                 generator = ComputeEngineGenerator(

--- a/tests/test_gcp_generator.py
+++ b/tests/test_gcp_generator.py
@@ -481,4 +481,3 @@ class TestGCPGenerator(TestCase):
 
         for row in hourly_data:
             self.assertEqual(row["invoice.month"], start_date.strftime("%Y%m"))
-

--- a/tests/test_gcp_generator.py
+++ b/tests/test_gcp_generator.py
@@ -37,7 +37,6 @@ class TestGCPGenerator(TestCase):
             "cost_type": "regular",
             "labels": [{"cody": "test"}],
             "instance-type": "test",
-            "cross_over_data": True,
             "service.description": "Fire",
         }
         self.usage_attributes = {
@@ -418,7 +417,14 @@ class TestGCPGenerator(TestCase):
         if self.now.day > 1:
             expected_cross_over_days.append(str(self.now.replace(day=2).date()))
 
-        attributes = {"cross_over_data": True}
+        attributes = {
+            "cross_over":
+                {
+                    "month": "current",
+                    "days": [1, 2],
+                    "overwrite": True
+                }
+        }
         generator = ComputeEngineGenerator(start_date, end_date, self.currency, self.project, attributes=attributes)
         hourly_data = list(generator._generate_hourly_data())
 
@@ -455,7 +461,14 @@ class TestGCPGenerator(TestCase):
         start_date = datetime(2024, 1, 1, 0, 0, 0)
         end_date = datetime(2024, 1, 2, 23, 0, 0)
 
-        attributes = {"cross_over_data": True}
+        attributes = {
+            "cross_over":
+                {
+                    "month": "current",
+                    "days": [1, 2],
+                    "overwrite": True
+                }
+        }
         generator = ComputeEngineGenerator(start_date, end_date, self.currency, self.project, attributes=attributes)
 
         hourly_data = list(generator._generate_hourly_data())
@@ -471,7 +484,14 @@ class TestGCPGenerator(TestCase):
         start_date = self.now.replace(day=3)
         end_date = self.now.replace(day=4)
 
-        attributes = {"cross_over_data": True}
+        attributes = {
+            "cross_over":
+                {
+                    "month": "current",
+                    "days": [1, 2],
+                    "overwrite": True
+                }
+        }
         generator = ComputeEngineGenerator(start_date, end_date, self.currency, self.project, attributes=attributes)
 
         hourly_data = list(generator._generate_hourly_data())

--- a/tests/test_gcp_generator.py
+++ b/tests/test_gcp_generator.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 from unittest import TestCase
 
 from faker import Faker
-from nise.generators.gcp.gcp_generator import apply_previous_invoice_month
+from nise.generators.gcp.gcp_generator import apply_different_invoice_month
 from nise.generators.gcp import CloudStorageGenerator
 from nise.generators.gcp import ComputeEngineGenerator
 from nise.generators.gcp import GCPDatabaseGenerator
@@ -374,17 +374,17 @@ class TestGCPGenerator(TestCase):
                 credit_amount = row.get("credits", {}).get("amount", 0)
                 self.assertEqual(credit_amount, expected_credit_amount)
 
-    def test_apply_previous_invoice_month(self):
+    def test_apply_different_invoice_month(self):
         invoice_month = "202508"
         expected_month = "202507"
-        output = apply_previous_invoice_month({"invoice.month": invoice_month})
+        output = apply_different_invoice_month({"invoice.month": invoice_month}, -1)
         self.assertEqual(expected_month, output.get("invoice.month"))
-        output = apply_previous_invoice_month({"invoice": {"month": invoice_month}})
+        output = apply_different_invoice_month({"invoice": {"month": invoice_month}}, -1)
         self.assertEqual(expected_month, output.get("invoice", {}).get("month"))
 
-    def test_apply_previous_invoice_month_no_invoice(self):
+    def test_apply_different_invoice_month_no_invoice(self):
         input = {}
-        output = apply_previous_invoice_month(input)
+        output = apply_different_invoice_month(input, 1)
         self.assertEqual(input, output)
 
     def test_generate_hourly_data(self):

--- a/tests/test_gcp_generator.py
+++ b/tests/test_gcp_generator.py
@@ -468,18 +468,17 @@ class TestGCPGenerator(TestCase):
 
     def test_generate_hourly_data_no_cross_over_not_first_two_days(self):
         """Test that cross_over_data are not generated when not on first or second day."""
-        # not testable on the first and second of the month
-        if self.now.day >= 3:
-            start_date = self.now.replace(day=3)
-            end_date = self.now.replace(day=4)
+        start_date = self.now.replace(day=3)
+        end_date = self.now.replace(day=4)
 
-            attributes = {"cross_over_data": True}
-            generator = ComputeEngineGenerator(start_date, end_date, self.currency, self.project, attributes=attributes)
+        attributes = {"cross_over_data": True}
+        generator = ComputeEngineGenerator(start_date, end_date, self.currency, self.project, attributes=attributes)
 
-            hourly_data = list(generator._generate_hourly_data())
+        hourly_data = list(generator._generate_hourly_data())
 
-            expected_rows = len(generator.hours)
-            self.assertEqual(len(hourly_data), expected_rows)
+        expected_rows = len(generator.hours)
+        self.assertEqual(len(hourly_data), expected_rows)
 
-            for row in hourly_data:
-                self.assertEqual(row["invoice.month"], start_date.strftime("%Y%m"))
+        for row in hourly_data:
+            self.assertEqual(row["invoice.month"], start_date.strftime("%Y%m"))
+


### PR DESCRIPTION
This is a follow-up PR to #572. The goal is to add more flexibility to GCP cross over data generation by enabling specification of stuff direcly in YAML files instead of hard-coding them in Nise:
- select whether shifting of the invoice month should happen with our without duplicating line items
- select if we want to shift only the current month's data, only previous month's data or data for all months
- specify days in the month which should be shifted

```
      cross_over:
        month: current | previous | all | None  # shift only current month's data vs. only previous monht data vs. shift all months' data
        days: [1, 2, -3]       # days to be shifted, negative values represents count from the end of the month (e.g., -1 is last day of the month). postive values shift costs to the *previous* month, negative values shift cost to the *next* month
        overwrite: True | False  #  no duplication vs. duplication of line items
```

These changes will allow us to cover processing of GCP crossover data by our test automation.

Additionally, this PR also shifts partition date of the last hour of each day to the followoing day

