### PR TITLE
[COST-6882] - Fix GCP persistent disk pricing for multi-month reports

### DIFF
--- a/nise/__init__.py
+++ b/nise/__init__.py
@@ -1,5 +1,5 @@
 from .helpers import gcp_calculate_persistent_disk_usage_amount
 from .helpers import gcp_calculate_usage_amount_in_pricing
 
-__version__ = "5.2.1"
+__version__ = "5.2.2"
 VERSION = __version__.split(".")

--- a/nise/helpers.py
+++ b/nise/helpers.py
@@ -8,8 +8,8 @@ def gcp_calculate_persistent_disk_usage_amount(capacity):
     return bytes_conversion * SECONDS_IN_HOUR
 
 
-def gcp_calculate_usage_amount_in_pricing(start_date, usage_amount):
-    hours_in_month = calendar.monthrange(start_date.year, start_date.month)[1] * 24
+def gcp_calculate_usage_amount_in_pricing(usage_date, usage_amount):
+    hours_in_month = calendar.monthrange(usage_date.year, usage_date.month)[1] * 24
     seconds_in_month = hours_in_month * SECONDS_IN_HOUR
     usage_in_pricing = usage_amount / (BYTES_TO_GIBIBYTE * seconds_in_month)
     return round(usage_in_pricing, 8)

--- a/tests/test_gcp_generator.py
+++ b/tests/test_gcp_generator.py
@@ -802,8 +802,6 @@ class TestGCPGenerator(TestCase):
         self.assertIn(generator.region, generator.DEFAULT_REGIONS)
         self.assertIn(generator.sku_id, generator.SKU_DESCRIPTION.keys())
         self.assertIsNotNone(generator.usage_amount)
-        self.assertIsNotNone(generator.usage_in_pricing_units)
-        self.assertIsNotNone(generator.cost)
 
     def test_persistent_disk_custom_properties(self):
         """Test custom properties for Persistent Disk."""
@@ -833,8 +831,6 @@ class TestGCPGenerator(TestCase):
         expected_bytes = 100 * (1024**3)
         expected_usage = expected_bytes * 3600
         self.assertEqual(generator.usage_amount, expected_usage)
-        self.assertIsInstance(generator.usage_in_pricing_units, float)
-        self.assertGreater(generator.usage_in_pricing_units, 0)
 
     def test_persistent_disk_sku_descriptions(self):
         """Test SKU descriptions mapping for Persistent Disk."""


### PR DESCRIPTION
This PR fixes a bug in the GCP persistent disk cost calculation where usage_in_pricing_units was incorrectly determined for reports spanning multiple months.

The original code used the report's global start_date for the calculation in a cached property. This caused an incorrect number of seconds in the month to be used for any data rows that fell outside of the starting month.

Note: This bug primarily impacts the JSONL generator, as the standard CSV flow already generates reports on a per-month basis. However, the fix has been applied to both flows for consistency and robustness.

The solution moves the calculation into the _update_data method, ensuring that each row's specific usage_date is used. This guarantees the correct monthly divisor is applied, resulting in accurate cost and usage data.

## Summary by Sourcery

Fix GCP persistent disk cost and usage calculations for multi-month reports by moving pricing unit computations into per-row updates using each row’s usage_start_time and updating the helper to use usage_date for monthly divisors

Bug Fixes:
- Move usage_in_pricing_units and cost calculations from cached properties to the _update_data methods to use each row’s usage_start_time for correct multi-month pricing
- Update gcp_calculate_usage_amount_in_pricing to use usage_date instead of report start_date when determining monthly seconds

Chores:
- Bump version from 5.2.1 to 5.2.2