### PR TITLE
Add ability to generate invoice for next month

### DIFF
--- a/example_gcp_static_data.yml
+++ b/example_gcp_static_data.yml
@@ -33,6 +33,11 @@ generators:
       usage.amount_in_pricing_units: 1
       currency: EUR
       location.region: us-east4-a
+      cross_over:
+        month: all # options: current & all
+        days: [29]
+        invoice: next
+        overwrite: True
   - GCPDatabaseGenerator:
       start_date: last_month
       service.description: Fire


### PR DESCRIPTION
## Summary by Sourcery

Enable specifying invoice direction to adjust invoice month dynamically during data generation

New Features:
- Allow generating invoices for the next month by setting invoice: next in cross_over metadata

Enhancements:
- Refactor and rename invoice adjustment function to accept an invoice parameter for previous or next month
- Update hourly data generator to use the new parameterized invoice adjustment function based on metadata

Documentation:
- Add invoice: next option to example GCP static data configuration under cross_over