### PR TITLE
fix duplicate files

### DIFF
--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "5.1.13"
+__version__ = "5.1.14"
 
 
 VERSION = __version__.split(".")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,6 @@ include = [
 
 [tool.hatch.build.targets.wheel.force-include]
 "nise/aws-template-manifest.json" = "nise/aws-template-manifest.json"
-"nise/yaml_generators/static" = "nise/yaml_generators/static"
 
 [tool.hatch.build.targets.sdist]
 include = [


### PR DESCRIPTION
## Summary by Sourcery

Remove duplicate static file inclusion from wheel build configuration and bump version to 5.1.14

Bug Fixes:
- Remove duplicated "nise/yaml_generators/static" entry from wheel force-include configuration

Chores:
- Bump package version to 5.1.14