### PR TITLE
[RHINENG-20472] Add new CLI option (--container) with --ros-ocp-info  to generate ros specific container level csv

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,9 @@ All of the deployment is driven entirely by a Github Action workflow, so if issu
         --ros-ocp-info                          Optional, Generate ROS for Openshift data.
         --constant-values-ros-ocp               Optional, Generate constant values for ROS for OpenShift data only
                                                 when used with the ros-ocp-info parameter.
+        --container                             Optional, Generate ROS-specific container CSV report
+                                                (MUST be used with --ros-ocp-info).
+
 
     Common YAML Options:
         -o, --output YAML_NAME                  REQUIRED, Output file path (i.e "large.yml").

--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "5.1.14"
+__version__ = "5.1.15"
 
 
 VERSION = __version__.split(".")

--- a/nise/__main__.py
+++ b/nise/__main__.py
@@ -325,7 +325,7 @@ def add_ocp_parser_args(parser):
         dest="container",
         required=False,
         action="store_true",
-        help="Generate ROS-specific container CSV report (used with --ros-ocp-info)",
+        help="Generate ROS-specific container CSV report (Must be used with --ros-ocp-info)",
     )
 
 

--- a/nise/__main__.py
+++ b/nise/__main__.py
@@ -320,6 +320,13 @@ def add_ocp_parser_args(parser):
         action="store_true",
         help="Flag to generate constant values for ROS for Openshift",
     )
+    parser.add_argument(
+        "--container",
+        dest="container",
+        required=False,
+        action="store_true",
+        help="Generate ROS-specific container CSV report (used with --ros-ocp-info)",
+    )
 
 
 def create_parser():
@@ -580,6 +587,10 @@ def _validate_ocp_arguments(parser, options):
         msg = "\n\t--payload-name is only used with --minio-upload\n"
         msg = msg.format("--payload-name", payload_name)
         parser.error(msg)
+
+    # Validate --container flag can only be used with --ros-ocp-info
+    if options.get("container") and not options.get("ros_ocp_info"):
+        parser.error("--container can only be used with --ros-ocp-info")
 
     return True
 

--- a/nise/generators/ocp/ocp_generator.py
+++ b/nise/generators/ocp/ocp_generator.py
@@ -387,11 +387,14 @@ def get_vm_from_label(labels):
 class OCPGenerator(AbstractGenerator):
     """Defines a abstract class for generators."""
 
-    def __init__(self, start_date, end_date, attributes, ros_ocp_info=False, constant_values_ros_ocp=False):
+    def __init__(
+        self, start_date, end_date, attributes, ros_ocp_info=False, constant_values_ros_ocp=False, container=False
+    ):
         """Initialize the generator."""
         self._nodes = None
         self.ros_ocp_info = ros_ocp_info
         self.constant_values_ros_ocp = constant_values_ros_ocp
+        self.container = container
         if attributes:
             self._nodes = attributes.get("nodes")
 

--- a/nise/report.py
+++ b/nise/report.py
@@ -845,6 +845,7 @@ def ocp_create_report(options):  # noqa: C901
     static_report_data = options.get("static_report_data")
     ros_ocp_info = options.get("ros_ocp_info")
     constant_values_ros_ocp = options.get("constant_values_ros_ocp")
+    container = options.get("container")
 
     if static_report_data:
         generators = _get_generators(static_report_data.get("generators"))
@@ -889,7 +890,9 @@ def ocp_create_report(options):  # noqa: C901
 
                 gen_start_date, gen_end_date = _create_generator_dates_from_yaml(attributes, month)
 
-            gen = generator_cls(gen_start_date, gen_end_date, attributes, ros_ocp_info, constant_values_ros_ocp)
+            gen = generator_cls(
+                gen_start_date, gen_end_date, attributes, ros_ocp_info, constant_values_ros_ocp, container
+            )
             for report_type in gen.ocp_report_generation.keys():
                 LOG.info(f"Generating data for {report_type} for {month}")
                 for hour in gen.generate_data(report_type):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -26,6 +26,7 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from nise.__main__ import _load_static_report_data
+from nise.__main__ import _validate_ocp_arguments
 from nise.__main__ import _validate_provider_inputs
 from nise.__main__ import create_parser
 from nise.__main__ import length_of_cluster_id
@@ -750,3 +751,24 @@ class MainDateTest(TestCase):
 
         with self.assertRaises(SystemExit):
             _load_static_report_data(options)
+
+    def test_validate_ocp_arguments_container_requires_ros_ocp_info(self):
+        """
+        Test that --container flag requires --ros-ocp-info flag.
+        """
+        parser = create_parser()
+
+        # Test case 1: container=True but ros_ocp_info=False should raise error
+        options = {"ocp_cluster_id": "test-cluster", "container": True, "ros_ocp_info": False}
+        with self.assertRaises(SystemExit):
+            _validate_ocp_arguments(parser, options)
+
+        # Test case 2: container=True and ros_ocp_info=True should pass
+        options = {"ocp_cluster_id": "test-cluster", "container": True, "ros_ocp_info": True}
+        result = _validate_ocp_arguments(parser, options)
+        self.assertTrue(result)
+
+        # Test case 3: container=False and ros_ocp_info=False should pass
+        options = {"ocp_cluster_id": "test-cluster", "container": False, "ros_ocp_info": False}
+        result = _validate_ocp_arguments(parser, options)
+        self.assertTrue(result)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -772,3 +772,8 @@ class MainDateTest(TestCase):
         options = {"ocp_cluster_id": "test-cluster", "container": False, "ros_ocp_info": False}
         result = _validate_ocp_arguments(parser, options)
         self.assertTrue(result)
+
+        # Test case 4: container and ros_ocp_info are omitted, should pass
+        options = {"ocp_cluster_id": "test-cluster"}
+        result = _validate_ocp_arguments(parser, options)
+        self.assertTrue(result)

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -970,6 +970,28 @@ class OCPReportTestCase(TestCase):
             self.assertTrue(os.path.isfile(expected_month_output_file))
             os.remove(expected_month_output_file)
 
+    def test_ocp_create_report_ros_ocp_container_option(self):
+        """Test the ocp report creation method with container option and ros_ocp_info enabled."""
+        now = datetime.datetime.now().replace(microsecond=0, second=0, minute=0, hour=0)
+        one_day = datetime.timedelta(days=1)
+        yesterday = now - one_day
+        cluster_id = "11112222"
+        options = {
+            "start_date": yesterday,
+            "end_date": now,
+            "ocp_cluster_id": cluster_id,
+            "write_monthly": True,
+            "ros_ocp_info": True,
+            "container": True,
+        }
+        fix_dates(options, "ocp")
+        ocp_create_report(options)
+        for report_type in OCP_REPORT_TYPE_TO_COLS.keys():
+            month_output_file_name = f"{calendar.month_name[now.month]}-{now.year}-{cluster_id}-{report_type}"
+            expected_month_output_file = f"{os.getcwd()}/{month_output_file_name}.csv"
+            self.assertTrue(os.path.isfile(expected_month_output_file))
+            os.remove(expected_month_output_file)
+
     def test_ocp_create_report_minio_upload(self):
         """Test the ocp report creation method."""
         now = datetime.datetime.now().replace(microsecond=0, second=0, minute=0, hour=0)


### PR DESCRIPTION
The PR covers the following changes - 

- Added a new CLI option (--container) to generate ROS-specific container-level CSV 

**Testing** 

Case-1:  Regular ROS  report 
nise report ocp -s  2025-09-08 -w --ocp-cluster-id test-001 --ros-ocp-info  - This will generate a ROS regular  CSV ( in the future, if there is no additional option provided, it will generate two CSVs, namespace and container specific to ROS )

Case -2:  ROS container report (both flags together) - This will generate a ROS container-level CSV
nise report ocp -s 2025-09-02 -w --ocp-cluster-id test-001 --ros-ocp-info --container

Case-3:  Regular OCP report (no ROS flags) - This will generate a Regular OCP report and no ROS-specific data 
nise report ocp -s 2025-09-02 -w --ocp-cluster-id test-001

Case-4: Negative scenario, when the --ros-ocp-info is missing - 
nise report ocp -s 2025-09-02 -w --ocp-cluster-id test-001 --container - Error: --container can only be used with --ros-ocp-info

## Summary by Sourcery

Add a new --container option to the OCP reporting CLI that, when used alongside --ros-ocp-info, generates container-level ROS CSV output. Validate the flag combination at parse time, update the report generation pipeline to honor the new flag, add corresponding tests, update documentation, and bump the package version.

New Features:
- Add --container CLI flag to generate ROS-specific container-level CSV reports

Enhancements:
- Enforce validation so --container can only be used with --ros-ocp-info and propagate the flag through report creation and generators

Build:
- Bump version to 5.1.15

Documentation:
- Document the --container option in the README

Tests:
- Add unit tests for container-level report generation with --container and parser validation tests for --container requiring --ros-ocp-info