### PR TITLE
[COST-6067] Fix incorrect labels' structure in GCP JSONLPersistentDiskGenerator

### DIFF
--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,5 +1,5 @@
 from .helpers import gcp_calculate_persistent_disk_usage_amount
 from .helpers import gcp_calculate_usage_amount_in_pricing
 
-__version__ = "5.2.0"
+__version__ = "5.2.1"
 VERSION = __version__.split(".")

--- a/nise/generators/gcp/disk_generator.py
+++ b/nise/generators/gcp/disk_generator.py
@@ -175,7 +175,6 @@ class JSONLPersistentDiskGenerator(PersistentDiskGenerator):
         row["invoice"] = {"month": datetime.strptime(row.get("usage_start_time")[:7], "%Y-%m").strftime("%Y%m")}
         row["resource"] = {"name": self._resource_name, "global_name": self._resource_global_name}
         row["currency"] = self._currency
-        row["labels"] = self.determine_labels(self.LABELS)
         row["system_labels"] = []
         if self.attributes:
             for key in self.attributes:
@@ -184,6 +183,8 @@ class JSONLPersistentDiskGenerator(PersistentDiskGenerator):
                 elif key.split(".")[0] in self.column_labels:
                     outer_key, inner_key = key.split(".")
                     row[outer_key][inner_key] = self.attributes[key]
+        row["labels"] = self.determine_labels(self.LABELS)
+
         return row
 
     def generate_data(self, report_type=None):


### PR DESCRIPTION
This PR fixes a bug where the JSONLPersistentDiskGenerator produced an inconsistent structure for the 'labels' field compared to other generators.

The issue was caused by the attribute override logic running after the default labels were set, causing correctly formatted labels to be overwritten. This change reorders the operations to match the logic in the ComputeEngine generator, ensuring a consistent key-value pair format for labels across all generated data. This resolves JSON parsing errors in BigQuery.

== Assisted by Gemini ==

## Summary by Sourcery

Reorder label determination in JSONLPersistentDiskGenerator to fix inconsistent labels and align with ComputeEngine logic

Bug Fixes:
- Fix incorrect labels structure by applying attribute overrides before determining default labels, preventing overwrites and resolving BigQuery JSON parsing errors

Enhancements:
- Align label assignment order with ComputeEngine generator for consistency across GCP generators